### PR TITLE
Feature: add mat-spinner while loading bank statement data

### DIFF
--- a/src/app/backend/backend.component.css
+++ b/src/app/backend/backend.component.css
@@ -187,3 +187,11 @@
   overflow: hidden;
   min-height: 0;
 }
+
+/* ── Spinner ─────────────────────────────────────── */
+.backend__spinner {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}

--- a/src/app/backend/backend.component.html
+++ b/src/app/backend/backend.component.html
@@ -28,7 +28,13 @@
 
   <!-- ── Content ─────────────────────────────────────── -->
   <div class="backend__content">
-    <app-bookings [bookings]="responseData"></app-bookings>
+    @if (isLoading) {
+      <div class="backend__spinner">
+        <mat-spinner></mat-spinner>
+      </div>
+    } @else {
+      <app-bookings [bookings]="responseData"></app-bookings>
+    }
   </div>
 
 </div>

--- a/src/app/backend/backend.component.ts
+++ b/src/app/backend/backend.component.ts
@@ -8,6 +8,7 @@ import {MatIconModule} from '@angular/material/icon';
 import {environment} from '../../environments/environment';
 import {MatTooltip} from '@angular/material/tooltip';
 import {RouterLink} from '@angular/router';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 
 @Component({
   selector: 'app-backend',
@@ -18,7 +19,8 @@ import {RouterLink} from '@angular/router';
     MatButtonModule,
     MatIconModule,
     MatTooltip,
-    RouterLink
+    RouterLink,
+    MatProgressSpinnerModule
   ],
   styleUrls: ['./backend.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -27,6 +29,7 @@ export class BackendComponent {
 
   uploadedFile?: File;
   responseData?: BookingsDTO;
+  isLoading = false;
   private readonly http = inject(HttpClient);
   private readonly cdr = inject(ChangeDetectorRef);
 
@@ -39,14 +42,19 @@ export class BackendComponent {
     const formData = new FormData();
     formData.append('file', this.uploadedFile);
 
+    this.isLoading = true;
+    this.cdr.markForCheck();
+
     this.http.post<BookingsDTO>(`${environment.apiUrl}/camt-entries`, formData).subscribe({
       next: (response: BookingsDTO) => {
         this.responseData = response;
+        this.isLoading = false;
         this.cdr.markForCheck();
       },
       error: (error) => {
         console.error('Upload error:', error);
         alert('Error uploading file.');
+        this.isLoading = false;
         this.cdr.markForCheck();
       }
     });


### PR DESCRIPTION
## Summary
- Added `isLoading` flag to `BackendComponent`, set to `true` before the CAMT upload request and reset to `false` on completion or error
- Imported `MatProgressSpinnerModule` and added `<mat-spinner>` to the template, shown while loading via `@if`/`@else`
- Added `.backend__spinner` CSS class to center the spinner within the content area

## Test plan
- [ ] Select a CAMT file and click Upload — spinner should appear during the request
- [ ] After the response, spinner should disappear and bookings should render
- [ ] On upload error, spinner should disappear and error alert should show

🤖 Generated with [Claude Code](https://claude.com/claude-code)