### PR TITLE
Add filter for vocabulary entries without descriptions

### DIFF
--- a/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.html
+++ b/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.html
@@ -31,6 +31,11 @@
         (change)="filterMarkedAsUpdated('markedAsUpdated')"
       >Updated
       </mat-checkbox>
+      <mat-checkbox
+        [(ngModel)]="withoutDescription"
+        (change)="filterWithoutDescription('withoutDescription')"
+      >Without Description
+      </mat-checkbox>
     </div>
     <div class="col-8"></div>
   </div>

--- a/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.ts
+++ b/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.ts
@@ -33,6 +33,10 @@ function applyFilter(flashcard: Flashcard, filter: string, value: string): boole
     return flashcard.updated;
   }
 
+  if ('withoutDescription' === filter) {
+    return !flashcard.description || flashcard.description.trim() === '';
+  }
+
   let wordFilter = /####([a-z]+)####/i.exec(filter);
   if (wordFilter) {
     return value.toLowerCase().includes(wordFilter[1]);
@@ -76,6 +80,7 @@ export class VocabularyListComponent implements OnInit, AfterViewInit {
 
   readonly withoutArticle: ModelSignal<boolean> = model(false);
   readonly markedAsupdated: ModelSignal<boolean> = model(false);
+  readonly withoutDescription: ModelSignal<boolean> = model(false);
 
   constructor(
     private vocabularyService: VocabularyService,
@@ -181,6 +186,10 @@ export class VocabularyListComponent implements OnInit, AfterViewInit {
 
   filterMarkedAsUpdated(value: string): void {
     this.filterFlashcards(value, this.markedAsupdated());
+  }
+
+  filterWithoutDescription(value: string): void {
+    this.filterFlashcards(value, this.withoutDescription());
   }
 
   private filterFlashcards(value: string, isSet: boolean): void {


### PR DESCRIPTION
## Summary
- Add new filter option to show vocabulary entries with empty descriptions
- Updated vocabulary list component with checkbox UI and filter logic
- Follows existing filter patterns and conventions

## Test plan
- [x] Build compiles successfully
- [ ] Verify new filter checkbox appears in vocabulary list
- [ ] Test filtering shows only entries without descriptions
- [ ] Verify filter works in combination with other filters