### PR TITLE
Fix: navigate to Statistics & History page when viewing results

### DIFF
--- a/src/app/mental-arithmetic/components/arithmetic-session/arithmetic-session.component.ts
+++ b/src/app/mental-arithmetic/components/arithmetic-session/arithmetic-session.component.ts
@@ -488,7 +488,7 @@ export class ArithmeticSessionComponent implements OnInit, OnDestroy {
   }
 
   viewResults(): void {
-    this.router.navigate(['/mental-arithmetic/main']);
+    this.router.navigate(['/mental-arithmetic/arithmetic-list']);
   }
 
   goToMain(): void {


### PR DESCRIPTION
## Summary
- The "Ergebnisse ansehen" button after a completed mental arithmetic session was routing to `/mental-arithmetic/main` (the start page) instead of `/mental-arithmetic/arithmetic-list` (the Statistics & History page).

## Test plan
- [ ] Complete a mental arithmetic session
- [ ] Click "Ergebnisse ansehen"
- [ ] Verify it navigates to the Statistics & History page