### PR TITLE
feat: Add NPM version template resolution to generate-env.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "eslint . --fix",
     "lint:ts": "eslint \"**/*.ts\"",
     "lint:html": "eslint \"**/*.html\"",
-    "env:production": "node scripts/generate-env.js --build-time --node-version --angular-version"
+    "env:production": "node scripts/generate-env.js --build-time --node-version --angular-version --npm-version"
   },
   "private": true,
   "dependencies": {

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,7 +1,8 @@
 export const environment = {
   production: true,
   apiUrl: 'http://backend.home-lab.com',
-  buildTime: '2025-12-21T12:21:32.472Z',
+  buildTime: '2025-12-21T12:54:14.935Z',
   nodeVersion: 'v23.9.0',
-  angularVersion: '20.2.8'
+  angularVersion: '20.2.8',
+  npmVersion: '11.2.0'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,7 +1,8 @@
 export const environment = {
   production: false,
   apiUrl: 'http://localhost:9001',
-  buildTime: '2025-12-21T12:21:32.471Z',
+  buildTime: '2025-12-21T12:54:14.850Z',
   nodeVersion: 'v23.9.0',
-  angularVersion: '20.2.8'
+  angularVersion: '20.2.8',
+  npmVersion: '11.2.0'
 };

--- a/src/environments/environment.ts.template
+++ b/src/environments/environment.ts.template
@@ -3,5 +3,6 @@ export const environment = {
   apiUrl: ###apiUrl###,
   buildTime: ###buildTime###,
   nodeVersion: ###nodeVersion###,
-  angularVersion: ###angularVersion###
+  angularVersion: ###angularVersion###,
+  npmVersion: ###npmVersion###
 };


### PR DESCRIPTION
This PR adds NPM version template resolution support to the generate-env.js script.

## Changes:
- Added  command line option
- Added NPM version reading logic using child_process
- Added template replacement for  placeholder
- Made necessary async function updates to support ES module imports

## Usage:


This allows the environment files to include the current NPM version in the generated configuration.