### PR TITLE
Style: dark PWA theme for bookings and table components

### DIFF
--- a/src/app/backend/backend.component.css
+++ b/src/app/backend/backend.component.css
@@ -62,23 +62,23 @@
   gap: 0.5rem;
 }
 
-.topbar__home {
-  display: flex;
-  align-items: center;
-  text-decoration: none;
-  color: inherit;
-  -webkit-tap-highlight-color: transparent;
+.topbar__home-btn.mat-mdc-icon-button {
+  color: var(--text-muted) !important;
+  width: 36px !important;
+  height: 36px !important;
+  line-height: 36px !important;
+  transition: color 0.2s !important;
+}
+
+.topbar__home-btn.mat-mdc-icon-button:hover {
+  color: var(--c-a) !important;
+  background: rgba(77, 166, 255, 0.08) !important;
 }
 
 .topbar__hex {
   color: var(--c-a);
   font-size: 0.9rem;
   filter: drop-shadow(0 0 6px rgba(77, 166, 255, 0.5));
-  transition: filter 0.2s;
-}
-
-.topbar__home:hover .topbar__hex {
-  filter: drop-shadow(0 0 10px rgba(77, 166, 255, 0.8));
 }
 
 .topbar__name {

--- a/src/app/backend/backend.component.css
+++ b/src/app/backend/backend.component.css
@@ -1,9 +1,177 @@
-/* Minimal custom CSS - Bootstrap handles most styling */
-.header-section {
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+/* ── Design Tokens ───────────────────────────────── */
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-a:  #4da6ff;  --cg-a: rgba(77,  166, 255, 0.18);
+  --c-p:  #22d35e;  --cg-p: rgba(34,  211,  94, 0.18);
+  --c-e:  #fb7185;  --cg-e: rgba(251, 113, 133, 0.18);
+
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+  background-color: var(--bg);
+  background-image:
+    radial-gradient(ellipse 70% 35% at 0% 0%,    rgba(77,  166, 255, 0.05) 0%, transparent 100%),
+    radial-gradient(ellipse 50% 35% at 100% 100%, rgba(167, 139, 250, 0.04) 0%, transparent 100%),
+    radial-gradient(circle, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+  background-size: auto, auto, 28px 28px;
+}
+
+/* ── Shell ───────────────────────────────────────── */
+.backend {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* ── Topbar ──────────────────────────────────────── */
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: max(0.75rem, env(safe-area-inset-top)) max(1.25rem, env(safe-area-inset-right)) 0.75rem max(1.25rem, env(safe-area-inset-left));
+  background: rgba(6, 8, 14, 0.88);
+  border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  box-shadow: 0 1px 0 rgba(77, 166, 255, 0.06);
   flex-shrink: 0;
 }
 
-.content-section {
-  flex: 1;
+.topbar__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.topbar__home {
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+  color: inherit;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.topbar__hex {
+  color: var(--c-a);
+  font-size: 0.9rem;
+  filter: drop-shadow(0 0 6px rgba(77, 166, 255, 0.5));
+  transition: filter 0.2s;
+}
+
+.topbar__home:hover .topbar__hex {
+  filter: drop-shadow(0 0 10px rgba(77, 166, 255, 0.8));
+}
+
+.topbar__name {
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  color: var(--text-muted);
+}
+
+/* ── Topbar Actions ──────────────────────────────── */
+.topbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+/* ── File Input ──────────────────────────────────── */
+.file-input {
+  position: relative;
+  cursor: pointer;
+}
+
+.file-input__native {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+  width: 100%;
+}
+
+.file-input__label {
+  display: inline-flex;
+  align-items: center;
+  height: 28px;
+  padding: 0 0.75rem;
+  background: var(--raised);
+  border: 1px solid var(--border-mid);
+  border-radius: 6px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  white-space: nowrap;
+  transition: border-color 0.2s, color 0.2s;
+  pointer-events: none;
+}
+
+.file-input:hover .file-input__label {
+  border-color: rgba(77, 166, 255, 0.4);
+  color: var(--c-a);
+}
+
+/* ── Action Buttons ──────────────────────────────── */
+.action-btn.mat-mdc-mini-fab {
+  box-shadow: none !important;
+  width: 28px !important;
+  height: 28px !important;
+  border: 1px solid var(--border-mid) !important;
+}
+
+.action-btn .mat-icon {
+  font-size: 16px !important;
+  width: 16px !important;
+  height: 16px !important;
+  line-height: 16px !important;
+}
+
+.action-btn--upload.mat-mdc-mini-fab {
+  background: rgba(77, 166, 255, 0.1) !important;
+  color: var(--c-a) !important;
+  border-color: rgba(77, 166, 255, 0.3) !important;
+}
+
+.action-btn--upload.mat-mdc-mini-fab:hover {
+  background: rgba(77, 166, 255, 0.2) !important;
+}
+
+.action-btn--backup.mat-mdc-mini-fab {
+  background: var(--raised) !important;
+  color: var(--text-muted) !important;
+}
+
+.action-btn--backup.mat-mdc-mini-fab:hover {
+  background: var(--surface) !important;
+  color: var(--text) !important;
+  border-color: var(--border-mid) !important;
+}
+
+/* ── Content Area ────────────────────────────────── */
+.backend__content {
+  flex: 1 1 auto;
   overflow: hidden;
+  min-height: 0;
 }

--- a/src/app/backend/backend.component.css
+++ b/src/app/backend/backend.component.css
@@ -113,7 +113,9 @@
 .file-input__label {
   display: inline-flex;
   align-items: center;
+  gap: 0.35rem;
   height: 28px;
+  max-width: 240px;
   padding: 0 0.75rem;
   background: var(--raised);
   border: 1px solid var(--border-mid);
@@ -123,9 +125,19 @@
   font-weight: 500;
   letter-spacing: 0.06em;
   color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
   transition: border-color 0.2s, color 0.2s;
   pointer-events: none;
+}
+
+.file-input__icon {
+  font-size: 14px !important;
+  width: 14px !important;
+  height: 14px !important;
+  line-height: 14px !important;
+  flex-shrink: 0;
 }
 
 .file-input:hover .file-input__label {

--- a/src/app/backend/backend.component.html
+++ b/src/app/backend/backend.component.html
@@ -12,7 +12,10 @@
     <div class="topbar__actions">
       <label class="file-input">
         <input type="file" class="file-input__native" (change)="onFileSelected($event)" />
-        <span class="file-input__label">Datei wählen</span>
+        <span class="file-input__label">
+          <mat-icon class="file-input__icon">attach_file</mat-icon>
+          {{ uploadedFile ? uploadedFile.name : 'Datei wählen' }}
+        </span>
       </label>
       <button mat-mini-fab (click)="uploadFile()" matTooltip="Upload" class="action-btn action-btn--upload">
         <mat-icon>upload</mat-icon>

--- a/src/app/backend/backend.component.html
+++ b/src/app/backend/backend.component.html
@@ -1,28 +1,30 @@
-<div class="container-fluid h-100 d-flex flex-column bg-dark text-light">
+<div class="backend">
 
-  <div class="header-section" style="flex: 0 0 auto; padding: 1rem; border-bottom: 1px solid var(--bs-secondary);">
-    <div class="d-flex justify-content-center mb-3">
-      <button mat-fab routerLink="/" class="position-absolute start-0 ms-2 z-3">
-        <mat-icon>home</mat-icon>
+  <!-- ── Topbar ──────────────────────────────────────── -->
+  <header class="topbar">
+    <div class="topbar__brand">
+      <a class="topbar__home" routerLink="/" matTooltip="Home">
+        <span class="topbar__hex">⬡</span>
+      </a>
+      <span class="topbar__name">KONTOAUSZÜGE</span>
+    </div>
+    <div class="topbar__actions">
+      <label class="file-input">
+        <input type="file" class="file-input__native" (change)="onFileSelected($event)" />
+        <span class="file-input__label">Datei wählen</span>
+      </label>
+      <button mat-mini-fab (click)="uploadFile()" matTooltip="Upload" class="action-btn action-btn--upload">
+        <mat-icon>upload</mat-icon>
       </button>
-      <h1 class="text-light m-0">Auswertung der Kontoauszüge</h1>
+      <button mat-mini-fab (click)="backupCostData()" matTooltip="Backup" class="action-btn action-btn--backup">
+        <mat-icon>backup</mat-icon>
+      </button>
     </div>
-    <div class="d-flex justify-content-between align-items-center">
-      <div class="d-flex gap-2 align-items-center">
-        <input type="file" class="form-control bg-secondary text-light border-secondary" (change)="onFileSelected($event)" style="width: auto;"/>
-        <button mat-mini-fab (click)="uploadFile()" matTooltip="Upload File">
-          <mat-icon>upload</mat-icon>
-        </button>
-      </div>
-      <div>
-        <button mat-mini-fab (click)="backupCostData()" matTooltip="Backup Cost Data">
-          <mat-icon>backup</mat-icon>
-        </button>
-      </div>
-    </div>
-  </div>
+  </header>
 
-  <div class="content-section" style="flex: 1 1 auto; overflow: hidden;">
+  <!-- ── Content ─────────────────────────────────────── -->
+  <div class="backend__content">
     <app-bookings [bookings]="responseData"></app-bookings>
   </div>
+
 </div>

--- a/src/app/backend/backend.component.html
+++ b/src/app/backend/backend.component.html
@@ -3,9 +3,10 @@
   <!-- ── Topbar ──────────────────────────────────────── -->
   <header class="topbar">
     <div class="topbar__brand">
-      <a class="topbar__home" routerLink="/" matTooltip="Home">
-        <span class="topbar__hex">⬡</span>
-      </a>
+      <button mat-icon-button routerLink="/" matTooltip="Home" class="topbar__home-btn">
+        <mat-icon>home</mat-icon>
+      </button>
+      <span class="topbar__hex">⬡</span>
       <span class="topbar__name">KONTOAUSZÜGE</span>
     </div>
     <div class="topbar__actions">

--- a/src/app/backend/backend.component.ts
+++ b/src/app/backend/backend.component.ts
@@ -67,5 +67,6 @@ export class BackendComponent {
   onFileSelected(event: Event): void {
     const target = event.target as HTMLInputElement;
     this.uploadedFile = target.files?.[0];
+    this.cdr.markForCheck();
   }
 }

--- a/src/app/backend/bookings/bookings.component.css
+++ b/src/app/backend/bookings/bookings.component.css
@@ -1,9 +1,216 @@
-/* Minimal custom CSS - Bootstrap handles most styling */
-.booking-header {
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+/* ── Design Tokens ───────────────────────────────── */
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-a:  #4da6ff;  --cg-a: rgba(77,  166, 255, 0.18);
+  --c-p:  #22d35e;  --cg-p: rgba(34,  211,  94, 0.18);
+  --c-v:  #fbbf24;  --cg-v: rgba(251, 191,  36, 0.18);
+  --c-m:  #a78bfa;  --cg-m: rgba(167, 139, 250, 0.18);
+  --c-e:  #fb7185;  --cg-e: rgba(251, 113, 133, 0.18);
+
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+  background-color: var(--bg);
+  background-image:
+    radial-gradient(ellipse 70% 35% at 0% 0%,    rgba(77,  166, 255, 0.05) 0%, transparent 100%),
+    radial-gradient(ellipse 50% 35% at 100% 100%, rgba(167, 139, 250, 0.04) 0%, transparent 100%),
+    radial-gradient(circle, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+  background-size: auto, auto, 28px 28px;
+}
+
+/* ── Scroll Container ────────────────────────────── */
+.bookings {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.bookings__scroll {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+  overflow-y: auto;
+  height: 100%;
+  box-sizing: border-box;
+}
+
+@media (min-width: 1024px) {
+  .bookings__scroll {
+    padding: 1.5rem;
+    gap: 1.5rem;
+  }
+}
+
+/* ── Booking Panel ───────────────────────────────── */
+.booking-panel {
+  display: flex;
+  flex-direction: column;
+  flex: 0 0 calc(100% - 2rem);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  animation: fadeUp 0.45s ease both;
+}
+
+.booking-panel:nth-child(1) { animation-delay: 0.05s; }
+.booking-panel:nth-child(2) { animation-delay: 0.12s; }
+.booking-panel:nth-child(3) { animation-delay: 0.19s; }
+.booking-panel:nth-child(4) { animation-delay: 0.26s; }
+.booking-panel:nth-child(5) { animation-delay: 0.33s; }
+.booking-panel:nth-child(n+6) { animation-delay: 0.4s; }
+
+/* ── Panel Header ────────────────────────────────── */
+.panel__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--raised);
   flex-shrink: 0;
 }
 
-.booking-content {
-  flex: 1;
+.panel__title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.panel__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--c-p);
+  flex-shrink: 0;
+  animation: blink 2s ease-in-out infinite;
+  box-shadow: 0 0 5px var(--c-p);
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.2; }
+}
+
+.panel__month {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--text);
+}
+
+/* ── Stats Row ───────────────────────────────────── */
+.panel__stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding: 0.3rem 0.65rem;
+  border-radius: 6px;
+  border: 1px solid var(--border-mid);
+  background: var(--surface);
+}
+
+.stat__key {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.55rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.stat__val {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
+.stat--neutral .stat__val { color: var(--text-muted); }
+
+.stat--income {
+  border-color: rgba(34, 211, 94, 0.25);
+  background: rgba(34, 211, 94, 0.05);
+}
+.stat--income .stat__val { color: var(--c-p); }
+
+.stat--positive {
+  border-color: rgba(77, 166, 255, 0.25);
+  background: rgba(77, 166, 255, 0.05);
+}
+.stat--positive .stat__val { color: var(--c-a); }
+
+.stat--negative {
+  border-color: rgba(251, 113, 133, 0.25);
+  background: rgba(251, 113, 133, 0.05);
+}
+.stat--negative .stat__val { color: var(--c-e); }
+
+/* ── Panel Body ──────────────────────────────────── */
+.panel__body {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+  flex: 1 1 auto;
   overflow: hidden;
+}
+
+@media (min-width: 768px) {
+  .panel__body {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.panel__col {
+  overflow: hidden;
+  min-height: 0;
+  border-right: 1px solid var(--border);
+}
+
+.panel__col:last-child {
+  border-right: none;
+}
+
+.panel__col--split {
+  display: flex;
+  flex-direction: column;
+}
+
+.panel__col--split > * {
+  flex: 1 1 50%;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.panel__col--split > *:first-child {
+  border-bottom: 1px solid var(--border);
+}
+
+/* ── Entrance Animation ──────────────────────────── */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
 }

--- a/src/app/backend/bookings/bookings.component.html
+++ b/src/app/backend/bookings/bookings.component.html
@@ -1,41 +1,44 @@
-<div class="h-100 d-flex flex-column justify-content-center align-items-center bg-dark text-light">
-  <div class="h-100 w-100 d-flex flex-column overflow-auto gap-3">
+<div class="bookings">
+  <div class="bookings__scroll">
 
     @for (booking of bookings?.bookingsPerMonth; track $index) {
-      <div class="d-flex flex-column justify-content-between overflow-auto border border-secondary"
-           style="flex: 0 0 100%">
-        <div class="row m-0 booking-header" style="flex: 0 0 auto; padding: 0.25rem;">
-          <div class="d-flex flex-column align-items-center">
-            <h3 class="text-light fs-5 mb-2">{{ booking.year }}-{{ booking.month }}</h3>
-            <div class="d-flex gap-2">
-              <span class="badge bg-secondary">Gesamtausgaben: {{ getTotalAmount(booking) | number: '.2' : 'de' }}</span>
-              <span class="badge bg-success">Einnahmen: {{ getIncomeAmount(booking) | number: '.2' : 'de' }}</span>
-              <span class="badge"
-                [ngClass]="getEarningsDifference(booking) >= 0 ? 'bg-primary' : 'bg-danger'"
-              >Differenz: {{ getEarningsDifference(booking) | number: '.2' : 'de' }}
-                @if (getEarningsDifference(booking) < 0) {
-                  (Die Ausgaben sind höher als die Einnahmen!)
-                }
-              </span>
-            </div>
+      <div class="booking-panel">
+
+        <!-- ── Panel Header ──────────────────────────────── -->
+        <div class="panel__header">
+          <div class="panel__title">
+            <span class="panel__dot"></span>
+            <span class="panel__month">{{ booking.year }}-{{ booking.month }}</span>
+          </div>
+          <div class="panel__stats">
+            <span class="stat stat--neutral">
+              <span class="stat__key">Ausgaben</span>
+              <span class="stat__val">{{ getTotalAmount(booking) | number: '.2' : 'de' }}</span>
+            </span>
+            <span class="stat stat--income">
+              <span class="stat__key">Einnahmen</span>
+              <span class="stat__val">{{ getIncomeAmount(booking) | number: '.2' : 'de' }}</span>
+            </span>
+            <span class="stat"
+                  [class.stat--positive]="getEarningsDifference(booking) >= 0"
+                  [class.stat--negative]="getEarningsDifference(booking) < 0">
+              <span class="stat__key">Differenz</span>
+              <span class="stat__val">{{ getEarningsDifference(booking) | number: '.2' : 'de' }}</span>
+            </span>
           </div>
         </div>
 
-        <div class="row m-0 p-1 booking-content" style="flex: 1 1 auto; overflow: hidden;">
-          <div class="col h-100">
+        <!-- ── Panel Body ────────────────────────────────── -->
+        <div class="panel__body">
+          <div class="panel__col">
             <app-table title="Generelle Buchungen" [bookings]="booking.usualBookings"
                        (itemRemoved)="onItemRemoved($event, booking)"></app-table>
           </div>
-
-          <div class="col h-100 d-flex flex-column gap-1">
-            <div style="flex: 0 0 50%; overflow: hidden;">
-              <app-table title="Täglicher Bedarf" [bookings]="booking.dailyCosts"
-                         (itemRemoved)="onItemRemoved($event, booking)"></app-table>
-            </div>
-            <div style="flex: 0 0 50%; overflow: hidden;">
-              <app-table title="Einkommen" [bookings]="booking.incomes"
-                         (itemRemoved)="onItemRemoved($event, booking)"></app-table>
-            </div>
+          <div class="panel__col panel__col--split">
+            <app-table title="Täglicher Bedarf" [bookings]="booking.dailyCosts"
+                       (itemRemoved)="onItemRemoved($event, booking)"></app-table>
+            <app-table title="Einkommen" [bookings]="booking.incomes"
+                       (itemRemoved)="onItemRemoved($event, booking)"></app-table>
           </div>
         </div>
 

--- a/src/app/backend/table/table.component.css
+++ b/src/app/backend/table/table.component.css
@@ -1,85 +1,180 @@
-span {
-  font-weight: bold;
+/* ── Design Tokens (inherited from host context) ─── */
+/* These vars are defined on :host of the bookings component
+   and cascade down. We redeclare fallbacks here for standalone use. */
+:host {
+  --bg:         #06080e;
+  --surface:    #0c1018;
+  --raised:     #111826;
+  --border:     rgba(255, 255, 255, 0.07);
+  --border-mid: rgba(255, 255, 255, 0.13);
+  --text:       #c8d4e8;
+  --text-muted: #7a93b0;
+  --text-dim:   #3d5470;
+  --c-a:  #4da6ff;
+  --c-p:  #22d35e;
+  --c-e:  #fb7185;
+
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
 }
 
-/* Angular Material Table dark theme overrides - Bootstrap can't handle these */
-.mat-mdc-table {
+/* ── Shell ───────────────────────────────────────── */
+.tbl {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* ── Header ──────────────────────────────────────── */
+.tbl__header {
+  flex-shrink: 0;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border-mid);
+  background: var(--raised);
+}
+
+.tbl__title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.tbl__title {
+  margin: 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+/* ── Body / Scroll ───────────────────────────────── */
+.tbl__body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+/* ── Footer ──────────────────────────────────────── */
+.tbl__footer {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.4rem 0.75rem;
+  border-top: 1px solid var(--border-mid);
+  background: var(--raised);
+}
+
+.tbl__sum-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.tbl__sum-val {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+/* ── Angular Material Table Overrides ────────────── */
+.tbl__mat {
   background-color: transparent !important;
-  border-top: 1px solid var(--bs-primary) !important;
-}
-
-.mat-mdc-header-cell {
-  background-color: var(--bs-gray-800) !important;
-  color: var(--bs-light) !important;
-  border-bottom: 1px solid var(--bs-primary) !important;
-  font-weight: 500 !important;
-  font-size: 0.75rem !important;
-  padding: 4px 8px !important;
-  line-height: 1.2 !important;
+  width: 100%;
 }
 
 .mat-mdc-header-row {
   height: 28px !important;
   min-height: 28px !important;
+  background: var(--raised) !important;
+}
+
+.mat-mdc-header-cell {
+  background: var(--raised) !important;
+  color: var(--text-dim) !important;
+  border-bottom: 1px solid var(--border-mid) !important;
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.6rem !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.08em !important;
+  text-transform: uppercase !important;
+  padding: 4px 12px !important;
+  line-height: 1.2 !important;
 }
 
 .mat-mdc-cell {
-  color: var(--bs-light) !important;
-  border-bottom: 1px solid var(--bs-gray-700) !important;
+  color: var(--text) !important;
+  border-bottom: 1px solid var(--border) !important;
+  background: transparent !important;
   padding: 6px 12px !important;
   height: auto !important;
-  font-size: 0.875rem !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.8rem !important;
 }
 
 .mat-mdc-row:hover .mat-mdc-cell {
-  background-color: var(--bs-gray-800) !important;
+  background: var(--raised) !important;
 }
 
-/* FAB mini button styling for dark theme */
-button.mat-mdc-mini-fab {
-  background-color: var(--bs-secondary) !important;
-  color: var(--bs-light) !important;
-  width: 32px !important;
-  height: 32px !important;
-  font-size: 14px !important;
+/* ── Sort / Action Buttons ───────────────────────── */
+.tbl__sort-btn.mat-mdc-mini-fab {
+  background: var(--surface) !important;
+  color: var(--text-muted) !important;
+  border: 1px solid var(--border-mid) !important;
+  box-shadow: none !important;
+  width: 28px !important;
+  height: 28px !important;
 }
 
-button.mat-mdc-mini-fab:hover {
-  background-color: var(--bs-primary) !important;
+.tbl__sort-btn.mat-mdc-mini-fab:hover {
+  background: var(--raised) !important;
+  color: var(--c-a) !important;
+  border-color: rgba(77, 166, 255, 0.35) !important;
 }
 
-button.mat-mdc-mini-fab.mat-warn {
-  background-color: var(--bs-danger) !important;
-  color: var(--bs-light) !important;
-  width: 32px !important;
-  height: 32px !important;
-  font-size: 14px !important;
-}
-
-button.mat-mdc-mini-fab.mat-warn:hover {
-  background-color: #dc3545 !important;
-  color: var(--bs-light) !important;
-}
-
-/* Backend header buttons */
-.header-section button.mat-mdc-mini-fab {
-  width: 36px !important;
-  height: 36px !important;
+.tbl__sort-btn .mat-icon {
   font-size: 16px !important;
+  width: 16px !important;
+  height: 16px !important;
+  line-height: 16px !important;
 }
 
-/* Legacy icon button styling (if any remain) */
+.tbl__delete-btn.mat-mdc-mini-fab {
+  background: rgba(251, 113, 133, 0.1) !important;
+  color: var(--c-e) !important;
+  border: 1px solid rgba(251, 113, 133, 0.25) !important;
+  box-shadow: none !important;
+  width: 28px !important;
+  height: 28px !important;
+}
+
+.tbl__delete-btn.mat-mdc-mini-fab:hover {
+  background: rgba(251, 113, 133, 0.2) !important;
+}
+
+.tbl__delete-btn .mat-icon {
+  font-size: 16px !important;
+  width: 16px !important;
+  height: 16px !important;
+  line-height: 16px !important;
+}
+
+/* ── Icon button fallback ────────────────────────── */
 button.mat-mdc-icon-button {
-  color: var(--bs-light) !important;
+  color: var(--text-muted) !important;
 }
 
 button.mat-mdc-icon-button:hover {
-  background-color: var(--bs-gray-700) !important;
-}
-
-/* Clear separation between component header and table */
-.table-header-separator {
-  border-bottom: 2px solid var(--bs-primary);
-  margin: 8px 0;
-  padding: 0;
+  background: var(--raised) !important;
 }

--- a/src/app/backend/table/table.component.html
+++ b/src/app/backend/table/table.component.html
@@ -1,36 +1,41 @@
-<div class="h-100 d-flex flex-column border border-secondary bg-dark text-light">
-  <div class="d-flex justify-content-between align-items-center bg-secondary p-1">
-    <h6 class="m-0 text-light fs-6">{{ title || 'n/a' }}</h6>
-    <button mat-mini-fab (click)="toggleSort()"
-            matTooltip="Sortierung umschalten ({{ sortDirection === 'desc' ? 'Höchste zuerst' : 'Niedrigste zuerst' }}"
-            class="mat-dark">
-      <mat-icon>{{ sortDirection === 'desc' ? 'arrow_downward' : 'arrow_upward' }}</mat-icon>
-    </button>
+<div class="tbl">
+
+  <!-- ── Table Header ──────────────────────────────── -->
+  <div class="tbl__header">
+    <div class="tbl__title-row">
+      <h6 class="tbl__title">{{ title || 'n/a' }}</h6>
+      <button mat-mini-fab (click)="toggleSort()"
+              [matTooltip]="'Sortierung: ' + (sortDirection === 'desc' ? 'Höchste zuerst' : 'Niedrigste zuerst')"
+              class="tbl__sort-btn">
+        <mat-icon>{{ sortDirection === 'desc' ? 'arrow_downward' : 'arrow_upward' }}</mat-icon>
+      </button>
+    </div>
   </div>
-  <div class="table-header-separator" style="margin: 2px 0;"></div>
-  <div class="flex-grow-1 overflow-auto px-1">
-    <table mat-table [dataSource]="getSortedBookings() || []" class="text-light">
+
+  <!-- ── Table Body ────────────────────────────────── -->
+  <div class="tbl__body">
+    <table mat-table [dataSource]="getSortedBookings() || []" class="tbl__mat">
 
       <ng-container matColumnDef="creditName">
-        <th mat-header-cell *matHeaderCellDef class="text-light">An</th>
+        <th mat-header-cell *matHeaderCellDef>An</th>
         <td mat-cell *matCellDef="let element">{{ element.creditName }}</td>
       </ng-container>
 
       <ng-container matColumnDef="additionalInfo">
-        <th mat-header-cell *matHeaderCellDef class="text-light">Buchungstext</th>
+        <th mat-header-cell *matHeaderCellDef>Buchungstext</th>
         <td mat-cell *matCellDef="let element">{{ element.additionalInfo }}</td>
       </ng-container>
 
       <ng-container matColumnDef="amount">
-        <th mat-header-cell *matHeaderCellDef class="text-light">Betrag</th>
+        <th mat-header-cell *matHeaderCellDef>Betrag</th>
         <td mat-cell *matCellDef="let element">{{ element.amount | number: '.2' : 'de' }}</td>
       </ng-container>
 
       <ng-container matColumnDef="actions">
-        <th mat-header-cell *matHeaderCellDef class="text-light"></th>
+        <th mat-header-cell *matHeaderCellDef></th>
         <td mat-cell *matCellDef="let element">
           <button mat-mini-fab color="warn" (click)="removeItem(element)"
-                  matTooltip="Entfernen">
+                  matTooltip="Entfernen" class="tbl__delete-btn">
             <mat-icon>delete</mat-icon>
           </button>
         </td>
@@ -41,8 +46,10 @@
     </table>
   </div>
 
-  <div class="border-top border-secondary bg-secondary mx-1 my-1 p-1">
-    <strong class="text-light fs-6 small">Summe: {{ getTotalAmount() | number: '.2' : 'de' }}</strong>
+  <!-- ── Table Footer ──────────────────────────────── -->
+  <div class="tbl__footer">
+    <span class="tbl__sum-label">Summe</span>
+    <span class="tbl__sum-val">{{ getTotalAmount() | number: '.2' : 'de' }}</span>
   </div>
 
 </div>


### PR DESCRIPTION
## Summary

- Replace Bootstrap utility classes and inline styles across all three backend components (`backend`, `bookings`, `table`) with the shared dark PWA design system used by the home component
- `backend.component`: sticky glass topbar matching the home component (hex glyph as home link, JetBrains Mono brand label, compact file input + upload/backup action buttons with accent colour variants)
- `bookings.component`: monthly panels using `--surface`/`--raised` card structure with a header strip showing Ausgaben, Einnahmen, and Differenz stat chips (neutral / green / blue-positive / red-negative), `fadeUp` entrance animations
- `table.component`: header, cells, sort button, and delete button restyled using the shared design tokens, Outfit + JetBrains Mono typography, and the accent colour palette

## Test plan

- [ ] Open the backend view — topbar renders with dark glass background, blurred backdrop, hex home link, and compact action controls
- [ ] Select a file — file input label highlights with blue accent on hover
- [ ] Upload a file — bookings panels appear with dark surface cards and correct stat chips
- [ ] Confirm Differenz chip turns blue when positive and red when negative
- [ ] Check table headers use JetBrains Mono uppercase labels with `--text-dim` colour
- [ ] Verify sort and delete buttons match the dark theme (no Bootstrap colours visible)
- [ ] Test on mobile (< 768 px) — panel body stacks columns vertically; topbar wraps cleanly
- [ ] Test on desktop (≥ 768 px) — panel body shows two columns (Generelle Buchungen left, Täglicher Bedarf + Einkommen stacked right)

🤖 Generated with [Claude Code](https://claude.com/claude-code)