### PR TITLE
feat: Add delete file button to InfluxDB buckets files section

### DIFF
--- a/delete-file-api-spec.md
+++ b/delete-file-api-spec.md
@@ -1,0 +1,106 @@
+# Delete File API Specification
+
+## Endpoint Details
+
+- **Method**: `DELETE`
+- **Path**: `/files/{fileId}`
+- **Base URL**: `http://192.168.178.29:9001`
+- **Full URL**: `http://192.168.178.29:9001/files/{fileId}`
+- **Tags**: File List
+
+## Description
+
+Deletes a specific file from Google Drive using its file ID. This operation is permanent and cannot be undone.
+
+## Parameters
+
+### Path Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `fileId` | string | Yes | The ID of the file to delete from Google Drive |
+
+## Responses
+
+### 200 OK - Success
+**Description**: File successfully deleted from Google Drive
+**Content-Type**: `application/json`
+**Schema**: [FileDeleteResponse](#filedeleteresponse-schema)
+
+### 400 Bad Request
+**Description**: Bad request - invalid file ID provided
+**Content-Type**: `application/json`
+**Schema**: [FileDeleteResponse](#filedeleteresponse-schema)
+
+### 404 Not Found
+**Description**: File not found in Google Drive
+**Content-Type**: `application/json`
+**Schema**: [FileDeleteResponse](#filedeleteresponse-schema)
+
+### 500 Internal Server Error
+**Description**: Internal server error occurred while deleting file from Google Drive
+**Content-Type**: `application/json`
+**Schema**: [FileDeleteResponse](#filedeleteresponse-schema)
+
+## Schemas
+
+### FileDeleteResponse Schema
+
+```json
+{
+  "success": "boolean",
+  "message": "string",
+  "error": "string",
+  "timestamp": "string (date-time)"
+}
+```
+
+#### Properties
+
+| Name | Type | Description |
+|------|------|-------------|
+| `success` | boolean | Indicates whether the deletion was successful |
+| `message` | string | Descriptive message about the operation result |
+| `error` | string | Error details (if applicable) |
+| `timestamp` | string | ISO 8601 timestamp of when the operation was performed |
+
+## Example Usage
+
+### Request
+
+```http
+DELETE /files/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms HTTP/1.1
+Host: 192.168.178.29:9001
+```
+
+### Success Response (200 OK)
+
+```json
+{
+  "success": true,
+  "message": "File successfully deleted from Google Drive",
+  "timestamp": "2024-01-15T10:30:00Z"
+}
+```
+
+### Error Response (404 Not Found)
+
+```json
+{
+  "success": false,
+  "message": "File not found in Google Drive",
+  "error": "File with ID 'invalid-file-id' does not exist",
+  "timestamp": "2024-01-15T10:30:00Z"
+}
+```
+
+## Related Endpoints
+
+- `GET /files/list` - List files in Google Drive (to get file IDs)
+- See also: [File List API Documentation](#) for retrieving file IDs that can be used with this delete endpoint
+
+## Notes
+
+- This operation is **permanent** and cannot be undone
+- File IDs can be obtained from the `/files/list` endpoint
+- The endpoint requires proper authentication with Google Drive API permissions

--- a/src/app/influxdb-buckets/influxdb-buckets.html
+++ b/src/app/influxdb-buckets/influxdb-buckets.html
@@ -119,6 +119,12 @@
                         matTooltip="Open file">
                   <mat-icon>open_in_new</mat-icon>
                 </button>
+                <button mat-icon-button
+                        (click)="deleteFile(file.id, file.name)"
+                        matTooltip="Delete file"
+                        class="text-danger">
+                  <mat-icon>delete</mat-icon>
+                </button>
               </td>
             </ng-container>
 

--- a/src/app/influxdb-buckets/influxdb-buckets.ts
+++ b/src/app/influxdb-buckets/influxdb-buckets.ts
@@ -9,7 +9,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { InfluxBucketsService } from './services/influx-buckets.service';
 import { FileService } from './services/file/file.service';
 import {InfluxBucket, InfluxBucketResponse, InfluxExportRequest, InfluxExportResponse} from './model/influx-bucket';
-import {FileItem, FileItemTime, FileListResponse} from './services/file/file.model';
+import {FileItem, FileItemTime, FileListResponse, FileDeleteResponse} from './services/file/file.model';
 
 @Component({
   selector: 'app-influxdb-buckets',
@@ -171,6 +171,27 @@ export class InfluxdbBuckets implements OnInit {
   openFile(webViewLink?: string): void {
     if (webViewLink) {
       window.open(webViewLink, '_blank');
+    }
+  }
+
+  deleteFile(fileId: string, fileName: string): void {
+    const confirmed = window.confirm(`Are you sure you want to delete the file "${fileName}"? This action cannot be undone.`);
+
+    if (confirmed) {
+      this.fileService.deleteFile(fileId).subscribe({
+        next: (response: FileDeleteResponse) => {
+          if (response.success) {
+            // Reload the files list after successful deletion
+            this.loadFiles();
+          } else {
+            this.filesError = response.error || 'Failed to delete file';
+          }
+        },
+        error: (error) => {
+          this.filesError = 'Failed to delete file: ' + error.message;
+          console.error('Error deleting file:', error);
+        }
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add delete button in Actions column for each file in the InfluxDB buckets files section
- Implement deleteFile method with browser confirmation dialog
- Refresh files list automatically after successful deletion
- Display error messages when deletion fails

## Changes
- Added delete button with delete icon and red styling in the Actions column
- Implemented deleteFile method that calls the FileService.deleteFile API
- Added confirmation dialog before deletion
- Files list reloads after successful deletion
- Error handling with user-friendly messages

## Test plan
- [ ] Verify delete button appears for each file in the Actions column
- [ ] Test confirmation dialog appears when clicking delete
- [ ] Verify file is deleted when confirmed
- [ ] Verify files list refreshes after deletion
- [ ] Test error handling for failed deletions