### PR TITLE
feat: Add delete file API service implementation

### DIFF
--- a/src/app/influxdb-buckets/services/file/file.model.ts
+++ b/src/app/influxdb-buckets/services/file/file.model.ts
@@ -15,3 +15,10 @@ export interface FileListResponse {
   success: boolean;
   error?: string;
 }
+
+export interface FileDeleteResponse {
+  success: boolean;
+  message: string;
+  error?: string;
+  timestamp: string;
+}

--- a/src/app/influxdb-buckets/services/file/file.service.ts
+++ b/src/app/influxdb-buckets/services/file/file.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../../environments/environment';
-import { FileListResponse, FileItem } from './file.model';
+import { FileListResponse, FileItem, FileDeleteResponse } from './file.model';
 
 @Injectable({
   providedIn: 'root'
@@ -14,5 +14,9 @@ export class FileService {
 
   listFiles(): Observable<FileListResponse> {
     return this.http.get<FileListResponse>(`${this.host}/files/list`);
+  }
+
+  deleteFile(fileId: string): Observable<FileDeleteResponse> {
+    return this.http.delete<FileDeleteResponse>(`${this.host}/files/${fileId}`);
   }
 }


### PR DESCRIPTION
## Summary
- Add FileDeleteResponse interface matching the API specification
- Implement deleteFile method in FileService to call DELETE /files/{fileId} endpoint
- Update imports to include new response type

## Changes Made
- Created FileDeleteResponse interface with success, message, error, and timestamp fields
- Added deleteFile(fileId: string) method to FileService that returns Observable<FileDeleteResponse>
- Updated imports to include the new FileDeleteResponse type

## Test Plan
- [x] Code compiles successfully (npm run build)
- [x] TypeScript types are correct
- [x] API endpoint matches the specification (DELETE /files/{fileId})
- [ ] Integration testing with actual API endpoint