### PR TITLE
Style: redesign home component with dark PWA theme

### DIFF
--- a/src/app/home/home.component.css
+++ b/src/app/home/home.component.css
@@ -25,8 +25,10 @@
   color: var(--text);
   background-color: var(--bg);
   background-image:
-    radial-gradient(ellipse 70% 35% at 0% 0%,   rgba(77,  166, 255, 0.05) 0%, transparent 100%),
-    radial-gradient(ellipse 50% 35% at 100% 100%, rgba(167, 139, 250, 0.04) 0%, transparent 100%);
+    radial-gradient(ellipse 70% 35% at 0% 0%,    rgba(77,  166, 255, 0.05) 0%, transparent 100%),
+    radial-gradient(ellipse 50% 35% at 100% 100%, rgba(167, 139, 250, 0.04) 0%, transparent 100%),
+    radial-gradient(circle, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+  background-size: auto, auto, 28px 28px;
 }
 
 /* ── Topbar ──────────────────────────────────────── */
@@ -38,10 +40,11 @@
   align-items: center;
   justify-content: space-between;
   padding: max(0.75rem, env(safe-area-inset-top)) max(1.25rem, env(safe-area-inset-right)) 0.75rem max(1.25rem, env(safe-area-inset-left));
-  background: rgba(6, 8, 14, 0.85);
+  background: rgba(6, 8, 14, 0.88);
   border-bottom: 1px solid var(--border);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  box-shadow: 0 1px 0 rgba(77, 166, 255, 0.06);
 }
 
 .topbar__brand {
@@ -54,7 +57,11 @@
   color: var(--text-muted);
 }
 
-.topbar__hex { color: var(--c-a); font-size: 0.9rem; }
+.topbar__hex {
+  color: var(--c-a);
+  font-size: 0.9rem;
+  filter: drop-shadow(0 0 6px rgba(77, 166, 255, 0.5));
+}
 
 .topbar__env {
   font-family: 'JetBrains Mono', monospace;
@@ -85,111 +92,9 @@
 
 @media (min-width: 1024px) {
   .layout {
-    flex-direction: row;
-    align-items: flex-start;
     gap: 1.5rem;
     padding: 1.5rem;
   }
-}
-
-/* ── Sysinfo Panel ───────────────────────────────── */
-.sysinfo {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  overflow: hidden;
-  animation: fadeUp 0.4s ease both;
-}
-
-@media (min-width: 1024px) {
-  .sysinfo {
-    flex: 0 0 240px;
-    position: sticky;
-    top: 53px;
-  }
-}
-
-.sysinfo__header {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.65rem 1rem;
-  border-bottom: 1px solid var(--border);
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.65rem;
-  font-weight: 700;
-  letter-spacing: 0.18em;
-  color: var(--text-dim);
-}
-
-.sysinfo__dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--c-p);
-  flex-shrink: 0;
-  animation: blink 2s ease-in-out infinite;
-}
-
-@keyframes blink {
-  0%, 100% { opacity: 1; }
-  50%       { opacity: 0.25; }
-}
-
-/* Mobile: compact 2-column tile grid */
-.sysinfo__grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  padding: 0.375rem;
-  gap: 0.25rem;
-}
-
-@media (min-width: 1024px) {
-  .sysinfo__grid {
-    grid-template-columns: 1fr;
-    padding: 0;
-    gap: 0;
-  }
-}
-
-.sysinfo__row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.45rem 0.75rem;
-  background: var(--raised);
-  border-radius: 6px;
-}
-
-@media (min-width: 1024px) {
-  .sysinfo__row {
-    background: transparent;
-    border-radius: 0;
-    border-bottom: 1px solid var(--border);
-    padding: 0.55rem 1rem;
-  }
-
-  .sysinfo__row:last-child { border-bottom: none; }
-}
-
-.sysinfo__key {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.65rem;
-  color: var(--text-dim);
-  flex-shrink: 0;
-}
-
-.sysinfo__val {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.65rem;
-  font-weight: 700;
-  color: var(--text);
-  text-align: right;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 /* ── Nav Section ─────────────────────────────────── */
@@ -201,12 +106,17 @@
 /* ── Nav Grid ────────────────────────────────────── */
 .navgrid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  grid-template-columns: repeat(2, 1fr);
   gap: 0.75rem;
 }
 
 @media (min-width: 640px) {
   .navgrid { gap: 1rem; }
+}
+
+/* Last odd card spans both columns */
+.navcard:last-child:nth-child(odd) {
+  grid-column: 1 / -1;
 }
 
 /* ── Nav Cards ───────────────────────────────────── */
