### PR TITLE
Add earnings difference to monthly analysis

### DIFF
--- a/src/app/backend/bookings/bookings.component.html
+++ b/src/app/backend/bookings/bookings.component.html
@@ -7,13 +7,17 @@
         <div class="row m-0" style="height: 10%">
           <div class="d-flex flex-column align-items-center">
             <h2>{{ booking.year }}-{{ booking.month }}</h2>
-            <span
-              [ngClass]="areExpensesHigherThanIncome(booking) ? 'bg-danger' : 'bg-info-subtle'"
-            >Gesamtausgaben: {{ getTotalAmount(booking) | number: '.2' : 'de' }}
-              @if (areExpensesHigherThanIncome(booking)) {
-                (Die Ausgaben sind höher als die Einnahmen!)
-              }
-            </span>
+            <div class="d-flex gap-3">
+              <span class="bg-info-subtle">Gesamtausgaben: {{ getTotalAmount(booking) | number: '.2' : 'de' }}</span>
+              <span class="bg-success-subtle">Einnahmen: {{ getIncomeAmount(booking) | number: '.2' : 'de' }}</span>
+              <span
+                [ngClass]="getEarningsDifference(booking) >= 0 ? 'bg-primary-subtle' : 'bg-danger'"
+              >Differenz: {{ getEarningsDifference(booking) | number: '.2' : 'de' }}
+                @if (getEarningsDifference(booking) < 0) {
+                  (Die Ausgaben sind höher als die Einnahmen!)
+                }
+              </span>
+            </div>
           </div>
         </div>
 

--- a/src/app/backend/bookings/bookings.component.ts
+++ b/src/app/backend/bookings/bookings.component.ts
@@ -42,4 +42,14 @@ export class BookingsComponent {
     return total > income;
   }
 
+  getIncomeAmount(booking: MonthlyBookingEntriesDTO): number {
+    return this.round2(this.sumAmounts(booking.incomes));
+  }
+
+  getEarningsDifference(booking: MonthlyBookingEntriesDTO): number {
+    const income = this.getIncomeAmount(booking);
+    const expenses = this.getTotalAmount(booking);
+    return this.round2(income - expenses);
+  }
+
 }


### PR DESCRIPTION
## Summary
- Extend monthly analysis to display earnings difference (income - expenses)
- Add income amount display alongside existing expense information
- Implement color-coded difference: blue for positive, red for negative
- Maintain existing warning functionality when expenses exceed income

## Changes
- Added `getIncomeAmount()` method to calculate total income per month
- Added `getEarningsDifference()` method to calculate financial balance
- Updated UI to show three metrics: expenses, income, and difference
- Improved visual layout with horizontal spacing between metrics

## Test plan
- [ ] Verify income calculation is accurate across different months
- [ ] Test earnings difference calculation for both positive and negative values
- [ ] Confirm color coding works correctly (blue for savings, red for deficit)
- [ ] Ensure existing expense warning functionality remains intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)