### PR TITLE
Refactor generate-env.js to minimal representation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 
 COPY . .
 
-RUN npm run env:full
+RUN npm run env:production
 RUN npm run build --production
 
 FROM nginx:1.25 AS production-stage

--- a/package.json
+++ b/package.json
@@ -12,13 +12,7 @@
     "lint:fix": "eslint . --fix",
     "lint:ts": "eslint \"**/*.ts\"",
     "lint:html": "eslint \"**/*.html\"",
-    "generate-env": "node scripts/generate-env.js",
-    "env:dev": "node scripts/generate-env.js --env=development",
-    "env:prod": "node scripts/generate-env.js --env=production",
-    "env:build": "node scripts/generate-env.js --build-time --node-version",
-    "env:full": "node scripts/generate-env.js --build-time --node-version --angular-version",
-    "env:preview": "node scripts/generate-env.js --dry-run",
-    "env:test": "node scripts/generate-env.js --dry-run --angular-version"
+    "env:production": "node scripts/generate-env.js --build-time --node-version --angular-version"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Refactored generate-env.js to its minimal representation while preserving core functionality:\n\n- Removed help function (--help)\n- Removed dry-run functionality\n- Simplified error handling\n- Kept essential template parsing and file generation\n- Maintained all core environment generation capabilities