### PR TITLE
feat: Add FileService with listFiles method

### DIFF
--- a/src/app/services/file/file.model.ts
+++ b/src/app/services/file/file.model.ts
@@ -1,0 +1,13 @@
+export interface FileItem {
+  id: string;
+  name: string;
+  size?: number;
+  modifiedTime?: string;
+  webViewLink?: string;
+}
+
+export interface FileListResponse {
+  files: FileItem[];
+  success: boolean;
+  error?: string;
+}

--- a/src/app/services/file/file.service.ts
+++ b/src/app/services/file/file.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { FileListResponse, FileItem } from './file.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FileService {
+  host: string = environment.apiUrl;
+
+  constructor(private http: HttpClient) { }
+
+  listFiles(): Observable<FileListResponse> {
+    return this.http.get<FileListResponse>(`${this.host}/files/list`);
+  }
+}


### PR DESCRIPTION
## Summary
- Add FileService with listFiles() method to call /files/list endpoint
- Create TypeScript interfaces for FileItem and FileListResponse
- Follow existing Angular 20 service patterns with HttpClient injection

## Changes
- Created src/app/services/file/file.model.ts with response interfaces
- Created src/app/services/file/file.service.ts with listFiles() method
- Service returns Observable<FileListResponse> for the /files/list endpoint

## Test plan
- [ ] Service compiles successfully
- [ ] Can inject FileService into components
- [ ] listFiles() method makes GET request to /files/list