### PR TITLE
Add filter count display to vocabulary list

### DIFF
--- a/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.html
+++ b/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.html
@@ -37,7 +37,15 @@
       >Without Description
       </mat-checkbox>
     </div>
-    <div class="col-8"></div>
+    <div class="col-7">
+      @if (hasActiveFilters()) {
+        <div class="alert alert-info mb-0 py-2 px-3">
+          <small>
+            <strong>{{ filteredCount() }}</strong> of <strong>{{ totalCount() }}</strong> entries match current filters
+          </small>
+        </div>
+      }
+    </div>
   </div>
 
   <div class="border border-black border-1 overflow-auto">

--- a/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.ts
+++ b/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, model, ModelSignal, OnInit, ViewChild} from '@angular/core';
+import {AfterViewInit, Component, model, ModelSignal, OnInit, ViewChild, computed} from '@angular/core';
 import {VocabularyService} from '../../services/vocabulary.service';
 import {Flashcard} from '../../model/Flashcard';
 import {
@@ -81,6 +81,10 @@ export class VocabularyListComponent implements OnInit, AfterViewInit {
   readonly withoutArticle: ModelSignal<boolean> = model(false);
   readonly markedAsupdated: ModelSignal<boolean> = model(false);
   readonly withoutDescription: ModelSignal<boolean> = model(false);
+
+  readonly filteredCount = computed(() => this.flashcards.filteredData.length);
+  readonly totalCount = computed(() => this.flashcards.data.length);
+  readonly hasActiveFilters = computed(() => this.filters.length > 0 && this.filters.some(f => f.trim() !== '' && f !== ' '));
 
   constructor(
     private vocabularyService: VocabularyService,


### PR DESCRIPTION
## Summary
- Added a filter count display that shows how many entries match the current filters
- Displays "X of Y entries match current filters" in an info alert box
- Only shows when filters are actively applied

## Changes
- Added computed properties for filtered and total entry counts
- Added logic to detect when filters are active
- Updated HTML template to display count information in the filter section

## Test plan
- [ ] Test with text search filter
- [ ] Test with checkbox filters (Without Article, Updated, Without Description)
- [ ] Test with multiple filters combined
- [ ] Verify count updates correctly when filters are added/removed
- [ ] Verify info box is hidden when no filters are applied