### PR TITLE
Remove duplicate Vocabulary card from landing page

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -45,8 +45,4 @@
       <p>Manage Vocabulary</p>
     </div>
   </div>
-  <div class="card" routerLink="/vocabulary">
-    <h2>Vocabulary</h2>
-    <p>Manage Vocabulary</p>
-  </div>
 </div>


### PR DESCRIPTION
## Summary
- Removed duplicate Vocabulary card from landing page
- The page had two Vocabulary cards - one inside card-container and one duplicate outside
- Cleaned up the layout by removing the misplaced card

## Test plan
- [ ] Verify landing page loads correctly
- [ ] Confirm only one Vocabulary card remains in the card-container
- [ ] Test navigation to Vocabulary module still works