### PR TITLE
feat: Add Angular version to environment generator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 
 COPY . .
 
-RUN npm run env:build
+RUN npm run env:full
 RUN npm run build --production
 
 FROM nginx:1.25 AS production-stage

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "env:dev": "node scripts/generate-env.js --env=development",
     "env:prod": "node scripts/generate-env.js --env=production",
     "env:build": "node scripts/generate-env.js --build-time --node-version",
-    "env:preview": "node scripts/generate-env.js --dry-run"
+    "env:full": "node scripts/generate-env.js --build-time --node-version --angular-version",
+    "env:preview": "node scripts/generate-env.js --dry-run",
+    "env:test": "node scripts/generate-env.js --dry-run --angular-version"
   },
   "private": true,
   "dependencies": {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -19,7 +19,7 @@ export class HomeComponent {
   readonly metadata = {
     nodeVersion: environment.nodeVersion,
     npmVersion: '11.6.1',
-    angularVersion: '20.2.8',
+    angularVersion: environment.angularVersion,
     projectVersion: '0.0.0',
     buildTime: environment.buildTime,
     environment: environment.production ? 'prod' : 'dev'

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,6 +1,7 @@
 export const environment = {
   production: true,
   apiUrl: 'http://backend.home-lab.com',
-  buildTime: '2025-12-19T20:13:50.266Z',
-  nodeVersion: 'v23.9.0'
+  buildTime: '2025-12-21T12:21:32.472Z',
+  nodeVersion: 'v23.9.0',
+  angularVersion: '20.2.8'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,6 +1,7 @@
 export const environment = {
   production: false,
   apiUrl: 'http://localhost:9001',
-  buildTime: '2025-12-19T20:13:50.266Z',
-  nodeVersion: 'v23.9.0'
+  buildTime: '2025-12-21T12:21:32.471Z',
+  nodeVersion: 'v23.9.0',
+  angularVersion: '20.2.8'
 };

--- a/src/environments/environment.ts.template
+++ b/src/environments/environment.ts.template
@@ -2,5 +2,6 @@ export const environment = {
   production: ###production###,
   apiUrl: ###apiUrl###,
   buildTime: ###buildTime###,
-  nodeVersion: ###nodeVersion###
+  nodeVersion: ###nodeVersion###,
+  angularVersion: ###angularVersion###
 };


### PR DESCRIPTION
## Summary
- Added `--angular-version` flag to `scripts/generate-env.js` to include Angular version in generated environment files
- Reads Angular version from `package.json` using the `@angular/core` dependency
- Strips the caret (^) from version (e.g., `^20.2.8` → `20.2.8`) for cleaner output
- Updated environment template with `angularVersion` placeholder
- Added new npm scripts: `env:full` (includes all versions) and `env:test` (for testing Angular version output)

## Changes
- **scripts/generate-env.js**: Extended with Angular version reading and template replacement logic
- **src/environments/environment.ts.template**: Added `angularVersion` property
- **package.json**: Added `env:full` and `env:test` npm scripts

## Testing
- Tested with `--dry-run` to verify output
- Tested with all flags combined (`--build-time --node-version --angular-version`)
- Verified help text displays new option correctly
- Confirmed generated environment files contain correct Angular version (`20.2.8`)

## Example Usage
```bash
# Generate with Angular version
node scripts/generate-env.js --angular-version

# Generate with all versions
node scripts/generate-env.js --build-time --node-version --angular-version

# Use npm script
npm run env:full
```

## Test plan
- [x] Run `node scripts/generate-env.js --angular-version --dry-run` to verify output
- [x] Test with all flags: `node scripts/generate-env.js --build-time --node-version --angular-version`
- [x] Verify generated environment files contain correct Angular version
- [x] Test error handling with missing package.json
- [x] Verify help text displays new option correctly