### PR TITLE
Style: make Anki Sync card match Files card

### DIFF
--- a/src/app/exports/exports.component.css
+++ b/src/app/exports/exports.component.css
@@ -103,17 +103,6 @@
   box-shadow: var(--ex-shadow), 0 0 0 3px var(--ex-focus);
 }
 
-.export-card.placeholder {
-  cursor: default;
-  opacity: 0.72;
-}
-
-.export-card.placeholder:hover {
-  transform: none;
-  box-shadow: var(--ex-shadow-soft);
-  border-color: var(--ex-border);
-}
-
 /* Material card header typography */
 .export-card mat-card-title {
   color: rgba(255, 255, 255, 0.92);
@@ -137,11 +126,6 @@
   height: 52px;
   color: var(--ex-accent);
   filter: drop-shadow(0 10px 18px rgba(124, 92, 255, 0.18));
-}
-
-.placeholder .card-icon mat-icon {
-  color: rgba(255, 255, 255, 0.42);
-  filter: none;
 }
 
 .export-card mat-card-actions {

--- a/src/app/exports/exports.component.html
+++ b/src/app/exports/exports.component.html
@@ -23,7 +23,7 @@
       </mat-card-actions>
     </mat-card>
 
-    <mat-card class="export-card placeholder">
+    <mat-card class="export-card">
       <mat-card-header>
         <mat-card-title>Anki Sync</mat-card-title>
         <mat-card-subtitle>Synchronization of Anki decks</mat-card-subtitle>


### PR DESCRIPTION
## Summary
- Removed `placeholder` CSS class from the Anki Sync card
- Deleted the now-unused `.export-card.placeholder` and `.placeholder .card-icon mat-icon` CSS rules
- Both cards now share the same hover animation, icon color (violet accent), opacity, and cursor style

## Test plan
- [ ] Navigate to `/exports` and verify the Anki Sync card looks identical to the Files card
- [ ] Hover over both cards and confirm the same lift/border/shadow transition
- [ ] Confirm the SYNC button still triggers the Anki sync action

🤖 Generated with [Claude Code](https://claude.com/claude-code)