### PR TITLE
Add tooltips to vocabulary add-word component buttons

### DIFF
--- a/src/app/vocabulary/components/add-word/add-word.component.html
+++ b/src/app/vocabulary/components/add-word/add-word.component.html
@@ -40,6 +40,8 @@
                       <div class="definition flex-grow-1">{{ definition.definition }}</div>
                       <button
                         class="mini-button border border-1 border-black rounded-2"
+                        matTooltip="Select as description"
+                        matTooltipPosition="above"
                         (click)="setChosenText(a + '-' + aa + '-' + aaa, definition.definition)">
                         @if (isChosen(a + '-' + aa + '-' + aaa)) {
                           x
@@ -47,6 +49,8 @@
                       </button>
                       <button
                         class="mini-button border border-1 border-black rounded-2"
+                        matTooltip="Add to translation context"
+                        matTooltipPosition="above"
                         (click)="setChosenForContext(a + '-' + aa + '-' + aaa, definition.definition)">
                         @if (isChosenForContext(a + '-' + aa + '-' + aaa)) {
                           x

--- a/src/app/vocabulary/components/add-word/add-word.component.ts
+++ b/src/app/vocabulary/components/add-word/add-word.component.ts
@@ -22,6 +22,7 @@ import {ActivatedRoute} from '@angular/router';
 import {MatButtonToggle, MatButtonToggleGroup} from '@angular/material/button-toggle';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {NgClass} from '@angular/common';
+import {MatTooltip} from '@angular/material/tooltip';
 
 const DEFAULT_DECK = 'Standard';
 
@@ -64,7 +65,8 @@ function validateWordPrefix(
     MatFormField,
     MatButtonToggleGroup,
     MatButtonToggle,
-    NgClass
+    NgClass,
+    MatTooltip
   ],
   templateUrl: './add-word.component.html',
   styleUrl: './add-word.component.css',


### PR DESCRIPTION
## Summary
- Added descriptive tooltips to the two buttons next to each definition text in the vocabulary add-word component
- First button now shows "Select as description" tooltip when hovered
- Second button now shows "Add to translation context" tooltip when hovered
- Tooltips are positioned above the buttons for better visibility

## Test plan
- [x] Build compiles successfully (`npm run build`)
- [x] No new linting errors introduced
- [x] Test tooltips appear on hover in the vocabulary add-word interface
- [x] Verify tooltips clearly indicate the purpose of each button