### PR TITLE
feat: Add InfluxDB export service method

### DIFF
--- a/src/app/influxdb-buckets/model/influx-bucket.ts
+++ b/src/app/influxdb-buckets/model/influx-bucket.ts
@@ -9,3 +9,17 @@ export interface InfluxBucket {
   bucketName: string;
   description: string;
 }
+
+export interface InfluxExportRequest {
+  buckets?: string[];
+  startTime?: string;
+  endTime?: string;
+}
+
+export interface InfluxExportResponse {
+  success: boolean;
+  message: string;
+  exportedFiles: string[];
+  timestamp: string;
+  error?: string;
+}

--- a/src/app/influxdb-buckets/services/influx-buckets.service.ts
+++ b/src/app/influxdb-buckets/services/influx-buckets.service.ts
@@ -2,7 +2,7 @@ import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {Observable} from 'rxjs';
 import {environment} from '../../../environments/environment';
-import {InfluxBucketResponse} from '../model/influx-bucket';
+import {InfluxBucketResponse, InfluxExportRequest, InfluxExportResponse} from '../model/influx-bucket';
 
 @Injectable({
   providedIn: 'root'
@@ -14,6 +14,10 @@ export class InfluxBucketsService {
 
   getAvailableBuckets(): Observable<InfluxBucketResponse> {
     return this.http.get<InfluxBucketResponse>(`${this.host}/export/influxdb/buckets`);
+  }
+
+  exportInfluxBuckets(request: InfluxExportRequest): Observable<InfluxExportResponse> {
+    return this.http.post<InfluxExportResponse>(`${this.host}/export/influxdb`, request);
   }
 
 }


### PR DESCRIPTION
## Summary
- Add InfluxExportRequest and InfluxExportResponse interfaces to support the `/export/influxdb` API endpoint
- Implement exportInfluxBuckets method in InfluxBucketsService with full API specification compliance
- Support optional bucket selection and time range filtering for exports

## Test plan
- [ ] Verify exportInfluxBuckets method accepts InfluxExportRequest correctly
- [ ] Test with various bucket combinations (empty, single, multiple buckets)
- [ ] Test time range filtering with startTime and endTime parameters
- [ ] Verify response handling for success and error scenarios
- [ ] Check TypeScript compilation for new interfaces