### PR TITLE
feat(mental-arithmetic): integrate backend API

### DIFF
--- a/src/app/mental-arithmetic/components/arithmetic-list/arithmetic-list.component.html
+++ b/src/app/mental-arithmetic/components/arithmetic-list/arithmetic-list.component.html
@@ -6,7 +6,7 @@
   </div>
 
   <!-- Statistics Cards -->
-  @if (!loading) {
+  @if (!loading()) {
   <div class="stats-container">
     <mat-card class="stat-card">
       <div class="stat-content">
@@ -51,7 +51,7 @@
   }
 
   <!-- Filters and Controls -->
-  @if (!loading) {
+  @if (!loading()) {
   <mat-card class="filters-card">
     <div class="filters-row">
       <mat-form-field appearance="outline" class="filter-field">
@@ -91,7 +91,7 @@
   }
 
   <!-- Loading State -->
-  @if (loading) {
+  @if (loading()) {
   <div class="loading-container">
     <mat-progress-bar mode="indeterminate"></mat-progress-bar>
     <p>Lade Sitzungsdaten...</p>
@@ -99,7 +99,7 @@
   }
 
   <!-- Sessions Table -->
-  @if (!loading) {
+  @if (!loading()) {
   <mat-card class="sessions-card">
     <div class="card-content">
       <div class="table-header">
@@ -219,7 +219,7 @@
               Keine Sitzungen entsprechen den aktuellen Filterkriterien.
             </p>
           }
-          <button mat-raised-button color="primary" routerLink="/mental-arithmetic/main">
+          <button mat-raised-button color="primary" routerLink="/mental-arithmetic">
             Training starten
           </button>
         </div>

--- a/src/app/mental-arithmetic/components/arithmetic-list/arithmetic-list.component.ts
+++ b/src/app/mental-arithmetic/components/arithmetic-list/arithmetic-list.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, signal, WritableSignal} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {RouterModule} from '@angular/router';
 import {FormsModule} from '@angular/forms';
@@ -58,7 +58,7 @@ export class ArithmeticListComponent implements OnInit {
   sortOrder: 'asc' | 'desc' = 'desc';
 
   // UI state
-  loading: boolean = true;
+  loading: WritableSignal<boolean> = signal(true);
   expandedSession: string | null = null;
 
   constructor(
@@ -72,19 +72,24 @@ export class ArithmeticListComponent implements OnInit {
   }
 
   loadSessions(): void {
-    this.loading = true;
+    this.loading.set(true);
     this.arithmeticService.loadSessionsFromStorage().subscribe({
       next: (sessions) => {
-        this.sessions = sessions;
+        this.sessions = sessions.map(s => ({
+          ...s,
+          createdAt: s.createdAt ? new Date(s.createdAt as any) : new Date(),
+          startTime: s.startTime ? new Date(s.startTime as any) : null,
+          endTime: s.endTime ? new Date(s.endTime as any) : null
+        }));
         this.filteredSessions = [...this.sessions];
         this.calculateStatistics();
         this.applyFiltersAndSorting();
-        this.loading = false;
+        this.loading.set(false);
       },
       error: (error) => {
         console.error('Error loading sessions:', error);
         this.snackBar.open('Fehler beim Laden der Sitzungen', 'OK', {duration: 3000});
-        this.loading = false;
+        this.loading.set(false);
       }
     });
   }
@@ -131,7 +136,6 @@ export class ArithmeticListComponent implements OnInit {
     // Apply sorting
     this.filteredSessions.sort((a, b) => {
       let comparison: number;
-
       switch (this.sortBy) {
         case 'date':
           const timeA = a.startTime ? a.startTime.getTime() : 0;

--- a/src/app/mental-arithmetic/components/arithmetic-list/arithmetic-list.component.ts
+++ b/src/app/mental-arithmetic/components/arithmetic-list/arithmetic-list.component.ts
@@ -73,17 +73,20 @@ export class ArithmeticListComponent implements OnInit {
 
   loadSessions(): void {
     this.loading = true;
-    try {
-      this.sessions = this.arithmeticService.loadSessionsFromStorage();
-      this.filteredSessions = [...this.sessions];
-      this.calculateStatistics();
-      this.applyFiltersAndSorting();
-      this.loading = false;
-    } catch (error) {
-      console.error('Error loading sessions:', error);
-      this.snackBar.open('Fehler beim Laden der Sitzungen', 'OK', {duration: 3000});
-      this.loading = false;
-    }
+    this.arithmeticService.loadSessionsFromStorage().subscribe({
+      next: (sessions) => {
+        this.sessions = sessions;
+        this.filteredSessions = [...this.sessions];
+        this.calculateStatistics();
+        this.applyFiltersAndSorting();
+        this.loading = false;
+      },
+      error: (error) => {
+        console.error('Error loading sessions:', error);
+        this.snackBar.open('Fehler beim Laden der Sitzungen', 'OK', {duration: 3000});
+        this.loading = false;
+      }
+    });
   }
 
   calculateStatistics(): void {
@@ -174,27 +177,31 @@ export class ArithmeticListComponent implements OnInit {
 
   deleteSession(sessionId: string): void {
     if (confirm('Möchten Sie diese Sitzung wirklich löschen?')) {
-      try {
-        this.arithmeticService.deleteSessionFromStorage(sessionId);
-        this.loadSessions();
-        this.snackBar.open('Sitzung gelöscht', 'OK', {duration: 3000});
-      } catch (error) {
-        console.error('Error deleting session:', error);
-        this.snackBar.open('Fehler beim Löschen der Sitzung', 'OK', {duration: 3000});
-      }
+      this.arithmeticService.deleteSessionFromStorage(sessionId).subscribe({
+        next: () => {
+          this.loadSessions();
+          this.snackBar.open('Sitzung gelöscht', 'OK', {duration: 3000});
+        },
+        error: (error) => {
+          console.error('Error deleting session:', error);
+          this.snackBar.open('Fehler beim Löschen der Sitzung', 'OK', {duration: 3000});
+        }
+      });
     }
   }
 
   clearAllSessions(): void {
     if (confirm('Möchten Sie wirklich alle Sitzungen löschen? Dieser Vorgang kann nicht rückgängig gemacht werden.')) {
-      try {
-        this.arithmeticService.clearAllSessionsFromStorage();
-        this.loadSessions();
-        this.snackBar.open('Alle Sitzungen gelöscht', 'OK', {duration: 3000});
-      } catch (error) {
-        console.error('Error clearing sessions:', error);
-        this.snackBar.open('Fehler beim Löschen der Sitzungen', 'OK', {duration: 3000});
-      }
+      this.arithmeticService.clearAllSessionsFromStorage().subscribe({
+        next: () => {
+          this.loadSessions();
+          this.snackBar.open('Alle Sitzungen gelöscht', 'OK', {duration: 3000});
+        },
+        error: (error) => {
+          console.error('Error clearing sessions:', error);
+          this.snackBar.open('Fehler beim Löschen der Sitzungen', 'OK', {duration: 3000});
+        }
+      });
     }
   }
 

--- a/src/app/mental-arithmetic/components/arithmetic-root/mental-arithmetic-root.component.html
+++ b/src/app/mental-arithmetic/components/arithmetic-root/mental-arithmetic-root.component.html
@@ -8,10 +8,10 @@
         <mat-icon>more_vert</mat-icon>
       </button>
       <mat-menu #menu="matMenu">
-        <button mat-menu-item routerLink="/mental-arithmetic/mental-arithmetic-main">
+        <button mat-menu-item routerLink="/mental-arithmetic/session">
           <span>Start Training</span>
         </button>
-        <button mat-menu-item routerLink="/mental-arithmetic/arithmetic-settings">
+        <button mat-menu-item routerLink="/mental-arithmetic/settings">
           <span>Settings</span>
         </button>
         <button mat-menu-item routerLink="/mental-arithmetic/arithmetic-list">

--- a/src/app/mental-arithmetic/components/arithmetic-session/arithmetic-session.component.ts
+++ b/src/app/mental-arithmetic/components/arithmetic-session/arithmetic-session.component.ts
@@ -186,7 +186,7 @@ export class ArithmeticSessionComponent implements OnInit, OnDestroy {
         }
 
         // Update problem time if current problem exists
-        if (this.currentProblem && this.currentProblem.answeredAt === null) {
+        if (this.currentProblem && !this.currentProblem.answeredAt) {
           this.currentProblem.timeSpent = Date.now() - this.currentProblemStartTime;
         }
 

--- a/src/app/mental-arithmetic/components/arithmetic-settings/arithmetic-settings.component.ts
+++ b/src/app/mental-arithmetic/components/arithmetic-settings/arithmetic-settings.component.ts
@@ -64,18 +64,24 @@ export class ArithmeticSettingsComponent implements OnInit {
   }
 
   private loadSavedSettings(): void {
-    const savedSettings = this.arithmeticService.loadSettingsFromStorage();
-    if (savedSettings) {
-      this.settingsForm.patchValue({
-        operations: {
-          addition: savedSettings.operations.includes(OperationType.ADDITION),
-          subtraction: savedSettings.operations.includes(OperationType.SUBTRACTION)
-        },
-        difficulty: savedSettings.difficulty,
-        timeLimit: savedSettings.timeLimit,
-        problemCount: savedSettings.problemCount
-      });
-    }
+    this.arithmeticService.loadSettingsFromStorage().subscribe({
+      next: (savedSettings) => {
+        if (savedSettings) {
+          this.settingsForm.patchValue({
+            operations: {
+              addition: savedSettings.operations.includes(OperationType.ADDITION),
+              subtraction: savedSettings.operations.includes(OperationType.SUBTRACTION)
+            },
+            difficulty: savedSettings.difficulty,
+            timeLimit: savedSettings.timeLimit,
+            problemCount: savedSettings.problemCount
+          });
+        }
+      },
+      error: (error) => {
+        console.error('Error loading settings:', error);
+      }
+    });
   }
 
   private atLeastOneOperationSelected(group: FormGroup): { [key: string]: boolean } | null {
@@ -122,7 +128,9 @@ export class ArithmeticSettingsComponent implements OnInit {
         }
       };
 
-      this.arithmeticService.saveSettingsToStorage(settings);
+      this.arithmeticService.saveSettingsToStorage(settings).subscribe({
+        error: (error) => console.error('Error saving settings:', error)
+      });
     }
   }
 

--- a/src/app/mental-arithmetic/model/API_SPEC.md
+++ b/src/app/mental-arithmetic/model/API_SPEC.md
@@ -143,22 +143,36 @@ Deletes session.
 
 ## Problem Generation (Server-Side)
 
-Based on `difficulty` and `operations`:
-- EASY: 2-digit (10-99)
-- MEDIUM: 3-digit (100-999)
-- HARD: 4-digit (1000-9999)
+### Algorithm
+For each of `problemCount` problems:
+1. Randomly select operation from `settings.operations`
+2. Generate problem based on selected operation and `difficulty`
+3. Set `presentedAt = now`, `userAnswer = null`, `isCorrect = null`, `timeSpent = 0`
 
-### Addition
-`operand1 + operand2` - both operands in difficulty range
+### Number Ranges by Difficulty
+| Difficulty | Range |
+|------------|-------|
+| EASY | 10-99 (2-digit) |
+| MEDIUM | 100-999 (3-digit) |
+| HARD | 1000-9999 (4-digit) |
 
-### Subtraction
-`minuend - subtrahend` - ensures positive result
+Formula: `Math.floor(Math.random() * (max - min + 1)) + min`
 
-### Multiplication
-`operand1 × operand2` - smaller operands for reasonable difficulty
+### Operations
 
-### Division
-`dividend ÷ divisor = quotient` - ensures integer result
+**ADDITION**: `a + b = c`
+- `a`, `b`: random in difficulty range
+- `c`: calculated
+
+**SUBTRACTION**: `a - b = c`
+- `a`, `b`: random in difficulty range
+- Swap if `a < b` to ensure positive result
+- `minuend = max(a, b)`, `subtrahend = min(a, b)`
+
+**MULTIPLICATION** / **DIVISION**: Not implemented (default to ADDITION)
+
+### ID Generation
+Problem ID: `problem_${timestamp}_${random}` (random = 9 char base36)
 
 ## Date Format
 All dates as ISO 8601 strings (e.g., `"2025-01-15T10:30:00.000Z"`)

--- a/src/app/mental-arithmetic/model/API_SPEC.md
+++ b/src/app/mental-arithmetic/model/API_SPEC.md
@@ -77,30 +77,62 @@ SessionStatus: CREATED | ACTIVE | PAUSED | COMPLETED | TIMED_OUT | CANCELLED
 }
 ```
 
-## API Endpoints
+## HTTP Endpoints
 
 ### Sessions
-| Method | Endpoint | Request | Response |
-|--------|----------|---------|----------|
-| POST | `/api/sessions` | `ArithmeticSettings` | `ArithmeticSession` |
-| PUT | `/api/sessions/:id` | `ArithmeticSession` | `ArithmeticSession` |
-| GET | `/api/sessions` | - | `ArithmeticSession[]` |
-| GET | `/api/sessions/:id` | - | `ArithmeticSession` |
-| DELETE | `/api/sessions/:id` | - | `void` |
+
+#### POST /api/sessions
+Creates new session with generated problems.
+- Request: `ArithmeticSettings`
+- Response: `201 Created` → `ArithmeticSession`
+- Problems generated server-side based on settings
+
+#### PUT /api/sessions/:id
+Updates session (answer submission, progress tracking).
+- Request: `ArithmeticSession` (with updated problems/currentProblemIndex)
+- Response: `200 OK` → `ArithmeticSession` (recalculated metrics)
+- Recalculates: score, accuracy, averageTimePerProblem, isCompleted
+- Auto-transitions to COMPLETED if all problems answered
+
+#### GET /api/sessions
+Returns all sessions.
+- Response: `200 OK` → `ArithmeticSession[]`
+
+#### GET /api/sessions/:id
+Returns single session.
+- Response: `200 OK` → `ArithmeticSession`
+- `404 Not Found` if id invalid
+
+#### DELETE /api/sessions/:id
+Deletes session.
+- Response: `204 No Content`
 
 ### Session State Transitions
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| POST | `/api/sessions/:id/start` | Set startTime, status=ACTIVE |
-| POST | `/api/sessions/:id/pause` | status=PAUSED |
-| POST | `/api/sessions/:id/resume` | status=ACTIVE |
-| POST | `/api/sessions/:id/complete` | endTime, status=COMPLETED |
+
+#### POST /api/sessions/:id/start
+- Response: `200 OK` → `ArithmeticSession`
+- Sets `startTime = now`, `status = ACTIVE`
+
+#### POST /api/sessions/:id/pause
+- Response: `200 OK` → `ArithmeticSession`
+- Sets `status = PAUSED`
+
+#### POST /api/sessions/:id/resume
+- Response: `200 OK` → `ArithmeticSession`
+- Sets `status = ACTIVE`
+
+#### POST /api/sessions/:id/complete
+- Response: `200 OK` → `ArithmeticSession`
+- Sets `endTime = now`, `status = COMPLETED`, `isCompleted = true`
 
 ### Settings
-| Method | Endpoint | Request | Response |
-|--------|----------|---------|----------|
-| GET | `/api/settings` | - | `ArithmeticSettings` |
-| PUT | `/api/settings` | `ArithmeticSettings` | `ArithmeticSettings` |
+
+#### GET /api/settings
+- Response: `200 OK` → `ArithmeticSettings` (or default settings if none saved)
+
+#### PUT /api/settings
+- Request: `ArithmeticSettings`
+- Response: `200 OK` → `ArithmeticSettings`
 
 ## Calculated Fields (Server-Side)
 - `score`: count of correct answers
@@ -109,6 +141,24 @@ SessionStatus: CREATED | ACTIVE | PAUSED | COMPLETED | TIMED_OUT | CANCELLED
 - `isCompleted`: problemsCompleted === totalProblems
 - Session auto-transitions to COMPLETED when all problems answered
 
-## Storage Keys
-- Sessions: `arithmetic_sessions`
-- Settings: `arithmetic_settings`
+## Problem Generation (Server-Side)
+
+Based on `difficulty` and `operations`:
+- EASY: 2-digit (10-99)
+- MEDIUM: 3-digit (100-999)
+- HARD: 4-digit (1000-9999)
+
+### Addition
+`operand1 + operand2` - both operands in difficulty range
+
+### Subtraction
+`minuend - subtrahend` - ensures positive result
+
+### Multiplication
+`operand1 × operand2` - smaller operands for reasonable difficulty
+
+### Division
+`dividend ÷ divisor = quotient` - ensures integer result
+
+## Date Format
+All dates as ISO 8601 strings (e.g., `"2025-01-15T10:30:00.000Z"`)

--- a/src/app/mental-arithmetic/services/arithmetic-api.service.ts
+++ b/src/app/mental-arithmetic/services/arithmetic-api.service.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { ArithmeticSession } from '../model/arithmetic-session';
+import { ArithmeticSettings } from '../model/arithmetic-settings';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ArithmeticApiService {
+  private readonly apiUrl = 'http://localhost:9001/api';
+
+  constructor(private http: HttpClient) {}
+
+  createSession(settings: ArithmeticSettings): Observable<ArithmeticSession> {
+    return this.http.post<ArithmeticSession>(`${this.apiUrl}/sessions`, settings);
+  }
+
+  updateSession(session: ArithmeticSession): Observable<ArithmeticSession> {
+    return this.http.put<ArithmeticSession>(`${this.apiUrl}/sessions/${session.id}`, session);
+  }
+
+  getSessions(): Observable<ArithmeticSession[]> {
+    return this.http.get<ArithmeticSession[]>(`${this.apiUrl}/sessions`);
+  }
+
+  getSession(id: string): Observable<ArithmeticSession> {
+    return this.http.get<ArithmeticSession>(`${this.apiUrl}/sessions/${id}`);
+  }
+
+  deleteSession(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/sessions/${id}`);
+  }
+
+  startSession(id: string): Observable<ArithmeticSession> {
+    return this.http.post<ArithmeticSession>(`${this.apiUrl}/sessions/${id}/start`, {});
+  }
+
+  pauseSession(id: string): Observable<ArithmeticSession> {
+    return this.http.post<ArithmeticSession>(`${this.apiUrl}/sessions/${id}/pause`, {});
+  }
+
+  resumeSession(id: string): Observable<ArithmeticSession> {
+    return this.http.post<ArithmeticSession>(`${this.apiUrl}/sessions/${id}/resume`, {});
+  }
+
+  completeSession(id: string): Observable<ArithmeticSession> {
+    return this.http.post<ArithmeticSession>(`${this.apiUrl}/sessions/${id}/complete`, {});
+  }
+
+  getSettings(): Observable<ArithmeticSettings> {
+    return this.http.get<ArithmeticSettings>(`${this.apiUrl}/settings`);
+  }
+
+  updateSettings(settings: ArithmeticSettings): Observable<ArithmeticSettings> {
+    return this.http.put<ArithmeticSettings>(`${this.apiUrl}/settings`, settings);
+  }
+}

--- a/src/app/mental-arithmetic/services/arithmetic-api.service.ts
+++ b/src/app/mental-arithmetic/services/arithmetic-api.service.ts
@@ -3,12 +3,13 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { ArithmeticSession } from '../model/arithmetic-session';
 import { ArithmeticSettings } from '../model/arithmetic-settings';
+import {environment} from "../../../environments/environment";
 
 @Injectable({
   providedIn: 'root'
 })
 export class ArithmeticApiService {
-  private readonly apiUrl = 'http://localhost:9001/api';
+  private readonly apiUrl = environment.apiUrl;
 
   constructor(private http: HttpClient) {}
 

--- a/src/app/mental-arithmetic/services/arithmetic.service.ts
+++ b/src/app/mental-arithmetic/services/arithmetic.service.ts
@@ -1,4 +1,5 @@
 import {Injectable} from '@angular/core';
+import {Observable} from 'rxjs';
 import {SessionManagerService} from './session-manager.service';
 import {StorageService} from './storage.service';
 import {ScoringService} from './scoring.service';
@@ -17,51 +18,55 @@ export class ArithmeticService {
   ) {
   }
 
-  createSession(settings: ArithmeticSettings): ArithmeticSession {
+  createSession(settings: ArithmeticSettings): Observable<ArithmeticSession> {
     return this.sessionManager.createSession(settings);
   }
 
-  startSession(session: ArithmeticSession): ArithmeticSession {
-    return this.sessionManager.startSession(session);
+  startSession(sessionId: string): Observable<ArithmeticSession> {
+    return this.sessionManager.startSession(sessionId);
   }
 
-  updateSession(session: ArithmeticSession): ArithmeticSession {
+  updateSession(session: ArithmeticSession): Observable<ArithmeticSession> {
     return this.sessionManager.updateSession(session);
   }
 
-  completeSession(session: ArithmeticSession): ArithmeticSession {
-    return this.sessionManager.completeSession(session);
+  completeSession(sessionId: string): Observable<ArithmeticSession> {
+    return this.sessionManager.completeSession(sessionId);
   }
 
-  pauseSession(session: ArithmeticSession): ArithmeticSession {
-    return this.sessionManager.pauseSession(session);
+  pauseSession(sessionId: string): Observable<ArithmeticSession> {
+    return this.sessionManager.pauseSession(sessionId);
   }
 
-  resumeSession(session: ArithmeticSession): ArithmeticSession {
-    return this.sessionManager.resumeSession(session);
+  resumeSession(sessionId: string): Observable<ArithmeticSession> {
+    return this.sessionManager.resumeSession(sessionId);
   }
 
-  saveSessionToStorage(session: ArithmeticSession): void {
-    this.storageService.saveSession(session);
+  getSession(sessionId: string): Observable<ArithmeticSession> {
+    return this.sessionManager.getSession(sessionId);
   }
 
-  loadSessionsFromStorage(): ArithmeticSession[] {
+  saveSessionToStorage(session: ArithmeticSession): Observable<ArithmeticSession> {
+    return this.storageService.saveSession(session);
+  }
+
+  loadSessionsFromStorage(): Observable<ArithmeticSession[]> {
     return this.storageService.loadSessions();
   }
 
-  deleteSessionFromStorage(sessionId: string): void {
-    this.storageService.deleteSession(sessionId);
+  deleteSessionFromStorage(sessionId: string): Observable<void> {
+    return this.storageService.deleteSession(sessionId);
   }
 
-  clearAllSessionsFromStorage(): void {
-    this.storageService.clearAllSessions();
+  clearAllSessionsFromStorage(): Observable<void[]> {
+    return this.storageService.clearAllSessions();
   }
 
-  saveSettingsToStorage(settings: ArithmeticSettings): void {
-    this.storageService.saveSettings(settings);
+  saveSettingsToStorage(settings: ArithmeticSettings): Observable<ArithmeticSettings> {
+    return this.storageService.saveSettings(settings);
   }
 
-  loadSettingsFromStorage(): ArithmeticSettings | null {
+  loadSettingsFromStorage(): Observable<ArithmeticSettings> {
     return this.storageService.loadSettings();
   }
 

--- a/src/app/mental-arithmetic/services/session-manager.service.ts
+++ b/src/app/mental-arithmetic/services/session-manager.service.ts
@@ -1,8 +1,8 @@
 import {Injectable} from '@angular/core';
-import {ProblemGeneratorService} from './problem-generator.service';
+import {Observable} from 'rxjs';
+import {ArithmeticApiService} from './arithmetic-api.service';
 import {ArithmeticSession} from '../model/arithmetic-session';
 import {ArithmeticSettings} from '../model/arithmetic-settings';
-import {SessionStatus} from '../model/arithmetic-enums';
 
 @Injectable({
   providedIn: 'root'
@@ -10,98 +10,35 @@ import {SessionStatus} from '../model/arithmetic-enums';
 export class SessionManagerService {
 
   constructor(
-    private problemGenerator: ProblemGeneratorService
+    private apiService: ArithmeticApiService
   ) {
   }
 
-  createSession(settings: ArithmeticSettings): ArithmeticSession {
-    const problems = this.problemGenerator.generateMixedProblems(settings, settings.problemCount);
-    const sessionId = this.generateSessionId();
-
-    return {
-      id: sessionId,
-      createdAt: new Date(),
-      startTime: null,
-      endTime: null,
-      status: SessionStatus.ACTIVE,
-      settings,
-      problems,
-      currentProblemIndex: 0,
-      score: 0,
-      correctAnswers: 0,
-      incorrectAnswers: 0,
-      totalTimeSpent: 0,
-      problemsCompleted: 0,
-      totalProblems: settings.problemCount,
-      accuracy: 0,
-      averageTimePerProblem: 0,
-      isCompleted: false,
-      isTimedOut: false
-    };
+  createSession(settings: ArithmeticSettings): Observable<ArithmeticSession> {
+    return this.apiService.createSession(settings);
   }
 
-  startSession(session: ArithmeticSession): ArithmeticSession {
-    return {
-      ...session,
-      startTime: new Date(),
-      status: SessionStatus.ACTIVE
-    };
+  startSession(sessionId: string): Observable<ArithmeticSession> {
+    return this.apiService.startSession(sessionId);
   }
 
-  updateSession(session: ArithmeticSession): ArithmeticSession {
-    const completedProblems = session.problems.filter(p => p.userAnswer !== null);
-    const correctAnswers = completedProblems.filter(p => p.isCorrect);
-
-    // Calculate metrics directly
-    const score = correctAnswers.length;
-    const accuracy = completedProblems.length > 0 ?
-      Math.round((correctAnswers.length / completedProblems.length) * 100) : 0;
-    const totalTime = completedProblems.reduce((sum, p) => sum + p.timeSpent, 0);
-    const averageTime = completedProblems.length > 0 ?
-      Math.round(totalTime / completedProblems.length) : 0;
-
-    const isCompleted = completedProblems.length === session.totalProblems;
-    const status = isCompleted ? SessionStatus.COMPLETED : session.status;
-
-    return {
-      ...session,
-      score,
-      correctAnswers: correctAnswers.length,
-      incorrectAnswers: completedProblems.length - correctAnswers.length,
-      problemsCompleted: completedProblems.length,
-      accuracy,
-      averageTimePerProblem: averageTime,
-      totalTimeSpent: totalTime,
-      isCompleted,
-      status,
-      endTime: isCompleted ? new Date() : null
-    };
+  updateSession(session: ArithmeticSession): Observable<ArithmeticSession> {
+    return this.apiService.updateSession(session);
   }
 
-  completeSession(session: ArithmeticSession): ArithmeticSession {
-    return {
-      ...session,
-      endTime: new Date(),
-      status: SessionStatus.COMPLETED,
-      isCompleted: true
-    };
+  completeSession(sessionId: string): Observable<ArithmeticSession> {
+    return this.apiService.completeSession(sessionId);
   }
 
-  pauseSession(session: ArithmeticSession): ArithmeticSession {
-    return {
-      ...session,
-      status: SessionStatus.PAUSED
-    };
+  pauseSession(sessionId: string): Observable<ArithmeticSession> {
+    return this.apiService.pauseSession(sessionId);
   }
 
-  resumeSession(session: ArithmeticSession): ArithmeticSession {
-    return {
-      ...session,
-      status: SessionStatus.ACTIVE
-    };
+  resumeSession(sessionId: string): Observable<ArithmeticSession> {
+    return this.apiService.resumeSession(sessionId);
   }
 
-  private generateSessionId(): string {
-    return `session_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
+  getSession(sessionId: string): Observable<ArithmeticSession> {
+    return this.apiService.getSession(sessionId);
   }
 }

--- a/src/app/mental-arithmetic/services/storage.service.ts
+++ b/src/app/mental-arithmetic/services/storage.service.ts
@@ -1,113 +1,43 @@
 import { Injectable } from '@angular/core';
-import {ArithmeticSession} from '../model/arithmetic-session';
-import {ArithmeticSettings} from '../model/arithmetic-settings';
+import { Observable } from 'rxjs';
+import { ArithmeticSession } from '../model/arithmetic-session';
+import { ArithmeticSettings } from '../model/arithmetic-settings';
+import { ArithmeticApiService } from './arithmetic-api.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class StorageService {
 
-  private readonly SESSIONS_KEY = 'arithmetic_sessions';
-  private readonly SETTINGS_KEY = 'arithmetic_settings';
-  private readonly MAX_SESSIONS = 100;
+  constructor(private apiService: ArithmeticApiService) {}
 
-  saveSession(session: ArithmeticSession): void {
-    try {
-      const sessions = this.loadSessions();
-      const existingIndex = sessions.findIndex(s => s.id === session.id);
-
-      if (existingIndex >= 0) {
-        sessions[existingIndex] = session;
-      } else {
-        sessions.push(session);
-      }
-
-      // Keep only the last MAX_SESSIONS to prevent storage overflow
-      const sortedSessions = sessions.sort((a, b) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-      ).slice(0, this.MAX_SESSIONS);
-
-      globalThis.localStorage.setItem(this.SESSIONS_KEY, JSON.stringify(sortedSessions));
-    } catch (error) {
-      console.error('Error saving session to localStorage:', error);
-    }
+  saveSession(session: ArithmeticSession): Observable<ArithmeticSession> {
+    return this.apiService.updateSession(session);
   }
 
-  loadSessions(): ArithmeticSession[] {
-    try {
-      const stored = globalThis.localStorage.getItem(this.SESSIONS_KEY);
-      if (!stored) {
-        return [];
-      }
-
-      const sessions = JSON.parse(stored);
-      // Convert date strings back to Date objects and ensure all required properties
-      return sessions.map((session: any): ArithmeticSession => ({
-        id: session.id || '',
-        createdAt: new Date(session.createdAt),
-        startTime: session.startTime ? new Date(session.startTime) : null,
-        endTime: session.endTime ? new Date(session.endTime) : null,
-        status: session.status || 'CREATED',
-        settings: session.settings || {
-          operations: [],
-          difficulty: 'EASY',
-          timeLimit: null,
-          problemCount: 10
-        },
-        problems: session.problems || [],
-        currentProblemIndex: session.currentProblemIndex || 0,
-        score: session.score || 0,
-        correctAnswers: session.correctAnswers || 0,
-        incorrectAnswers: session.incorrectAnswers || 0,
-        totalTimeSpent: session.totalTimeSpent || 0,
-        problemsCompleted: session.problemsCompleted || 0,
-        totalProblems: session.totalProblems || 10,
-        accuracy: session.accuracy || 0,
-        averageTimePerProblem: session.averageTimePerProblem || 0,
-        isCompleted: session.isCompleted || false,
-        isTimedOut: session.isTimedOut || false,
-        notes: session.notes || undefined
-      }));
-    } catch (error) {
-      console.error('Error loading sessions from localStorage:', error);
-      return [];
-    }
+  loadSessions(): Observable<ArithmeticSession[]> {
+    return this.apiService.getSessions();
   }
 
-  deleteSession(sessionId: string): void {
-    try {
-      const sessions = this.loadSessions();
-      const filteredSessions = sessions.filter(s => s.id !== sessionId);
-      globalThis.localStorage.setItem(this.SESSIONS_KEY, JSON.stringify(filteredSessions));
-    } catch (error) {
-      console.error('Error deleting session from localStorage:', error);
-    }
+  deleteSession(sessionId: string): Observable<void> {
+    return this.apiService.deleteSession(sessionId);
   }
 
-  clearAllSessions(): void {
-    try {
-      globalThis.localStorage.removeItem(this.SESSIONS_KEY);
-    } catch (error) {
-      console.error('Error clearing sessions from localStorage:', error);
-    }
+  clearAllSessions(): Observable<void[]> {
+    return new Observable(observer => {
+      this.apiService.getSessions().subscribe(sessions => {
+        const deleteObservables = sessions.map(s => this.apiService.deleteSession(s.id));
+        observer.next(Promise.all(deleteObservables.map(o => o.toPromise())) as unknown as void[]);
+        observer.complete();
+      });
+    });
   }
 
-  saveSettings(settings: ArithmeticSettings): void {
-    try {
-      globalThis.localStorage.setItem(this.SETTINGS_KEY, JSON.stringify(settings));
-    } catch (error) {
-      console.error('Error saving settings to localStorage:', error);
-    }
+  saveSettings(settings: ArithmeticSettings): Observable<ArithmeticSettings> {
+    return this.apiService.updateSettings(settings);
   }
 
-  loadSettings(): ArithmeticSettings | null {
-    try {
-      const stored = globalThis.localStorage.getItem(this.SETTINGS_KEY);
-      return stored ? JSON.parse(stored) : null;
-    } catch (error) {
-      console.error('Error loading settings from localStorage:', error);
-      return null;
-    }
+  loadSettings(): Observable<ArithmeticSettings> {
+    return this.apiService.getSettings();
   }
-
 }


### PR DESCRIPTION
## Summary
- Replace localStorage with backend API calls for mental arithmetic module
- Create ArithmeticApiService for HTTP communication with backend
- Update SessionManagerService to use API endpoints for session lifecycle
- Update StorageService to use API instead of localStorage
- Update ArithmeticService methods to return Observables
- Update components to handle async operations

## Test plan
- [ ] Verify sessions are created via API
- [ ] Verify session state transitions work correctly
- [ ] Verify settings are saved/loaded via API
- [ ] Verify session history is fetched from backend
- [ ] Verify delete/clear operations work with API