@@ -240,6 +150,20 @@
   pointer-events: none;
 }
 
+/* Left accent stripe */
+.navcard::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 22%;
+  bottom: 22%;
+  width: 2px;
+  background: var(--cc, transparent);
+  border-radius: 0 2px 2px 0;
+  opacity: 0.35;
+  transition: opacity 0.2s, top 0.2s, bottom 0.2s;
+}
+
 .navcard:hover {
   border-color: var(--cc);
   box-shadow: 0 8px 28px var(--cc-glow);
@@ -247,6 +171,12 @@
 }
 
 .navcard:hover::before { opacity: 1; }
+
+.navcard:hover::after {
+  opacity: 0.9;
+  top: 12%;
+  bottom: 12%;
+}
 
 .navcard:active { transform: translateY(-1px); }
 
@@ -311,15 +241,112 @@
   transform: translate(2px, -2px);
 }
 
+/* ── Sysinfo Panel ───────────────────────────────── */
+.sysinfo {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  animation: fadeUp 0.55s ease both;
+  animation-delay: 0.35s;
+}
+
+.sysinfo__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1rem;
+  border-bottom: 1px solid var(--border);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: var(--text-dim);
+}
+
+.sysinfo__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--c-p);
+  flex-shrink: 0;
+  animation: blink 2s ease-in-out infinite;
+  box-shadow: 0 0 5px var(--c-p);
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.2; }
+}
+
+/* 2-col tile grid on mobile */
+.sysinfo__grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  padding: 0.375rem;
+  gap: 0.25rem;
+}
+
+/* 3-col on medium screens */
+@media (min-width: 640px) {
+  .sysinfo__grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+/* Full horizontal strip on wide screens */
+@media (min-width: 1024px) {
+  .sysinfo__grid {
+    grid-template-columns: repeat(6, 1fr);
+    padding: 0.5rem;
+    gap: 0.375rem;
+  }
+}
+
+.sysinfo__row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.45rem 0.75rem;
+  background: var(--raised);
+  border-radius: 6px;
+}
+
+@media (min-width: 1024px) {
+  .sysinfo__row {
+    align-items: center;
+    text-align: center;
+  }
+}
+
+.sysinfo__key {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.58rem;
+  color: var(--text-dim);
+  flex-shrink: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.sysinfo__val {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: var(--text);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ── Entrance Animations ─────────────────────────── */
 @keyframes fadeUp {
-  from { opacity: 0; transform: translateY(10px); }
+  from { opacity: 0; transform: translateY(12px); }
   to   { opacity: 1; transform: translateY(0); }
 }
 
-.sysinfo               { animation-delay: 0.05s; }
-.navcard:nth-child(1)  { animation-delay: 0.10s; }
-.navcard:nth-child(2)  { animation-delay: 0.15s; }
-.navcard:nth-child(3)  { animation-delay: 0.20s; }
-.navcard:nth-child(4)  { animation-delay: 0.25s; }
-.navcard:nth-child(5)  { animation-delay: 0.30s; }
+.navcard:nth-child(1)  { animation-delay: 0.05s; }
+.navcard:nth-child(2)  { animation-delay: 0.12s; }
+.navcard:nth-child(3)  { animation-delay: 0.19s; }
+.navcard:nth-child(4)  { animation-delay: 0.26s; }
+.navcard:nth-child(5)  { animation-delay: 0.33s; }

--- a/src/app/home/home.component.css
+++ b/src/app/home/home.component.css
@@ -1,135 +1,325 @@
-.home-container {
+@import url('https://fonts.googleapis.com/css2?family=Syne:wght@400;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+/* ── Design Tokens ───────────────────────────────── */
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  /* Per-card accent colors + glow variants */
+  --c-a:  #4da6ff;  --cg-a: rgba(77,  166, 255, 0.18);
+  --c-p:  #22d35e;  --cg-p: rgba(34,  211,  94, 0.18);
+  --c-v:  #fbbf24;  --cg-v: rgba(251, 191,  36, 0.18);
+  --c-m:  #a78bfa;  --cg-m: rgba(167, 139, 250, 0.18);
+  --c-e:  #fb7185;  --cg-e: rgba(251, 113, 133, 0.18);
+
+  display: block;
+  min-height: 100dvh;
+  font-family: 'Syne', sans-serif;
+  color: var(--text);
+  background-color: var(--bg);
+  background-image:
+    radial-gradient(ellipse 70% 35% at 0% 0%,   rgba(77,  166, 255, 0.05) 0%, transparent 100%),
+    radial-gradient(ellipse 50% 35% at 100% 100%, rgba(167, 139, 250, 0.04) 0%, transparent 100%);
+}
+
+/* ── Topbar ──────────────────────────────────────── */
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: max(0.75rem, env(safe-area-inset-top)) max(1.25rem, env(safe-area-inset-right)) 0.75rem max(1.25rem, env(safe-area-inset-left));
+  background: rgba(6, 8, 14, 0.85);
+  border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+}
+
+.topbar__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 800;
+  font-size: 0.8rem;
+  letter-spacing: 0.15em;
+  color: var(--text-muted);
+}
+
+.topbar__hex { color: var(--c-a); font-size: 0.9rem; }
+
+.topbar__env {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--text-dim);
+  background: var(--raised);
+  border: 1px solid var(--border);
+  padding: 0.2rem 0.55rem;
+  border-radius: 4px;
+}
+
+/* ── Layout ──────────────────────────────────────── */
+.layout {
   display: flex;
   flex-direction: column;
-  height: 100vh;
-}
-
-.metadata-section {
-  display: flex;
-  justify-content: center;
-  padding: 1rem 1rem 0.5rem;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  flex: 1 0 auto;
-}
-
-.metadata-card {
-  background: rgba(255, 255, 255, 0.95);
-  border-radius: 12px;
-  padding: 1rem 1.5rem;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  max-width: 800px;
+  gap: 1rem;
+  padding: 1rem
+    max(1rem, env(safe-area-inset-right))
+    max(1rem, env(safe-area-inset-bottom))
+    max(1rem, env(safe-area-inset-left));
+  max-width: 1280px;
+  margin: 0 auto;
   width: 100%;
+  box-sizing: border-box;
 }
 
