### PR TITLE
feat: Add home button to vocabulary module

### DIFF
--- a/src/app/vocabulary/components/add-word/add-word.component.html
+++ b/src/app/vocabulary/components/add-word/add-word.component.html
@@ -1,5 +1,20 @@
 <div class="add-word-container h-100 container-fluid p-2 d-flex flex-column align-items-center">
 
+  <header class="flex-shrink-0 mb-3">
+    <div class="d-flex justify-content-between align-items-center">
+      <h1 class="mb-0">Add Word</h1>
+      <button
+        mat-icon-button
+        color="primary"
+        aria-label="Go to home"
+        routerLink="/"
+        type="button"
+      >
+        <mat-icon>home</mat-icon>
+      </button>
+    </div>
+  </header>
+
   @if (!isFromRouteCall) {
     <section class="word-input-section flex-shrink-0 mb-3">
       <div class="search-input-container">

--- a/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.html
+++ b/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.html
@@ -1,5 +1,20 @@
 <div class="h-100 d-flex flex-column p-2">
 
+  <header class="pb-2">
+    <div class="d-flex justify-content-between align-items-center">
+      <h1 class="mb-0">Vocabulary List</h1>
+      <button
+        mat-icon-button
+        color="primary"
+        aria-label="Go to home"
+        routerLink="/"
+        type="button"
+      >
+        <mat-icon>home</mat-icon>
+      </button>
+    </div>
+  </header>
+
   <div class="pb-2">
     <div class="d-flex justify-content-between">
       <div>

--- a/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.ts
+++ b/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.ts
@@ -22,6 +22,8 @@ import {MatInput} from '@angular/material/input';
 import {MatLabel} from '@angular/material/select';
 import {MatCheckbox} from '@angular/material/checkbox';
 import {FormsModule} from '@angular/forms';
+import {MatIconModule} from '@angular/material/icon';
+import {MatButtonModule} from '@angular/material/button';
 
 function applyFilter(flashcard: Flashcard, filter: string, value: string): boolean {
 
@@ -64,7 +66,9 @@ function applyFilter(flashcard: Flashcard, filter: string, value: string): boole
     MatFormField,
     MatInput,
     MatCheckbox,
-    FormsModule
+    FormsModule,
+    MatIconModule,
+    MatButtonModule
   ],
   templateUrl: './vocabulary-list.component.html',
   styleUrl: './vocabulary-list.component.css'


### PR DESCRIPTION
## Summary
- Add home button to add-word component header
- Add home button to vocabulary-list component header  
- Include necessary Material imports for icon and button components
- Buttons navigate to root landing page via routerLink="/"

## Test plan
- [x] Build compiles successfully (`npm run build`)
- [x] Home buttons appear in both vocabulary components
- [x] Home buttons navigate to landing page when clicked
- [x] No console errors or build issues