### PR TITLE
feat: Add comprehensive dictionary error handling to vocabulary component

### DIFF
--- a/src/app/vocabulary/components/add-word/add-word.component.css
+++ b/src/app/vocabulary/components/add-word/add-word.component.css
@@ -77,3 +77,17 @@
 .overflow-auto::-webkit-scrollbar-thumb:hover {
   background-color: #999;
 }
+
+/* Dictionary error snackbar styling */
+::ng-deep .dictionary-error-snackbar {
+  background-color: #f44336 !important;
+  color: white !important;
+  font-weight: 500 !important;
+  border-radius: 8px !important;
+  box-shadow: 0 4px 12px rgba(244, 67, 54, 0.3) !important;
+}
+
+::ng-deep .dictionary-error-snackbar .mat-simple-snackbar-action {
+  color: white !important;
+  font-weight: 600 !important;
+}

--- a/src/app/vocabulary/model/dictionary-error.model.ts
+++ b/src/app/vocabulary/model/dictionary-error.model.ts
@@ -1,0 +1,67 @@
+export interface DictionaryError {
+  message: string;
+  statusCode: number;
+  errorType: string;
+}
+
+export class WordNotFoundError implements DictionaryError {
+  message: string;
+  statusCode = 404;
+  errorType = 'WORD_NOT_FOUND';
+
+  constructor(word: string) {
+    this.message = `The word "${word}" was not found in the dictionary.`;
+  }
+}
+
+export class RateLimitExceededError implements DictionaryError {
+  message: string;
+  statusCode = 429;
+  errorType = 'RATE_LIMIT_EXCEEDED';
+
+  constructor() {
+    this.message = 'Too many requests to the dictionary API. Please try again later.';
+  }
+}
+
+export class DictionaryServiceUnavailableError implements DictionaryError {
+  message: string;
+  statusCode = 503;
+  errorType = 'SERVICE_UNAVAILABLE';
+
+  constructor() {
+    this.message = 'The dictionary service is temporarily unavailable. Please try again later.';
+  }
+}
+
+export class InvalidWordError implements DictionaryError {
+  message: string;
+  statusCode = 400;
+  errorType = 'INVALID_WORD';
+
+  constructor(word: string) {
+    this.message = `The word "${word}" is invalid. Please enter a valid English word.`;
+  }
+}
+
+export class DictionaryApiError implements DictionaryError {
+  message: string;
+  statusCode: number;
+  errorType: string;
+
+  constructor(message: string, statusCode: number, errorType: string) {
+    this.message = message;
+    this.statusCode = statusCode;
+    this.errorType = errorType;
+  }
+}
+
+export class UnexpectedDictionaryError implements DictionaryError {
+  message: string;
+  statusCode = 500;
+  errorType = 'UNEXPECTED_ERROR';
+
+  constructor(word: string) {
+    this.message = `An unexpected error occurred while fetching the word "${word}". Please try again.`;
+  }
+}


### PR DESCRIPTION
## Summary
- Add DictionaryError interface and specific error classes (WordNotFoundError, RateLimitExceededError, etc.)
- Update VocabularyService to map HTTP status codes to specific error types  
- Enhance AddWordComponent with user-friendly error messages and styling
- Improve error UX with appropriate snackbar durations and visual styling
- Match backend error handling patterns from adapter_application

## Details
This change brings comprehensive error handling from the backend `DictionaryClient` to the frontend vocabulary component. Previously, users would see generic error messages like "Getting word failed: ${err.message}". Now they receive specific, actionable error messages based on the type of error that occurred.

### Error Types Added:
- **WordNotFoundError** (404): Clear message when word isn't found
- **RateLimitExceededError** (429): Inform about rate limiting with longer display time
- **DictionaryServiceUnavailableError** (503): Service outage information
- **InvalidWordError** (400): Input validation guidance
- **DictionaryApiError**: General client/server errors with context
- **UnexpectedDictionaryError**: Fallback for unknown errors

### UX Improvements:
- Contextual error messages with the specific word when relevant
- Different snackbar durations based on error severity
- Red-themed error styling for better visibility
- Proper error type checking and handling

## Test plan
- [ ] Test dictionary lookup with valid word (should work normally)
- [ ] Test with non-existent word to see WordNotFoundError message
- [ ] Test with invalid characters to see InvalidWordError message  
- [ ] Verify error styling appears correctly
- [ ] Test both add word flow and edit flashcard flow error handling
- [ ] Verify build passes and no TypeScript errors