### PR TITLE
Style: wrap monthly booking panels in mat-expansion-panel

### DIFF
--- a/src/app/backend/bookings/bookings.component.css
+++ b/src/app/backend/bookings/bookings.component.css
@@ -193,12 +193,19 @@ mat-accordion {
 }
 .stat--negative .stat__val { color: var(--c-e); }
 
+/* ── mat-expansion-panel body: remove padding, constrain height ── */
+::ng-deep .booking-panel .mat-expansion-panel-body {
+  padding: 0 !important;
+  height: calc(100vh - 165px);
+  overflow: hidden;
+}
+
 /* ── Panel Body ──────────────────────────────────── */
 .panel__body {
   display: grid;
   grid-template-columns: 1fr;
   gap: 0;
-  flex: 1 1 auto;
+  height: 100%;
   overflow: hidden;
 }
 

--- a/src/app/backend/bookings/bookings.component.css
+++ b/src/app/backend/bookings/bookings.component.css
@@ -80,22 +80,6 @@ mat-accordion {
 .booking-panel:nth-child(5) { animation-delay: 0.33s; }
 .booking-panel:nth-child(n+6) { animation-delay: 0.4s; }
 
-/* ── Panel Header ────────────────────────────────── */
-::ng-deep .booking-panel .mat-expansion-panel-header {
-  background: var(--raised) !important;
-  border-bottom: 1px solid var(--border);
-  padding: 0.5rem 1rem;
-  height: auto !important;
-}
-
-::ng-deep .booking-panel .mat-expansion-panel-header:hover {
-  background: color-mix(in srgb, var(--raised) 85%, var(--c-a) 15%) !important;
-}
-
-::ng-deep .booking-panel .mat-expansion-indicator::after {
-  color: var(--text-muted);
-}
-
 .panel__header {
   display: flex;
   flex-wrap: wrap;
@@ -134,12 +118,6 @@ mat-accordion {
 }
 
 /* ── Stats Row ───────────────────────────────────── */
-::ng-deep .booking-panel .mat-expansion-panel-header .mat-expansion-panel-header-description {
-  flex-grow: 1;
-  margin: 0;
-  color: inherit;
-}
-
 .panel__stats {
   display: flex;
   flex-wrap: wrap;
@@ -192,13 +170,6 @@ mat-accordion {
   background: rgba(251, 113, 133, 0.05);
 }
 .stat--negative .stat__val { color: var(--c-e); }
-
-/* ── mat-expansion-panel body: remove padding, constrain height ── */
-::ng-deep .booking-panel .mat-expansion-panel-body {
-  padding: 0 !important;
-  height: calc(100vh - 165px);
-  overflow: hidden;
-}
 
 /* ── Panel Body ──────────────────────────────────── */
 .panel__body {

--- a/src/app/backend/bookings/bookings.component.css
+++ b/src/app/backend/bookings/bookings.component.css
@@ -56,16 +56,21 @@
   }
 }
 
-/* ── Booking Panel ───────────────────────────────── */
-.booking-panel {
+/* ── mat-accordion override ──────────────────────── */
+mat-accordion {
   display: flex;
   flex-direction: column;
-  flex: 0 0 calc(100% - 2rem);
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 12px;
+  gap: 0.75rem;
+}
+
+/* ── Booking Panel (mat-expansion-panel) ─────────── */
+.booking-panel {
+  background: var(--surface) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: 12px !important;
   overflow: hidden;
   animation: fadeUp 0.45s ease both;
+  box-shadow: none !important;
 }
 
 .booking-panel:nth-child(1) { animation-delay: 0.05s; }
@@ -76,14 +81,26 @@
 .booking-panel:nth-child(n+6) { animation-delay: 0.4s; }
 
 /* ── Panel Header ────────────────────────────────── */
+::ng-deep .booking-panel .mat-expansion-panel-header {
+  background: var(--raised) !important;
+  border-bottom: 1px solid var(--border);
+  padding: 0.5rem 1rem;
+  height: auto !important;
+}
+
+::ng-deep .booking-panel .mat-expansion-panel-header:hover {
+  background: color-mix(in srgb, var(--raised) 85%, var(--c-a) 15%) !important;
+}
+
+::ng-deep .booking-panel .mat-expansion-indicator::after {
+  color: var(--text-muted);
+}
+
 .panel__header {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--border);
-  background: var(--raised);
   flex-shrink: 0;
 }
 
@@ -117,10 +134,17 @@
 }
 
 /* ── Stats Row ───────────────────────────────────── */
+::ng-deep .booking-panel .mat-expansion-panel-header .mat-expansion-panel-header-description {
+  flex-grow: 1;
+  margin: 0;
+  color: inherit;
+}
+
 .panel__stats {
   display: flex;
   flex-wrap: wrap;
   gap: 0.4rem;
+  flex-grow: 1;
 }
 
 .stat {

--- a/src/app/backend/bookings/bookings.component.html
+++ b/src/app/backend/bookings/bookings.component.html
@@ -1,49 +1,51 @@
 <div class="bookings">
   <div class="bookings__scroll">
 
-    @for (booking of bookings?.bookingsPerMonth; track $index) {
-      <div class="booking-panel">
+    <mat-accordion multi>
+      @for (booking of bookings?.bookingsPerMonth; track $index) {
+        <mat-expansion-panel class="booking-panel">
 
-        <!-- ── Panel Header ──────────────────────────────── -->
-        <div class="panel__header">
-          <div class="panel__title">
-            <span class="panel__dot"></span>
-            <span class="panel__month">{{ booking.year }}-{{ booking.month }}</span>
-          </div>
-          <div class="panel__stats">
-            <span class="stat stat--neutral">
-              <span class="stat__key">Ausgaben</span>
-              <span class="stat__val">{{ getTotalAmount(booking) | number: '.2' : 'de' }}</span>
-            </span>
-            <span class="stat stat--income">
-              <span class="stat__key">Einnahmen</span>
-              <span class="stat__val">{{ getIncomeAmount(booking) | number: '.2' : 'de' }}</span>
-            </span>
-            <span class="stat"
-                  [class.stat--positive]="getEarningsDifference(booking) >= 0"
-                  [class.stat--negative]="getEarningsDifference(booking) < 0">
-              <span class="stat__key">Differenz</span>
-              <span class="stat__val">{{ getEarningsDifference(booking) | number: '.2' : 'de' }}</span>
-            </span>
-          </div>
-        </div>
+          <!-- ── Panel Header ──────────────────────────────── -->
+          <mat-expansion-panel-header class="panel__header">
+            <mat-panel-title class="panel__title">
+              <span class="panel__dot"></span>
+              <span class="panel__month">{{ booking.year }}-{{ booking.month }}</span>
+            </mat-panel-title>
+            <mat-panel-description class="panel__stats">
+              <span class="stat stat--neutral">
+                <span class="stat__key">Ausgaben</span>
+                <span class="stat__val">{{ getTotalAmount(booking) | number: '.2' : 'de' }}</span>
+              </span>
+              <span class="stat stat--income">
+                <span class="stat__key">Einnahmen</span>
+                <span class="stat__val">{{ getIncomeAmount(booking) | number: '.2' : 'de' }}</span>
+              </span>
+              <span class="stat"
+                    [class.stat--positive]="getEarningsDifference(booking) >= 0"
+                    [class.stat--negative]="getEarningsDifference(booking) < 0">
+                <span class="stat__key">Differenz</span>
+                <span class="stat__val">{{ getEarningsDifference(booking) | number: '.2' : 'de' }}</span>
+              </span>
+            </mat-panel-description>
+          </mat-expansion-panel-header>
 
-        <!-- ── Panel Body ────────────────────────────────── -->
-        <div class="panel__body">
-          <div class="panel__col">
-            <app-table title="Generelle Buchungen" [bookings]="booking.usualBookings"
-                       (itemRemoved)="onItemRemoved($event, booking)"></app-table>
+          <!-- ── Panel Body ────────────────────────────────── -->
+          <div class="panel__body">
+            <div class="panel__col">
+              <app-table title="Generelle Buchungen" [bookings]="booking.usualBookings"
+                         (itemRemoved)="onItemRemoved($event, booking)"></app-table>
+            </div>
+            <div class="panel__col panel__col--split">
+              <app-table title="Täglicher Bedarf" [bookings]="booking.dailyCosts"
+                         (itemRemoved)="onItemRemoved($event, booking)"></app-table>
+              <app-table title="Einkommen" [bookings]="booking.incomes"
+                         (itemRemoved)="onItemRemoved($event, booking)"></app-table>
+            </div>
           </div>
-          <div class="panel__col panel__col--split">
-            <app-table title="Täglicher Bedarf" [bookings]="booking.dailyCosts"
-                       (itemRemoved)="onItemRemoved($event, booking)"></app-table>
-            <app-table title="Einkommen" [bookings]="booking.incomes"
-                       (itemRemoved)="onItemRemoved($event, booking)"></app-table>
-          </div>
-        </div>
 
-      </div>
-    }
+        </mat-expansion-panel>
+      }
+    </mat-accordion>
 
   </div>
 </div>

--- a/src/app/backend/bookings/bookings.component.ts
+++ b/src/app/backend/bookings/bookings.component.ts
@@ -3,14 +3,15 @@ import {BookingsDTO} from '../model/BookingsDTO';
 import {TableComponent} from '../table/table.component';
 import {MonthlyBookingEntriesDTO} from '../model/MonthlyBookingEntriesDTO';
 import {BookingEntryDTO} from '../model/BookingEntryDTO';
-import {DecimalPipe, NgClass} from '@angular/common';
+import {DecimalPipe} from '@angular/common';
+import {MatExpansionModule} from '@angular/material/expansion';
 
 @Component({
   selector: 'app-bookings',
   imports: [
     TableComponent,
     DecimalPipe,
-    NgClass
+    MatExpansionModule
   ],
   templateUrl: './bookings.component.html',
   styleUrl: './bookings.component.css',

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,3 +3,32 @@
 html, body { height: 100vh; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 
+/* ── Bookings: mat-expansion-panel overrides ─────── */
+/* Scoped to .booking-panel to avoid leaking to other components. */
+.booking-panel .mat-expansion-panel-header {
+  background: var(--raised) !important;
+  border-bottom: 1px solid var(--border);
+  padding: 0.5rem 1rem;
+  height: auto !important;
+}
+
+.booking-panel .mat-expansion-panel-header:hover {
+  background: color-mix(in srgb, var(--raised) 85%, var(--c-a) 15%) !important;
+}
+
+.booking-panel .mat-expansion-indicator::after {
+  color: var(--text-muted);
+}
+
+.booking-panel .mat-expansion-panel-header .mat-expansion-panel-header-description {
+  flex-grow: 1;
+  margin: 0;
+  color: inherit;
+}
+
+.booking-panel .mat-expansion-panel-body {
+  padding: 0 !important;
+  height: calc(100vh - 165px);
+  overflow: hidden;
+}
+


### PR DESCRIPTION
## Summary

- Replaces static `.booking-panel` divs with Angular Material `mat-expansion-panel` inside a `mat-accordion` (multi mode)
- Month title and stats row moved into `mat-expansion-panel-header` using `mat-panel-title` / `mat-panel-description`
- Tables remain in the collapsible panel body
- Added `MatExpansionModule` import to `BookingsComponent`, removed unused `NgClass`
- CSS updated to theme the expansion panel with the existing dark PWA design tokens

## Test plan
- [ ] Each month renders as a collapsible expansion panel
- [ ] Header shows month label and Ausgaben / Einnahmen / Differenz stats
- [ ] Clicking the header expands/collapses the panel with the three tables
- [ ] Multiple panels can be open simultaneously (multi accordion)
- [ ] Dark theme styling matches the rest of the backend UI
- [ ] Build completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)