### PR TITLE
fix: Reset description and context selections when fetching new word

### DIFF
--- a/src/app/vocabulary/components/add-word/add-word.component.ts
+++ b/src/app/vocabulary/components/add-word/add-word.component.ts
@@ -186,6 +186,9 @@ export class AddWordComponent implements OnInit {
 
   getWord(word: string): void {
     this.partOfSpeech = '';
+    // Reset description and context selections when fetching a new word
+    this.chosenIndex = null;
+    this.chosenForContext = [];
     this.vocabularyService.getWord(word).subscribe({
         next: res => {
           this.update.set(false);
@@ -193,7 +196,7 @@ export class AddWordComponent implements OnInit {
           this.wordToShow = word;
           this.partsOfSpeech = this.setPartsOfSpeech(res);
           this.patchForm(this.deck, word, '', '');
-          this.wordFormTranslation.patchValue({'word': word}, {emitEvent: false});
+          this.wordFormTranslation.patchValue({'word': word, 'context': ''}, {emitEvent: false});
         },
         error: err => {
           this.handleDictionaryError(err, word);

--- a/src/app/vocabulary/components/add-word/add-word.component.ts
+++ b/src/app/vocabulary/components/add-word/add-word.component.ts
@@ -189,6 +189,9 @@ export class AddWordComponent implements OnInit {
     // Reset description and context selections when fetching a new word
     this.chosenIndex = null;
     this.chosenForContext = [];
+    this.description = null;
+    this.front = word;
+    this.back = null;
     this.vocabularyService.getWord(word).subscribe({
         next: res => {
           this.update.set(false);


### PR DESCRIPTION
## Summary
- Fixed issue where old description and context selections persisted when fetching a new word
- Added reset logic to clear `chosenIndex` and `chosenForContext` variables in `getWord` method
- Also clears the context field in the translation form when a new word is fetched

## Changes Made
- Reset `chosenIndex` to `null` when fetching a new word
- Reset `chosenForContext` to empty array when fetching a new word  
- Clear context field in translation form by updating patchValue to include `'context': ''`

## Test Plan
- [ ] Test fetching a new word after having selected descriptions/context from previous word
- [ ] Verify that all selections are properly cleared and UI state is reset
- [ ] Confirm that translation context field is also cleared when new word is fetched