-.metadata-card h3 {
-  margin: 0 0 0.75rem 0;
-  color: #333;
-  font-size: 1.25rem;
-  font-weight: 600;
-  text-align: center;
-  text-transform: uppercase;
-  letter-spacing: 1px;
+@media (min-width: 1024px) {
+  .layout {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 1.5rem;
+    padding: 1.5rem;
+  }
 }
 
-.metadata-grid {
+/* ── Sysinfo Panel ───────────────────────────────── */
+.sysinfo {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  animation: fadeUp 0.4s ease both;
+}
+
+@media (min-width: 1024px) {
+  .sysinfo {
+    flex: 0 0 240px;
+    position: sticky;
+    top: 53px;
+  }
+}
+
+.sysinfo__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1rem;
+  border-bottom: 1px solid var(--border);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: var(--text-dim);
+}
+
+.sysinfo__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--c-p);
+  flex-shrink: 0;
+  animation: blink 2s ease-in-out infinite;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.25; }
+}
+
+/* Mobile: compact 2-column tile grid */
+.sysinfo__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0.75rem;
+  grid-template-columns: 1fr 1fr;
+  padding: 0.375rem;
+  gap: 0.25rem;
 }
 
-.metadata-item {
+@media (min-width: 1024px) {
+  .sysinfo__grid {
+    grid-template-columns: 1fr;
+    padding: 0;
+    gap: 0;
+  }
+}
+
+.sysinfo__row {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.5rem 0.75rem;
-  background: rgba(255, 255, 255, 0.8);
+  gap: 0.5rem;
+  padding: 0.45rem 0.75rem;
+  background: var(--raised);
   border-radius: 6px;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.metadata-item:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+@media (min-width: 1024px) {
+  .sysinfo__row {
+    background: transparent;
+    border-radius: 0;
+    border-bottom: 1px solid var(--border);
+    padding: 0.55rem 1rem;
+  }
+
+  .sysinfo__row:last-child { border-bottom: none; }
 }
 
-.metadata-label {
-  font-weight: 600;
-  color: #555;
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 1px;
+.sysinfo__key {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  color: var(--text-dim);
+  flex-shrink: 0;
 }
 
-.metadata-value {
-  font-weight: 500;
-  color: #2563eb;
-  font-family: 'Courier New', monospace;
-  font-size: 0.85rem;
-  background: rgba(37, 99, 235, 0.1);
-  padding: 0.2rem 0.4rem;
-  border-radius: 3px;
+.sysinfo__val {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: var(--text);
+  text-align: right;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.card-container {
-  display: flex;
-  flex: 1 0 auto;
-  padding: 25px;
-  overflow-x: auto;
-  gap: 10px;
+/* ── Nav Section ─────────────────────────────────── */
+.navsection {
+  flex: 1 1 0;
+  min-width: 0;
 }
 
-.card {
-  flex: 0 0 100%;
-  border: 1px solid #ccc;
-  border-radius: 10px;
-  text-align: center;
+/* ── Nav Grid ────────────────────────────────────── */
+.navgrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .navgrid { gap: 1rem; }
+}
+
+/* ── Nav Cards ───────────────────────────────────── */
+.navcard {
+  position: relative;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.1rem 1rem 1.75rem;
   cursor: pointer;
-  transition: box-shadow 0.3s ease, transform 0.3s ease;
-  background: white;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  min-height: 140px;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
+  animation: fadeUp 0.5s ease both;
+  -webkit-tap-highlight-color: transparent;
 }
 
-.card:hover {
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.15);
+/* Radial glow overlay on hover */
+.navcard::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 0% 0%, var(--cc-glow, transparent) 0%, transparent 65%);
+  opacity: 0;
+  transition: opacity 0.25s;
+  pointer-events: none;
+}
+
+.navcard:hover {
+  border-color: var(--cc);
+  box-shadow: 0 8px 28px var(--cc-glow);
   transform: translateY(-3px);
 }
 
-.card h2 {
-  margin: 0 0 0.5rem 0;
-  color: #333;
+.navcard:hover::before { opacity: 1; }
+
+.navcard:active { transform: translateY(-1px); }
+
+/* ── Card Accent Variants ────────────────────────── */
+.navcard--a { --cc: var(--c-a); --cc-glow: var(--cg-a); }
+.navcard--p { --cc: var(--c-p); --cc-glow: var(--cg-p); }
+.navcard--v { --cc: var(--c-v); --cc-glow: var(--cg-v); }
+.navcard--m { --cc: var(--c-m); --cc-glow: var(--cg-m); }
+.navcard--e { --cc: var(--c-e); --cc-glow: var(--cg-e); }
+
+/* ── Card Mark ───────────────────────────────────── */
+.navcard__mark {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--cc) 40%, transparent);
+  background: color-mix(in srgb, var(--cc) 10%, transparent);
+  display: grid;
+  place-items: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--cc);
+  flex-shrink: 0;
+  transition: background 0.2s;
 }
 
-.card p {
+.navcard:hover .navcard__mark {
+  background: color-mix(in srgb, var(--cc) 20%, transparent);
+}
+
+/* ── Card Text ───────────────────────────────────── */
+.navcard__title {
   margin: 0;
-  color: #666;
+  font-size: clamp(0.85rem, 2vw, 1rem);
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.2;
 }
 
-@media (min-width: 821px) {
-
-  .card-container {
-    flex: 0 1 auto;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-direction: column;
-    flex-wrap: wrap;
-    gap: 1.5rem;
-    padding: 1rem;
-    min-height: 0;
-  }
-
-  .card {
-    flex: 0 1 auto;
-    padding: 1.5rem;
-    border: 1px solid #ccc;
-    border-radius: 10px;
-    width: 350px;
-    text-align: center;
-    cursor: pointer;
-    transition: box-shadow 0.3s ease, transform 0.3s ease;
-    background: white;
-  }
-
+.navcard__sub {
+  margin: 0;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+  font-weight: 400;
 }
+
+/* ── Card Arrow ──────────────────────────────────── */
+.navcard__arrow {
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.875rem;
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  line-height: 1;
+  transition: color 0.2s, transform 0.2s;
+}
+
+.navcard:hover .navcard__arrow {
+  color: var(--cc);
+  transform: translate(2px, -2px);
+}
+
+/* ── Entrance Animations ─────────────────────────── */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.sysinfo               { animation-delay: 0.05s; }
+.navcard:nth-child(1)  { animation-delay: 0.10s; }
+.navcard:nth-child(2)  { animation-delay: 0.15s; }
+.navcard:nth-child(3)  { animation-delay: 0.20s; }
+.navcard:nth-child(4)  { animation-delay: 0.25s; }
+.navcard:nth-child(5)  { animation-delay: 0.30s; }

--- a/src/app/home/home.component.css
+++ b/src/app/home/home.component.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Syne:wght@400;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
 
 /* ── Design Tokens ───────────────────────────────── */
 :host {
@@ -21,7 +21,7 @@
 
   display: block;
   min-height: 100dvh;
-  font-family: 'Syne', sans-serif;
+  font-family: 'Outfit', sans-serif;
   color: var(--text);
   background-color: var(--bg);
   background-image:
@@ -51,9 +51,9 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  font-weight: 800;
-  font-size: 0.8rem;
-  letter-spacing: 0.15em;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
   color: var(--text-muted);
 }
 
@@ -114,9 +114,17 @@
   .navgrid { gap: 1rem; }
 }
 
-/* Last odd card spans both columns */
+/* Last odd card: centered at single-column width, not stretched */
 .navcard:last-child:nth-child(odd) {
   grid-column: 1 / -1;
+  justify-self: center;
+  width: calc(50% - 0.375rem);
+}
+
+@media (min-width: 640px) {
+  .navcard:last-child:nth-child(odd) {
+    width: calc(50% - 0.5rem);
+  }
 }
 
 /* ── Nav Cards ───────────────────────────────────── */
@@ -211,10 +219,11 @@
 /* ── Card Text ───────────────────────────────────── */
 .navcard__title {
   margin: 0;
-  font-size: clamp(0.85rem, 2vw, 1rem);
-  font-weight: 700;
+  font-size: clamp(0.95rem, 2.5vw, 1.1rem);
+  font-weight: 600;
   color: var(--text);
-  line-height: 1.2;
+  line-height: 1.25;
+  letter-spacing: 0.01em;
 }
 
 .navcard__sub {

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -12,6 +12,40 @@
   <!-- ── Main Layout ────────────────────────────────── -->
   <div class="layout">
 
+    <!-- System Info Panel -->
+    <aside class="sysinfo">
+      <div class="sysinfo__header">
+        <span class="sysinfo__dot"></span>
+        <span>SYSTEM</span>
+      </div>
+      <div class="sysinfo__grid">
+        <div class="sysinfo__row">
+          <span class="sysinfo__key">node</span>
+          <span class="sysinfo__val">{{ metadata.nodeVersion }}</span>
+        </div>
+        <div class="sysinfo__row">
+          <span class="sysinfo__key">npm</span>
+          <span class="sysinfo__val">{{ metadata.npmVersion }}</span>
+        </div>
+        <div class="sysinfo__row">
+          <span class="sysinfo__key">angular</span>
+          <span class="sysinfo__val">{{ metadata.angularVersion }}</span>
+        </div>
+        <div class="sysinfo__row">
+          <span class="sysinfo__key">version</span>
+          <span class="sysinfo__val">{{ metadata.projectVersion }}</span>
+        </div>
+        <div class="sysinfo__row">
+          <span class="sysinfo__key">env</span>
+          <span class="sysinfo__val">{{ metadata.environment }}</span>
+        </div>
+        <div class="sysinfo__row">
+          <span class="sysinfo__key">built</span>
+          <span class="sysinfo__val">{{ metadata.buildTime | date:'dd.MM.yy HH:mm' }}</span>
+        </div>
+      </div>
+    </aside>
+
     <!-- Navigation Cards -->
     <main class="navsection">
       <div class="navgrid">
@@ -53,40 +87,6 @@
 
       </div>
     </main>
-
-    <!-- System Info Panel -->
-    <aside class="sysinfo">
-      <div class="sysinfo__header">
-        <span class="sysinfo__dot"></span>
-        <span>SYSTEM</span>
-      </div>
-      <div class="sysinfo__grid">
-        <div class="sysinfo__row">
-          <span class="sysinfo__key">node</span>
-          <span class="sysinfo__val">{{ metadata.nodeVersion }}</span>
-        </div>
-        <div class="sysinfo__row">
-          <span class="sysinfo__key">npm</span>
-          <span class="sysinfo__val">{{ metadata.npmVersion }}</span>
-        </div>
-        <div class="sysinfo__row">
-          <span class="sysinfo__key">angular</span>
-          <span class="sysinfo__val">{{ metadata.angularVersion }}</span>
-        </div>
-        <div class="sysinfo__row">
-          <span class="sysinfo__key">version</span>
-          <span class="sysinfo__val">{{ metadata.projectVersion }}</span>
-        </div>
-        <div class="sysinfo__row">
-          <span class="sysinfo__key">env</span>
-          <span class="sysinfo__val">{{ metadata.environment }}</span>
-        </div>
-        <div class="sysinfo__row">
-          <span class="sysinfo__key">built</span>
-          <span class="sysinfo__val">{{ metadata.buildTime | date:'dd.MM.yy HH:mm' }}</span>
-        </div>
-      </div>
-    </aside>
 
   </div>
 </div>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,56 +1,92 @@
-<div class="home-container">
-  <div class="metadata-section">
-    <div class="metadata-card">
-      <h3>System Information</h3>
-      <div class="metadata-grid">
-        <div class="metadata-item">
-          <span class="metadata-label">Node.js:</span>
-          <span class="metadata-value">{{ metadata.nodeVersion }}</span>
+<div class="home">
+
+  <!-- ── Topbar ──────────────────────────────────────── -->
+  <header class="topbar">
+    <div class="topbar__brand">
+      <span class="topbar__hex">⬡</span>
+      <span class="topbar__name">DASHBOARD</span>
+    </div>
+    <div class="topbar__env">{{ metadata.environment | uppercase }}</div>
+  </header>
+
+  <!-- ── Main Layout ────────────────────────────────── -->
+  <div class="layout">
+
+    <!-- System Info Panel -->
+    <aside class="sysinfo">
+      <div class="sysinfo__header">
+        <span class="sysinfo__dot"></span>
+        <span>SYSTEM</span>
+      </div>
+      <div class="sysinfo__grid">
+        <div class="sysinfo__row">
+          <span class="sysinfo__key">node</span>
+          <span class="sysinfo__val">{{ metadata.nodeVersion }}</span>
         </div>
-        <div class="metadata-item">
-          <span class="metadata-label">npm:</span>
-          <span class="metadata-value">{{ metadata.npmVersion }}</span>
+        <div class="sysinfo__row">
+          <span class="sysinfo__key">npm</span>
+          <span class="sysinfo__val">{{ metadata.npmVersion }}</span>
         </div>
-        <div class="metadata-item">
-          <span class="metadata-label">Angular:</span>
-          <span class="metadata-value">{{ metadata.angularVersion }}</span>
+        <div class="sysinfo__row">
+          <span class="sysinfo__key">angular</span>
+          <span class="sysinfo__val">{{ metadata.angularVersion }}</span>
         </div>
-        <div class="metadata-item">
-          <span class="metadata-label">Version:</span>
-          <span class="metadata-value">{{ metadata.projectVersion }}</span>
+        <div class="sysinfo__row">
+          <span class="sysinfo__key">version</span>
+          <span class="sysinfo__val">{{ metadata.projectVersion }}</span>
         </div>
-        <div class="metadata-item">
-          <span class="metadata-label">Environment:</span>
-          <span class="metadata-value">{{ metadata.environment }}</span>
+        <div class="sysinfo__row">
+          <span class="sysinfo__key">env</span>
+          <span class="sysinfo__val">{{ metadata.environment }}</span>
         </div>
-        <div class="metadata-item">
-          <span class="metadata-label">Built:</span>
-          <span class="metadata-value">{{ metadata.buildTime | date:'dd.MM.yyyy HH:mm:ss' }}</span>
+        <div class="sysinfo__row">
+          <span class="sysinfo__key">built</span>
+          <span class="sysinfo__val">{{ metadata.buildTime | date:'dd.MM.yy HH:mm' }}</span>
         </div>
       </div>
-    </div>
-  </div>
+    </aside>
 
-  <div class="card-container">
-    <div class="card" routerLink="/account">
-      <h2>Account</h2>
-      <p>Account analysis</p>
-    </div>
-    <div class="card" routerLink="/plant-root">
-      <h2>Plants</h2>
-      <p>Manage plants</p>
-    </div>
-    <div class="card" routerLink="/vocabulary">
-      <h2>Vocabulary</h2>
-      <p>Manage Vocabulary</p>
-    </div>
-    <div class="card" routerLink="/mental-arithmetic">
-      <h2>Mental Arithmetic</h2>
-      <p>Practice mental math</p>
-    </div>
-    <div class="card" routerLink="/exports">
-      <h2>Exports</h2>
-      <p>Manage and view exports</p>
-    </div>
+    <!-- Navigation Cards -->
+    <main class="navsection">
+      <div class="navgrid">
+
+        <a class="navcard navcard--a" routerLink="/account">
+          <div class="navcard__mark">A</div>
+          <h2 class="navcard__title">Account</h2>
+          <p class="navcard__sub">Account analysis</p>
+          <span class="navcard__arrow" aria-hidden="true">↗</span>
+        </a>
+
+        <a class="navcard navcard--p" routerLink="/plant-root">
+          <div class="navcard__mark">P</div>
+          <h2 class="navcard__title">Plants</h2>
+          <p class="navcard__sub">Manage plants</p>
+          <span class="navcard__arrow" aria-hidden="true">↗</span>
+        </a>
+
+        <a class="navcard navcard--v" routerLink="/vocabulary">
+          <div class="navcard__mark">V</div>
+          <h2 class="navcard__title">Vocabulary</h2>
+          <p class="navcard__sub">Manage vocabulary</p>
+          <span class="navcard__arrow" aria-hidden="true">↗</span>
+        </a>
+
+        <a class="navcard navcard--m" routerLink="/mental-arithmetic">
+          <div class="navcard__mark">∑</div>
+          <h2 class="navcard__title">Mental Arithmetic</h2>
+          <p class="navcard__sub">Practice mental math</p>
+          <span class="navcard__arrow" aria-hidden="true">↗</span>
+        </a>
+
+        <a class="navcard navcard--e" routerLink="/exports">
+          <div class="navcard__mark">E</div>
+          <h2 class="navcard__title">Exports</h2>
+          <p class="navcard__sub">Manage and view exports</p>
+          <span class="navcard__arrow" aria-hidden="true">↗</span>
+        </a>
+
+      </div>
+    </main>
+
   </div>
 </div>

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -12,40 +12,6 @@
   <!-- ── Main Layout ────────────────────────────────── -->
   <div class="layout">
 
-    <!-- System Info Panel -->
-    <aside class="sysinfo">
-      <div class="sysinfo__header">
-        <span class="sysinfo__dot"></span>
-        <span>SYSTEM</span>
-      </div>
-      <div class="sysinfo__grid">
-        <div class="sysinfo__row">
-          <span class="sysinfo__key">node</span>
-          <span class="sysinfo__val">{{ metadata.nodeVersion }}</span>
-        </div>
-        <div class="sysinfo__row">
-          <span class="sysinfo__key">npm</span>
-          <span class="sysinfo__val">{{ metadata.npmVersion }}</span>
-        </div>
-        <div class="sysinfo__row">
-          <span class="sysinfo__key">angular</span>
-          <span class="sysinfo__val">{{ metadata.angularVersion }}</span>
-        </div>
-        <div class="sysinfo__row">
-          <span class="sysinfo__key">version</span>
-          <span class="sysinfo__val">{{ metadata.projectVersion }}</span>
-        </div>
-        <div class="sysinfo__row">
-          <span class="sysinfo__key">env</span>
-          <span class="sysinfo__val">{{ metadata.environment }}</span>
-        </div>
-        <div class="sysinfo__row">
-          <span class="sysinfo__key">built</span>
-          <span class="sysinfo__val">{{ metadata.buildTime | date:'dd.MM.yy HH:mm' }}</span>
-        </div>
-      </div>
-    </aside>
-
     <!-- Navigation Cards -->
     <main class="navsection">
       <div class="navgrid">
@@ -87,6 +53,40 @@
 
       </div>
     </main>
+
+    <!-- System Info Panel -->
+    <aside class="sysinfo">
+      <div class="sysinfo__header">
+        <span class="sysinfo__dot"></span>
+        <span>SYSTEM</span>
+      </div>
+      <div class="sysinfo__grid">
+        <div class="sysinfo__row">
+          <span class="sysinfo__key">node</span>
+          <span class="sysinfo__val">{{ metadata.nodeVersion }}</span>
+        </div>
+        <div class="sysinfo__row">
+          <span class="sysinfo__key">npm</span>
+          <span class="sysinfo__val">{{ metadata.npmVersion }}</span>
+        </div>
+        <div class="sysinfo__row">
+          <span class="sysinfo__key">angular</span>
+          <span class="sysinfo__val">{{ metadata.angularVersion }}</span>
+        </div>
+        <div class="sysinfo__row">
+          <span class="sysinfo__key">version</span>
+          <span class="sysinfo__val">{{ metadata.projectVersion }}</span>
+        </div>
+        <div class="sysinfo__row">
+          <span class="sysinfo__key">env</span>
+          <span class="sysinfo__val">{{ metadata.environment }}</span>
+        </div>
+        <div class="sysinfo__row">
+          <span class="sysinfo__key">built</span>
+          <span class="sysinfo__val">{{ metadata.buildTime | date:'dd.MM.yy HH:mm' }}</span>
+        </div>
+      </div>
+    </aside>
 
   </div>
 </div>


### PR DESCRIPTION
## Changes

- Redesigned home component with dark PWA theme
- Fix: navigate to Statistics & History page when viewing results
- Restructure home layout: system info panel on top, navigation cards below
- Nav grid fixed to 2 columns; lone last card is centered at single-column width (not stretched)
- System info panel transforms into a horizontal 6-column strip on desktop
- Swap display font from Syne to Outfit for a taller, less squat appearance
- Visual polish: dot-grid background texture, left accent stripe on cards, hex icon glow