### PR TITLE
Remove Quick Exports section from exports files view

### DIFF
--- a/src/app/exports/exports-files.component.html
+++ b/src/app/exports/exports-files.component.html
@@ -11,24 +11,6 @@
     </div>
   </div>
 
-  <!-- Quick Actions Section -->
-  <div class="mt-5 exports-quick">
-    <h3>Quick Exports</h3>
-    <div class="quick-actions-container mt-3">
-      <button mat-raised-button color="primary" (click)="exportVocabulary()" [disabled]="isExporting">
-        <mat-icon>translate</mat-icon>
-        Export Vocabulary
-      </button>
-      <button mat-raised-button color="accent" (click)="exportCosts()" [disabled]="isExporting" class="ms-3">
-        <mat-icon>payments</mat-icon>
-        Export Costs
-      </button>
-      @if (isExporting) {
-        <mat-spinner diameter="24" class="ms-3 d-inline-block align-middle"></mat-spinner>
-      }
-    </div>
-  </div>
-
   <!-- Files Section -->
   <div class="mt-5 exports-files">
     <h3>Exported Files</h3>

--- a/src/app/exports/exports-files.component.ts
+++ b/src/app/exports/exports-files.component.ts
@@ -3,12 +3,9 @@ import { Component, OnInit } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
-import { ExportService } from './services/export.service';
 import { FileService } from './services/file/file.service';
 import { FileDeleteResponse, FileItem, FileItemTime, FileListResponse } from './services/file/file.model';
 
@@ -21,9 +18,7 @@ import { FileDeleteResponse, FileItem, FileItemTime, FileListResponse } from './
     MatTableModule,
     MatIconModule,
     MatButtonModule,
-    MatProgressSpinnerModule,
-    MatTooltipModule,
-    MatSnackBarModule
+    MatTooltipModule
   ],
   templateUrl: './exports-files.component.html',
   styleUrl: './exports-files.component.css'
@@ -32,14 +27,11 @@ export class ExportsFilesComponent implements OnInit {
   // Files table properties
   files: FileItem[] = [];
   isLoadingFiles = false;
-  isExporting = false;
   filesError: string | null = null;
   displayedColumns: string[] = ['name', 'size', 'modifiedTime', 'actions'];
 
   constructor(
-    private fileService: FileService,
-    private exportService: ExportService,
-    private snackBar: MatSnackBar
+    private fileService: FileService
   ) {}
 
   ngOnInit() {
@@ -63,30 +55,6 @@ export class ExportsFilesComponent implements OnInit {
         this.isLoadingFiles = false;
         this.filesError = 'Failed to load files: ' + error.message;
         console.error('Error loading files:', error);
-      }
-    });
-  }
-
-  exportVocabulary(): void {
-    this.triggerExport(this.exportService.exportVocabulary(), 'Vocabulary');
-  }
-
-  exportCosts(): void {
-    this.triggerExport(this.exportService.exportCosts(), 'Costs');
-  }
-
-  private triggerExport(obs: any, type: string): void {
-    this.isExporting = true;
-    obs.subscribe({
-      next: () => {
-        this.isExporting = false;
-        this.snackBar.open(`${type} export triggered successfully`, 'Close', { duration: 3000 });
-        this.loadFiles();
-      },
-      error: (error: any) => {
-        this.isExporting = false;
-        this.snackBar.open(`Failed to trigger ${type} export: ${error.message}`, 'Close', { duration: 5000 });
-        console.error(`Error exporting ${type}:`, error);
       }
     });
   }


### PR DESCRIPTION
## Summary
- Removed the Quick Exports section (Export Vocabulary / Export Costs buttons) from the exports files component
- Cleaned up related TypeScript code: removed `exportVocabulary`, `exportCosts`, and `triggerExport` methods
- Removed unused imports: `ExportService`, `MatProgressSpinnerModule`, `MatSnackBar`, `MatSnackBarModule`
- Removed `isExporting` property

## Test plan
- [ ] Verify the exports files page loads without errors
- [ ] Verify the file table still displays correctly
- [ ] Verify no TypeScript compilation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)