### PR TITLE
feat(plants): add fertilized button to plant gallery

### DIFF
--- a/src/app/plants/components/plant-gallery/plant-gallery.component.html
+++ b/src/app/plants/components/plant-gallery/plant-gallery.component.html
@@ -44,6 +44,7 @@
         </mat-card-content>
         <mat-card-actions class="d-flex justify-content-center py-sm-0 py-md-2">
           <button mat-button (click)="setWateredNow(plant)">Watered</button>
+          <button mat-button (click)="setFertilizedNow(plant)">Fertilized</button>
         </mat-card-actions>
       </mat-card>
     </div>

--- a/src/app/plants/components/plant-gallery/plant-gallery.component.ts
+++ b/src/app/plants/components/plant-gallery/plant-gallery.component.ts
@@ -68,4 +68,28 @@ export class PlantGalleryComponent implements OnInit {
       }
     });
   }
+
+  setFertilizedNow(plant: Plant) {
+    const now: Date = new Date();
+    const lastFertilizedDate = this.datePipe.transform(now, 'yyyy-MM-dd') ?? '1970-01-01';
+
+    this.plantService.fertilizedPlant(plant.id, lastFertilizedDate).subscribe({
+      next: ({nextFertilizedDate}) => {
+        this.plants.update(plants => {
+          return plants.map(p =>
+            p.id === plant.id ? {
+              ...p, lastFertilizedDate: lastFertilizedDate, nextFertilizedDate: nextFertilizedDate ?? null
+            } : p
+          ).sort((a, b) => a.id - b.id);
+        });
+        const formattedDate: string | null = this.datePipe.transform(now, 'dd.MM.yyyy');
+        this.snackBar.open(`Set last fertilized to: ${formattedDate}`, 'Dismiss', {duration: 5000});
+      },
+      error: err => {
+        this.snackBar.open(`Plant update failed: ${err}`, 'Dismiss', {
+          duration: 5000
+        })
+      }
+    });
+  }
 }

--- a/src/app/plants/services/plant.service.ts
+++ b/src/app/plants/services/plant.service.ts
@@ -51,4 +51,8 @@ export class PlantService {
     return this.http.patch<any>(`${this.host}/plants/${id}/watered?last-watered=${lastWatered}`, {observe: 'response'})
   }
 
+  fertilizedPlant(id: number, lastFertilized: string): Observable<Plant> {
+    return this.http.patch<any>(`${this.host}/plants/${id}/fertilized?last-fertilized=${lastFertilized}`, {observe: 'response'})
+  }
+
 }


### PR DESCRIPTION
## Summary
- Add `fertilizedPlant` method to `PlantService` that calls the backend API endpoint
- Add `setFertilizedNow` method to `PlantGalleryComponent` following the same pattern as `setWateredNow`
- Add "Fertilized" button to `plant-gallery.component.html` next to the existing "Watered" button
- Updates `lastFertilizedDate` to current date and refreshes plant data from API response

## Test plan
- [ ] Build passes successfully
- [ ] Clicking "Fertilized" button sets last fertilized date to current date
- [ ] Plant data updates correctly with next fertilized date from API
- [ ] Snackbar notification shows formatted date (DD.MM.YYYY)