### PR TITLE
Fix plant gallery sorting after watering/fertilizing

### DIFF
--- a/src/app/plants/components/plant-gallery/plant-gallery.component.ts
+++ b/src/app/plants/components/plant-gallery/plant-gallery.component.ts
@@ -60,7 +60,11 @@ export class PlantGalleryComponent implements OnInit {
             p.id === plant.id ? {
               ...p, lastWateredDate: lastWateredDate , nextWateredDate: nextWateredDate ?? null
             } : p
-          ).sort((a, b) => a.id - b.id);
+          ).sort((a, b) => {
+            let dateA = a.nextWateredDate ?? '';
+            let dateB = b.nextWateredDate ?? '';
+            return dateA.localeCompare(dateB);
+          });
         });
         const formattedDate: string | null = this.datePipe.transform(now, 'dd.MM.yyyy');
         this.snackBar.open(`Set last watered to: ${formattedDate}`, 'Dismiss', {duration: 5000});
@@ -84,7 +88,11 @@ export class PlantGalleryComponent implements OnInit {
             p.id === plant.id ? {
               ...p, lastFertilizedDate: lastFertilizedDate, nextFertilizedDate: nextFertilizedDate ?? null
             } : p
-          ).sort((a, b) => a.id - b.id);
+          ).sort((a, b) => {
+            let dateA = a.nextWateredDate ?? '';
+            let dateB = b.nextWateredDate ?? '';
+            return dateA.localeCompare(dateB);
+          });
         });
         const formattedDate: string | null = this.datePipe.transform(now, 'dd.MM.yyyy');
         this.snackBar.open(`Set last fertilized to: ${formattedDate}`, 'Dismiss', {duration: 5000});


### PR DESCRIPTION
Fixes the bug where the plant order is lost after clicking the watered or fertilized button. The sorting now maintains plants needing water first.