### PR TITLE
Style: restyle plants app with dark theme

### DIFF
--- a/plans/drifting-churning-bachman.md
+++ b/plans/drifting-churning-bachman.md
@@ -1,0 +1,333 @@
+# Plan: Restyle Plants Application to Match New Dark Theme
+
+## Context
+The home and bookings components have been redesigned with a premium dark UI using Outfit + JetBrains Mono fonts, deep navy backgrounds, and vibrant accent glows. The plants application still uses the old Bootstrap/Material default styling with light backgrounds, `#ccc` borders, and generic hover shadows. This plan brings the entire `/plants/` app into visual parity with the new aesthetic.
+
+---
+
+## Design Tokens (Shared Across All Components)
+
+Same token set as `home.component.css` / `bookings.component.css`:
+
+```css
+--bg:          #06080e;
+--surface:     #0c1018;
+--raised:      #111826;
+--border:      rgba(255,255,255,0.07);
+--border-mid:  rgba(255,255,255,0.13);
+--text:        #c8d4e8;
+--text-muted:  #7a93b0;
+--text-dim:    #3d5470;
+--c-a: #4da6ff;  --cg-a: rgba(77,166,255,0.18);   /* blue   */
+--c-p: #22d35e;  --cg-p: rgba(34,211,94,0.18);    /* green  */
+--c-v: #fbbf24;  --cg-v: rgba(251,191,36,0.18);   /* yellow */
+--c-m: #a78bfa;  --cg-m: rgba(167,139,250,0.18);  /* purple */
+--c-e: #fb7185;  --cg-e: rgba(251,113,133,0.18);  /* pink   */
+```
+
+Fonts: `'Outfit'` (body) + `'JetBrains Mono'` (data/labels/monospace).
+Background: deep `#06080e` with radial gradients + 28px dot-grid.
+Animations: `fadeUp` keyframe, staggered `animation-delay`.
+Cards: `border-radius: 12px`, 1px `var(--border)` border, no shadow by default.
+
+Plant-specific accent: **green (`--c-p`)** as the primary plant color (life/nature). Secondary accent for watering-due: **pink (`--c-e`)**. Fertilizing-due: **yellow (`--c-v`)**.
+
+---
+
+## Steps
+
+### [ ] Step 1 — `plant-layout.component` (HTML + CSS)
+
+**Goal:** Replace Bootstrap header row with a styled topbar matching `home.component`.
+
+**HTML changes:**
+- Remove Bootstrap grid (`container`, `row`, `col-*`) structure
+- New structure: `<div class="plant-layout">` wrapping `<header class="topbar">` + `<main class="content">`
+- Topbar: left side has home FAB + menu FAB; center has brand title "PLANTS" with `⬡` hex; right side has env-style breadcrumb or empty
+- Keep `matMenuTriggerFor` and `mat-menu` buttons; style them as flat icon buttons (not FABs)
+- `<router-outlet>` goes inside `<main class="content">`
+
+**CSS changes:**
+- Remove all Bootstrap-dependent classes
+- Topbar: sticky, `backdrop-filter: blur(20px)`, `background: rgba(6,8,14,0.88)`, border-bottom
+- Host: dark bg + radial gradient + dot-grid pattern (same as home)
+- Nav buttons: transparent icon buttons with `--border` outline, green glow on hover
+- Menu panel: dark `--surface` background, `--border` border, `--text` items
+- Content area: flex-grow, overflow managed
+
+**Files:**
+- `src/app/plants/components/plant-layout/plant-layout.component.html`
+- `src/app/plants/components/plant-layout/plant-layout.component.css`
+
+---
+
+### [x] Step 2 — `plant-home.component` (HTML + CSS)
+
+**Goal:** Transform 3 navigation cards to match `navcard` style from `home.component.html`.
+
+**HTML changes:**
+- Replace `<div class="plant-card">` with `<a class="navcard navcard--X" routerLink="...">` links
+- Add `navcard__mark` (single letter: S/E/C), `navcard__title`, `navcard__sub`, `navcard__arrow`
+- Card accents: Show → `navcard--p` (green), Edit → `navcard--v` (yellow), Create → `navcard--a` (blue)
+
+**CSS changes:**
+- Copy navcard CSS pattern from `home.component.css` exactly
+- Use `--c-p`, `--c-v`, `--c-a` for card variants
+- fadeUp staggered animations (delays: 0.05s, 0.12s, 0.19s)
+- Remove old `.plant-card` styles
+
+**Files:**
+- `src/app/plants/components/plant-home/plant-home.component.html`
+- `src/app/plants/components/plant-home/plant-home.component.css`
+
+---
+
+### [x] Step 3 — `plant-create.component` (HTML + CSS)
+
+**Goal:** Style multi-step stepper form with dark theme.
+
+**HTML changes:**
+- Wrap entire stepper in `<div class="plant-create">` host container
+- No major structural changes, keep stepper logic intact
+- Add CSS class `create-form` to each `<form>` element
+- Style navigation buttons: replace `mat-button` with styled buttons using design tokens
+
+**CSS changes:**
+- Host: dark bg, radial gradient, dot-grid (same pattern)
+- Stepper override: `--surface` background, `--border` borders on step headers
+- Step indicator circles: use `--c-p` (green) for active step
+- Form fields (`mat-form-field`): dark surface background, `--border` outline, `--text` input color; on focus use `--c-a` blue border
+- `mat-label` text: `--text-muted` color
+- `textarea`, `input`: `--surface` background, `--text` color, `--border` border
+- Navigation buttons: flat style with `--border` border, green (`--c-p`) for primary action, hover glow
+
+**Files:**
+- `src/app/plants/components/plant-create/plant-create.component.html`
+- `src/app/plants/components/plant-create/plant-create.component.css`
+
+---
+
+### [x] Step 4 — `plant-table.component` (HTML + CSS)
+
+**Goal:** Style management table matching bookings/table aesthetic.
+
+**HTML changes:**
+- Wrap in `<div class="plant-table">` host
+- Add `<header class="table-header">` with "MANAGEMENT" label + blinking dot
+- Table structure stays, add `panel__header`-style header row
+- Column headers: add `class="col-header"` — uppercase monospace
+- Image button / delete button: style as mini icon buttons with token colors
+- Preview container: keep as-is but restyle
+
+**CSS changes:**
+- Host: dark bg + radial gradient + dot-grid
+- `.plant-table`: flex column, full height, overflow hidden
+- Table container: `--surface` background, `--border` border, `border-radius: 12px`, overflow
+- Header cells: `--raised` background, uppercase, `JetBrains Mono`, `--text-dim` color, `--border-mid` bottom border, 28px height
+- Data cells: 0.8rem, `--text` color, transparent background
+- Row hover: `--raised` background tinted with `--c-p` (green, 8%), no scale transform
+- Image button: `--c-a` (blue) icon color, 10% blue background on hover
+- Delete button: `--c-e` (pink) icon color, 10% pink background on hover
+- Preview container: dark glassmorphism (see Step 9)
+- `@keyframes fadeInScale` kept
+
+**Files:**
+- `src/app/plants/components/plant-table/plant-table.component.html`
+- `src/app/plants/components/plant-table/plant-table.component.css`
+
+---
+
+### [x] Step 5 — `plant-view.component` (HTML + CSS)
+
+**Goal:** Replace light mat-card with dark detail panel.
+
+**HTML changes:**
+- Remove Bootstrap container/row/col classes
+- New structure: `<div class="plant-view">` with `<div class="view-card">` (replaces mat-card)
+- Header: plant name centered, monospace style
+- Two-column layout: image left, details right (CSS grid, no Bootstrap)
+- Info badges (species, location, last watered): replace `shadow p-1 rounded` with `info-badge` elements styled with dark tokens
+- Tab group: keep `mat-tab-group`, override colors
+
+**CSS changes:**
+- Host: dark bg + radial gradient + dot-grid
+- `.view-card`: `--surface` bg, `--border` border, `border-radius: 12px`, full height
+- Image: `object-fit: cover`, `border-radius: 8px`, constrained height
+- Info badges: `--raised` bg, `--border-mid` border, `border-radius: 6px`, `JetBrains Mono` for values
+- Tabs: override Material tab indicator to `--c-p` (green), text `--text-muted`
+- Description/care: `--raised` panel with `--text` color, `white-space: pre-wrap`
+- fadeUp entrance animation
+
+**Files:**
+- `src/app/plants/components/plant-view/plant-view.component.html`
+- `src/app/plants/components/plant-view/plant-view.component.css`
+
+---
+
+### [x] Step 6 — `plant-edit.component` (HTML + CSS)
+
+**Goal:** Dark theme for edit/view toggle layout.
+
+**HTML changes:**
+- Remove Bootstrap grid classes (`container-fluid`, `row`, `col-*`)
+- New structure: `<div class="plant-edit">` → `<header class="edit-header">` + `<div class="edit-body">`
+- Header: plant name left-aligned (not absolute positioned), action buttons right
+- Edit/save buttons: replace mat-mini-fab with styled icon buttons matching the theme
+- Edit mode indicator: when `isEditMode`, add a green `--c-p` left border on the edit panel
+- Info fields: replace `<mat-label>` + borders with dark `field-label` / `field-value` pattern
+- Remove `[ngClass]="{'bg-info': isEditMode}"` — use CSS class toggle instead
+
+**CSS changes:**
+- Host: dark bg + radial gradient + dot-grid
+- Header: flexbox, `--surface` bg, `--border` bottom border, monospace plant name
+- Toggle button: `--border` border, `--text-muted` color; in edit mode: `--c-p` green glow
+- Save button: `--c-p` green, with glow on hover
+- Edit body: two-column CSS grid (image | details)
+- Image container: `--surface` bg, `--border` border, rounded, overflow hidden
+- Details panel: `--surface` bg, `--border` border, rounded; edit mode: left 2px `--c-p` stripe
+- Field labels: `JetBrains Mono`, 0.6rem, uppercase, `--text-dim`
+- Field values (view): `--raised` bg, `--border` border, `border-radius: 6px`, `--text` color
+- Inputs/textareas (edit): `--raised` bg, `--c-a` focus border, `--text` color
+- Scrollable description areas with constrained height
+
+**Files:**
+- `src/app/plants/components/plant-edit/plant-edit.component.html`
+- `src/app/plants/components/plant-edit/plant-edit.component.css`
+
+---
+
+### [ ] Step 7 — `plant-gallery.component` (HTML + CSS)
+
+**Goal:** Dark plant cards with status coloring using design tokens (not Bootstrap `bg-danger`/`bg-success`).
+
+**HTML changes:**
+- Remove Bootstrap outer container/row/col classes
+- New: `<div class="gallery">` → `<div class="gallery__grid">` → `<div class="gallery__item">`
+- Plant card: replace mat-card structure with custom dark card `<div class="plant-card">` containing:
+  - `.plant-card__header`: name link + species subtitle
+  - `.plant-card__image`: img
+  - `.plant-card__info`: 2×2 grid of info tiles (last/next watered/fertilized, location)
+  - `.plant-card__actions`: Watered + Fertilized buttons
+- Replace `[ngClass]="{'bg-danger': ..., 'bg-success': ...}"` with `[class.plant-card--water]` and `[class.plant-card--fertilize]`
+- Info tiles: replace nested mat-cards with simple `<div class="info-tile">` elements
+
+**CSS changes:**
+- Host: dark bg + radial gradient + dot-grid
+- Gallery: `display: grid`, responsive columns (1 col → 2 col → 3 col), gap, overflow-y auto
+- Plant card: `--surface` bg, `--border` border, `border-radius: 12px`, flexbox column, overflow hidden
+- `plant-card--water`: left 3px `--c-e` (pink) border + very subtle pink bg tint
+- `plant-card--fertilize`: left 3px `--c-v` (yellow) border + subtle yellow bg tint
+- Card name link: `--text` color, font-weight 600; hover: `--c-p` green color, no underline
+- Image: `height: 35%`, `object-fit: cover`, no border-radius (flush with card)
+- Info tiles: `--raised` bg, `--border` border, `border-radius: 6px`, label in `JetBrains Mono` 0.55rem uppercase `--text-dim`, value in `JetBrains Mono` 0.68rem `--text`
+- Action buttons: flat, `--border` border, `--text-muted` text; Watered → hover `--c-a` (blue); Fertilized → hover `--c-v` (yellow)
+- fadeUp staggered animation for cards
+
+**Files:**
+- `src/app/plants/components/plant-gallery/plant-gallery.component.html`
+- `src/app/plants/components/plant-gallery/plant-gallery.component.css`
+
+---
+
+### [ ] Step 8 — `plant-preview.component` (HTML + CSS)
+
+**Goal:** Restyle hover preview popup to dark glassmorphism matching the overall theme.
+
+**HTML changes:**
+- Replace Bootstrap grid/col structure with flat CSS
+- Keep existing data: name, location icon, species, image
+
+**CSS changes:**
+- Remove light gradient (`#a1c4fd → #c2e9fb`)
+- New: `--surface` bg, `--border-mid` border, `border-radius: 12px`, `backdrop-filter: blur(16px)`
+- `box-shadow: 0 8px 32px rgba(0,0,0,0.6), 0 0 0 1px var(--border)`
+- Name: `JetBrains Mono`, `--text` color, font-weight 700
+- Meta text: `--text-muted`, Outfit font
+- Icon: `--c-p` (green) color (plant accent)
+- Image: `border-radius: 8px`, constrained size
+
+**Files:**
+- `src/app/plants/dialogs/plant-preview/plant-preview.component.html`
+- `src/app/plants/dialogs/plant-preview/plant-preview.component.css`
+
+---
+
+### [ ] Step 9 — Dialog Components (HTML + CSS for all 3)
+
+**Goal:** Style all three dialogs with dark theme overrides.
+
+**Approach:** Add a `<style>` override or component CSS targeting `::ng-deep` Material dialog backdrop/panel, OR add a single shared dialog class to each.
+
+**Changes per dialog:**
+
+**delete-confirmation-dialog:**
+- Title: `JetBrains Mono`, `--text` color
+- Content text: `--text-muted`
+- Confirm button: `--c-p` green icon, 10% green bg
+- Cancel button: `--c-e` pink icon, 10% pink bg
+
+**image-upload-dialog:**
+- Title: monospace style
+- File input: `--raised` bg, `--border` border, `--text` color
+- Cancel button: flat dark style
+- Upload button: `--c-a` (blue) filled style
+
+**image-view-dialog:**
+- Title: monospace style
+- Image: constrained, `border-radius: 8px`
+- Close button: flat dark style
+
+**All dialogs need (via global styles or per-component CSS):**
+```css
+::ng-deep .mat-mdc-dialog-container {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+}
+```
+> Note: Since CSS variables are on `:host`, dialogs need either a wrapper div with the variables defined, or the variables should be promoted to a global `:root` block in `styles.css`.
+
+**Files:**
+- `src/app/plants/dialogs/delete-confirmation-dialog/delete-confirmation-dialog.component.html`
+- `src/app/plants/dialogs/delete-confirmation-dialog/delete-confirmation-dialog.component.css`
+- `src/app/plants/dialogs/image-upload-dialog/image-upload-dialog.component.html`
+- `src/app/plants/dialogs/image-upload-dialog/image-upload-dialog.component.css`
+- `src/app/plants/dialogs/image-view-dialog/image-view-dialog.component.html`
+- `src/app/plants/dialogs/image-view-dialog/image-view-dialog.component.css`
+
+---
+
+### [ ] Step 10 — Global CSS Tokens for Dialogs
+
+**Goal:** Promote shared design tokens to `:root` in `styles.css` so they are accessible inside Material dialog overlays (which escape component scope).
+
+**Changes to `src/styles.scss`:**
+Add `:root` block with all shared design tokens (same values as `:host` in home/bookings).
+This allows dialogs and any future CDK overlays to access `var(--bg)`, `var(--surface)`, etc.
+
+**File:**
+- `src/styles.scss`
+
+---
+
+## Execution Order
+
+Steps should be executed in order 10 → 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 → 9.
+(Step 10 first to have tokens available for dialog CSS; then layout → home → inward.)
+
+---
+
+## Verification
+
+After implementation:
+1. Run `npm start` and navigate to `/plant-root`
+2. Check `plant-home` — 3 navcard-style cards with green/yellow/blue accents and fadeUp animations
+3. Navigate to `/plant-root/gallery` — dark cards with responsive grid; pink/yellow left borders for care-due plants
+4. Navigate to `/plant-root/management` — dark table with monospace headers, green hover rows, preview popup
+5. Click a row → `/plant-root/edit/:id` — dark edit layout, green edit mode indicator
+6. Navigate to `/plant-root/view/:id` — dark detail panel with tabs
+7. Navigate to `/plant-root/create` — dark stepper form
+8. Open delete/upload/view dialogs — verify dark background and token colors
+9. Hover a table row — verify dark glassmorphism preview popup
+10. Confirm all components use Outfit + JetBrains Mono fonts (check DevTools)

--- a/plans/drifting-churning-bachman.md
+++ b/plans/drifting-churning-bachman.md
@@ -36,7 +36,7 @@ Plant-specific accent: **green (`--c-p`)** as the primary plant color (life/natu
 
 ## Steps
 
-### [ ] Step 1 — `plant-layout.component` (HTML + CSS)
+### [x] Step 1 — `plant-layout.component` (HTML + CSS)
 
 **Goal:** Replace Bootstrap header row with a styled topbar matching `home.component`.
 
@@ -229,7 +229,7 @@ Plant-specific accent: **green (`--c-p`)** as the primary plant color (life/natu
 
 ---
 
-### [ ] Step 8 — `plant-preview.component` (HTML + CSS)
+### [x] Step 8 — `plant-preview.component` (HTML + CSS)
 
 **Goal:** Restyle hover preview popup to dark glassmorphism matching the overall theme.
 
@@ -252,7 +252,7 @@ Plant-specific accent: **green (`--c-p`)** as the primary plant color (life/natu
 
 ---
 
-### [ ] Step 9 — Dialog Components (HTML + CSS for all 3)
+### [x] Step 9 — Dialog Components (HTML + CSS for all 3)
 
 **Goal:** Style all three dialogs with dark theme overrides.
 

--- a/plans/drifting-churning-bachman.md
+++ b/plans/drifting-churning-bachman.md
@@ -196,7 +196,7 @@ Plant-specific accent: **green (`--c-p`)** as the primary plant color (life/natu
 
 ---
 
-### [ ] Step 7 — `plant-gallery.component` (HTML + CSS)
+### [x] Step 7 — `plant-gallery.component` (HTML + CSS)
 
 **Goal:** Dark plant cards with status coloring using design tokens (not Bootstrap `bg-danger`/`bg-success`).
 

--- a/src/app/plants/components/plant-create/plant-create.component.css
+++ b/src/app/plants/components/plant-create/plant-create.component.css
@@ -1,27 +1,113 @@
-mat-horizontal-stepper {
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+/* ── Design Tokens ───────────────────────────────── */
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-a:  #4da6ff;  --cg-a: rgba(77,  166, 255, 0.18);
+  --c-p:  #22d35e;  --cg-p: rgba(34,  211,  94, 0.18);
+  --c-v:  #fbbf24;  --cg-v: rgba(251, 191,  36, 0.18);
+  --c-m:  #a78bfa;  --cg-m: rgba(167, 139, 250, 0.18);
+  --c-e:  #fb7185;  --cg-e: rgba(251, 113, 133, 0.18);
+
+  display: block;
   height: 100%;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
 }
 
-form {
+/* ── Host Container ──────────────────────────────── */
+.plant-create {
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
   height: 100%;
-  gap: .5rem;
-  padding: 2% 10% 0 10%;
+  overflow: hidden;
+  background:
+    radial-gradient(ellipse 80% 50% at 20% 10%, rgba(34, 211, 94, 0.04) 0%, transparent 60%),
+    radial-gradient(ellipse 60% 40% at 80% 80%, rgba(77, 166, 255, 0.03) 0%, transparent 55%),
+    var(--bg);
+  background-image:
+    radial-gradient(ellipse 80% 50% at 20% 10%, rgba(34, 211, 94, 0.04) 0%, transparent 60%),
+    radial-gradient(ellipse 60% 40% at 80% 80%, rgba(77, 166, 255, 0.03) 0%, transparent 55%),
+    radial-gradient(circle, rgba(255,255,255,0.025) 1px, transparent 1px);
+  background-size: 100% 100%, 100% 100%, 28px 28px;
+  background-color: var(--bg);
 }
 
-.mat-mdc-form-field {
-  padding: 10px;
-  border: 1px solid #ccc;
-  border-radius: 10px;
-  text-align: center;
-  transition: box-shadow 0.3s ease;
+/* ── Stepper Overrides ───────────────────────────── */
+::ng-deep .plant-create mat-horizontal-stepper {
+  background: transparent !important;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
-.mat-mdc-form-field:hover {
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.15);
+::ng-deep .plant-create .mat-horizontal-stepper-header-container {
+  background: var(--surface) !important;
+  border-bottom: 1px solid var(--border) !important;
+  padding: 0 1rem;
+}
+
+::ng-deep .plant-create .mat-step-header {
+  background: transparent !important;
+}
+
+::ng-deep .plant-create .mat-step-header:hover {
+  background: var(--raised) !important;
+}
+
+::ng-deep .plant-create .mat-step-header .mat-step-label {
+  color: var(--text-muted) !important;
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.7rem !important;
+  letter-spacing: 0.04em !important;
+  text-transform: uppercase !important;
+}
+
+::ng-deep .plant-create .mat-step-header .mat-step-label.mat-step-label-active {
+  color: var(--text) !important;
+}
+
+::ng-deep .plant-create .mat-step-header .mat-step-icon {
+  background: var(--raised) !important;
+  color: var(--text-muted) !important;
+  border: 1px solid var(--border-mid) !important;
+}
+
+::ng-deep .plant-create .mat-step-header .mat-step-icon-selected,
+::ng-deep .plant-create .mat-step-header .mat-step-icon-state-done {
+  background: rgba(34, 211, 94, 0.15) !important;
+  color: var(--c-p) !important;
+  border-color: rgba(34, 211, 94, 0.4) !important;
+}
+
+::ng-deep .plant-create .mat-stepper-horizontal-line {
+  border-top-color: var(--border) !important;
+}
+
+::ng-deep .plant-create .mat-horizontal-content-container {
+  flex: 1;
+  overflow: auto;
+  padding: 0 !important;
+}
+
+/* ── Form Layout ─────────────────────────────────── */
+.create-form {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 2rem 10%;
+  min-height: 100%;
+  box-sizing: border-box;
 }
 
 .care-info,
@@ -34,4 +120,148 @@ form {
   .basic-info {
     width: 100%;
   }
+
+  .create-form {
+    padding: 1rem 1rem;
+  }
+}
+
+/* ── Material Form Field Overrides ───────────────── */
+::ng-deep .plant-create .mat-mdc-form-field {
+  width: 100%;
+}
+
+::ng-deep .plant-create .mat-mdc-text-field-wrapper {
+  background: var(--raised) !important;
+}
+
+::ng-deep .plant-create .mdc-notched-outline__leading,
+::ng-deep .plant-create .mdc-notched-outline__notch,
+::ng-deep .plant-create .mdc-notched-outline__trailing {
+  border-color: var(--border-mid) !important;
+}
+
+::ng-deep .plant-create .mat-mdc-form-field:hover .mdc-notched-outline__leading,
+::ng-deep .plant-create .mat-mdc-form-field:hover .mdc-notched-outline__notch,
+::ng-deep .plant-create .mat-mdc-form-field:hover .mdc-notched-outline__trailing {
+  border-color: rgba(255, 255, 255, 0.25) !important;
+}
+
+::ng-deep .plant-create .mat-mdc-form-field.mat-focused .mdc-notched-outline__leading,
+::ng-deep .plant-create .mat-mdc-form-field.mat-focused .mdc-notched-outline__notch,
+::ng-deep .plant-create .mat-mdc-form-field.mat-focused .mdc-notched-outline__trailing {
+  border-color: var(--c-a) !important;
+  border-width: 1px !important;
+}
+
+::ng-deep .plant-create .mat-mdc-form-field .mat-mdc-floating-label {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+}
+
+::ng-deep .plant-create .mat-mdc-form-field.mat-focused .mat-mdc-floating-label {
+  color: var(--c-a) !important;
+}
+
+::ng-deep .plant-create .mat-mdc-input-element {
+  color: var(--text) !important;
+  caret-color: var(--c-a) !important;
+}
+
+::ng-deep .plant-create .mat-mdc-select-value-text {
+  color: var(--text) !important;
+}
+
+::ng-deep .plant-create .mat-mdc-select-arrow {
+  color: var(--text-muted) !important;
+}
+
+::ng-deep .plant-create .mat-datepicker-toggle {
+  color: var(--text-muted) !important;
+}
+
+/* ── File Input ──────────────────────────────────── */
+.file-input {
+  background: var(--raised);
+  border: 1px solid var(--border-mid);
+  border-radius: 8px;
+  padding: 0.6rem 0.75rem;
+  color: var(--text);
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.85rem;
+  width: 75%;
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+
+.file-input:hover {
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.file-input::file-selector-button {
+  background: var(--surface);
+  border: 1px solid var(--border-mid);
+  border-radius: 6px;
+  color: var(--text-muted);
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.8rem;
+  padding: 0.25rem 0.75rem;
+  margin-right: 0.75rem;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.file-input::file-selector-button:hover {
+  border-color: var(--c-p);
+  color: var(--c-p);
+}
+
+/* ── Nav Buttons ─────────────────────────────────── */
+.form-nav {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  width: 75%;
+  padding-top: 0.25rem;
+}
+
+@media (max-width: 480px) {
+  .form-nav { width: 100%; }
+  .file-input { width: 100%; }
+}
+
+.btn-nav {
+  background: transparent !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 8px !important;
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.8rem !important;
+  letter-spacing: 0.04em !important;
+  padding: 0.4rem 1.1rem !important;
+  min-width: 80px !important;
+  transition: border-color 0.2s, color 0.2s, box-shadow 0.2s !important;
+}
+
+.btn-nav:hover {
+  border-color: rgba(255, 255, 255, 0.3) !important;
+  color: var(--text) !important;
+}
+
+.btn-nav--primary {
+  border-color: rgba(34, 211, 94, 0.4) !important;
+  color: var(--c-p) !important;
+}
+
+.btn-nav--primary:hover {
+  border-color: var(--c-p) !important;
+  box-shadow: 0 0 14px rgba(34, 211, 94, 0.2) !important;
+  color: var(--c-p) !important;
+}
+
+.btn-nav--primary:disabled {
+  border-color: var(--border) !important;
+  color: var(--text-dim) !important;
+  box-shadow: none !important;
+  cursor: not-allowed !important;
 }

--- a/src/app/plants/components/plant-create/plant-create.component.html
+++ b/src/app/plants/components/plant-create/plant-create.component.html
@@ -1,112 +1,114 @@
-<mat-horizontal-stepper linear>
+<div class="plant-create">
+  <mat-horizontal-stepper linear>
 
-  <mat-step [stepControl]="basicInfoForm">
-    <form [formGroup]="basicInfoForm">
-      <ng-template matStepLabel>
-        <ng-container *ngIf="!isSmallScreen">Basic Info</ng-container>
-      </ng-template>
+    <mat-step [stepControl]="basicInfoForm">
+      <form [formGroup]="basicInfoForm" class="create-form">
+        <ng-template matStepLabel>
+          <ng-container *ngIf="!isSmallScreen">Basic Info</ng-container>
+        </ng-template>
 
-      <div class="row basic-info">
-        <mat-form-field appearance="fill" class="col">
-          <mat-label>Name</mat-label>
-          <input matInput formControlName="name" required>
+        <div class="row basic-info">
+          <mat-form-field appearance="outline" class="col">
+            <mat-label>Name</mat-label>
+            <input matInput formControlName="name" required>
+          </mat-form-field>
+
+          <mat-form-field appearance="outline" class="col">
+            <mat-label>Species</mat-label>
+            <input matInput formControlName="species" required>
+          </mat-form-field>
+        </div>
+
+        <div class="row basic-info">
+          <mat-form-field appearance="outline">
+            <mat-label>Description</mat-label>
+            <textarea matInput formControlName="description" rows="10"></textarea>
+          </mat-form-field>
+        </div>
+
+        <div class="form-nav">
+          <button mat-button matStepperNext class="btn-nav btn-nav--primary" [disabled]="!basicInfoForm.valid">Next</button>
+        </div>
+      </form>
+    </mat-step>
+
+    <mat-step [stepControl]="locationForm">
+      <form [formGroup]="locationForm" class="create-form">
+        <ng-template matStepLabel>
+          <ng-container *ngIf="!isSmallScreen">Location</ng-container>
+        </ng-template>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Location</mat-label>
+          <mat-select formControlName="location" required>
+            <mat-option *ngFor="let loc of plantLocationOptions" [value]="loc">
+              {{ loc }}
+            </mat-option>
+          </mat-select>
         </mat-form-field>
 
-        <mat-form-field appearance="fill" class="col">
-          <mat-label>Species</mat-label>
-          <input matInput formControlName="species" required>
-        </mat-form-field>
-      </div>
+        <div class="form-nav">
+          <button mat-button matStepperPrevious class="btn-nav">Back</button>
+          <button mat-button matStepperNext class="btn-nav btn-nav--primary" [disabled]="!locationForm.valid">Next</button>
+        </div>
+      </form>
+    </mat-step>
 
-      <div class="row basic-info">
-        <mat-form-field appearance="fill">
-          <mat-label>Description</mat-label>
-          <textarea matInput formControlName="description" rows="10"></textarea>
-        </mat-form-field>
-      </div>
+    <mat-step [stepControl]="careForm">
+      <form [formGroup]="careForm" class="create-form">
+        <ng-template matStepLabel>
+          <ng-container *ngIf="!isSmallScreen">Care Details</ng-container>
+        </ng-template>
 
-      <div>
-        <button mat-button matStepperNext [disabled]="!basicInfoForm.valid">Next</button>
-      </div>
-    </form>
-  </mat-step>
+        <div class="row care-info">
+          <mat-form-field appearance="outline" class="col">
+            <mat-label>Watering Frequency (days)</mat-label>
+            <input matInput type="number" formControlName="wateringFrequency" required>
+          </mat-form-field>
 
-  <mat-step [stepControl]="locationForm">
-    <form [formGroup]="locationForm">
-      <ng-template matStepLabel>
-        <ng-container *ngIf="!isSmallScreen">Location</ng-container>
-      </ng-template>
+          <mat-form-field appearance="outline" class="col">
+            <mat-label>Last Watered Date</mat-label>
+            <input matInput [matDatepicker]="picker" formControlName="lastWateredDate" required>
+            <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
+            <mat-datepicker #picker></mat-datepicker>
+          </mat-form-field>
+        </div>
 
-      <mat-form-field appearance="fill">
-        <mat-label>Location</mat-label>
-        <mat-select formControlName="location" required>
-          <mat-option *ngFor="let loc of plantLocationOptions" [value]="loc">
-            {{ loc }}
-          </mat-option>
-        </mat-select>
-      </mat-form-field>
+        <div class="row care-info">
+          <mat-form-field appearance="outline" class="col">
+            <mat-label>Fertilizing Frequency (days)</mat-label>
+            <input matInput type="number" formControlName="fertilizingFrequency">
+          </mat-form-field>
+        </div>
 
-      <div>
-        <button mat-button matStepperPrevious>Back</button>
-        <button mat-button matStepperNext [disabled]="!locationForm.valid">Next</button>
-      </div>
-    </form>
-  </mat-step>
+        <div class="row care-info">
+          <mat-form-field appearance="outline">
+            <mat-label>Care Instructions</mat-label>
+            <textarea matInput formControlName="careInstructions" rows="10"></textarea>
+          </mat-form-field>
+        </div>
 
-  <mat-step [stepControl]="careForm">
-    <form [formGroup]="careForm">
-      <ng-template matStepLabel>
-        <ng-container *ngIf="!isSmallScreen">Care Details</ng-container>
-      </ng-template>
+        <div class="form-nav">
+          <button mat-button matStepperPrevious class="btn-nav">Back</button>
+          <button mat-button matStepperNext class="btn-nav btn-nav--primary" [disabled]="!careForm.valid">Next</button>
+        </div>
+      </form>
+    </mat-step>
 
-      <div class="row care-info">
-        <mat-form-field appearance="fill"  class="col">
-          <mat-label>Watering Frequency (days)</mat-label>
-          <input matInput type="number" formControlName="wateringFrequency" required>
-        </mat-form-field>
+    <mat-step [stepControl]="imageForm">
+      <form [formGroup]="imageForm" class="create-form">
+        <ng-template matStepLabel>
+          <ng-container *ngIf="!isSmallScreen">Image</ng-container>
+        </ng-template>
 
-        <mat-form-field appearance="fill" class="col">
-          <mat-label>Last Watered Date</mat-label>
-          <input matInput [matDatepicker]="picker" formControlName="lastWateredDate" required>
-          <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
-          <mat-datepicker #picker></mat-datepicker>
-        </mat-form-field>
-      </div>
+        <input type="file" class="file-input" (change)="onFileChange($event)">
 
-      <div class="row care-info">
-        <mat-form-field appearance="fill" class="col">
-          <mat-label>Fertilizing Frequency (days)</mat-label>
-          <input matInput type="number" formControlName="fertilizingFrequency">
-        </mat-form-field>
-      </div>
+        <div class="form-nav">
+          <button mat-button matStepperPrevious class="btn-nav">Back</button>
+          <button mat-button class="btn-nav btn-nav--primary" (click)="onSubmit()">Submit</button>
+        </div>
+      </form>
+    </mat-step>
 
-      <div class="row care-info">
-        <mat-form-field appearance="fill">
-          <mat-label>Care Instructions</mat-label>
-          <textarea matInput formControlName="careInstructions" rows="10"></textarea>
-        </mat-form-field>
-      </div>
-
-      <div>
-        <button mat-button matStepperPrevious>Back</button>
-        <button mat-button matStepperNext [disabled]="!careForm.valid">Next</button>
-      </div>
-    </form>
-  </mat-step>
-
-  <mat-step [stepControl]="imageForm">
-    <form [formGroup]="imageForm">
-      <ng-template matStepLabel>
-        <ng-container *ngIf="!isSmallScreen">Image</ng-container>
-      </ng-template>
-
-      <input type="file" (change)="onFileChange($event)">
-
-      <div>
-        <button mat-button matStepperPrevious>Back</button>
-        <button mat-button color="primary" (click)="onSubmit()">Submit</button>
-      </div>
-    </form>
-  </mat-step>
-
-</mat-horizontal-stepper>
+  </mat-horizontal-stepper>
+</div>

--- a/src/app/plants/components/plant-edit/plant-edit.component.css
+++ b/src/app/plants/components/plant-edit/plant-edit.component.css
@@ -1,108 +1,277 @@
-h2 {
-  margin: 0;
+:host {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--bg);
+  background-image:
+    radial-gradient(ellipse 80% 50% at 20% 20%, rgba(34,211,94,0.06) 0%, transparent 60%),
+    radial-gradient(ellipse 60% 40% at 80% 80%, rgba(77,166,255,0.04) 0%, transparent 50%);
+  overflow: hidden;
 }
 
-mat-label {
-  font-weight: bold;
+.plant-edit {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  animation: fadeUp 0.35s ease both;
 }
 
-mat-select,
-input,
-span {
-  padding: 6px;
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
-textarea {
-  resize: none;
-}
-
-.meta {
-  border: 1px solid #ccc;
-  border-radius: 10px;
-  text-align: center;
-  transition: box-shadow 0.3s ease;
+/* Header */
+.edit-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 20px;
+  height: 52px;
+  flex-shrink: 0;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
 }
 
 .plant-name {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
 }
 
-.description-care-container {
-  flex: 1 0 0;
-  overflow: auto;
+.header-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
 }
 
-.description-care-container-edit {
-  flex: 1 0 0;
+.icon-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all 0.2s ease;
 }
 
-.description-container,
-.care-container {
+.icon-btn:hover {
+  border-color: var(--border-mid);
+  color: var(--text);
+  background: rgba(255,255,255,0.04);
+}
+
+.icon-btn.save-btn {
+  color: var(--c-p);
+  border-color: rgba(34,211,94,0.3);
+}
+
+.icon-btn.save-btn:hover {
+  background: var(--cg-p);
+  box-shadow: 0 0 12px rgba(34,211,94,0.2);
+}
+
+.icon-btn.toggle-btn.active {
+  color: var(--c-e);
+  border-color: rgba(251,113,133,0.3);
+}
+
+.icon-btn.toggle-btn.active:hover {
+  background: var(--cg-e);
+}
+
+/* Body */
+.edit-body {
+  display: grid;
+  grid-template-columns: 1fr 1.4fr;
+  gap: 16px;
+  padding: 16px;
+  flex: 1;
+  overflow: hidden;
+}
+
+/* Image panel */
+.image-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.plant-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.file-form {
+  padding: 20px;
   display: flex;
   flex-direction: column;
-  overflow: auto;
-  padding: 0 0 5px 0;
-  flex: 1 0 auto;
+  gap: 8px;
 }
 
-.text-container {
-  border: 1px solid #ccc;
-  border-radius: 10px;
-  text-align: center;
-  padding-left: 5px;
-  padding-right: 5px;
-  overflow: auto;
-  flex: 1 0 0;
+.file-form input[type="file"] {
+  color: var(--text-muted);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
 }
 
-.care-instruction,
-.description {
-  text-align: left;
+/* Details panel */
+.details-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  overflow: auto;
+  transition: border-left-color 0.2s ease;
+}
+
+.details-panel.edit-mode {
+  border-left: 2px solid var(--c-p);
+}
+
+/* Text fields (description + care) */
+.text-fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+/* Meta grid */
+.meta-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+/* Field group */
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.field-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+}
+
+.field-value {
+  background: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 0.82rem;
+  color: var(--text);
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.field-text {
   white-space: pre-wrap;
+  min-height: 80px;
+  max-height: 180px;
+  overflow-y: auto;
+  text-align: left;
+  font-family: 'Outfit', sans-serif;
 }
 
-.last-watered-edit,
-.last-fertilized-edit {
-  border: 1px solid #ccc;
-  border-radius: 10px;
-  text-align: center;
+.field-input {
+  background: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 0.82rem;
+  color: var(--text);
+  font-family: 'Outfit', sans-serif;
   width: 100%;
-  transition: box-shadow 0.3s ease;
+  box-sizing: border-box;
+  outline: none;
+  transition: border-color 0.2s ease;
+  resize: none;
 }
 
-.img-container {
-  overflow: auto;
-  flex: 1 1 0;
+.field-input:focus {
+  border-color: var(--c-a);
+  box-shadow: 0 0 0 2px rgba(77,166,255,0.1);
 }
 
-.img {
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
-  flex: 1 1 auto;
+textarea.field-input {
+  min-height: 100px;
+  resize: vertical;
 }
 
-.save-button {
-  margin-right: 4px;
+/* Date input */
+.date-input-wrap {
+  display: flex;
+  align-items: center;
+  background: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
 }
 
-@media (max-width: 480px) {
-  .description-care-container {
-    flex: 1 0 auto;
+.date-input-wrap .field-input {
+  border: none;
+  background: transparent;
+  flex: 1;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.date-input-wrap .field-input:focus {
+  box-shadow: none;
+}
+
+/* Mat-select in dark theme */
+.field-select {
+  background: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 10px;
+}
+
+::ng-deep .field-select .mat-mdc-select-value {
+  color: var(--text);
+  font-size: 0.82rem;
+  font-family: 'Outfit', sans-serif;
+}
+
+::ng-deep .field-select .mat-mdc-select-arrow {
+  color: var(--text-muted);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .edit-body {
+    grid-template-columns: 1fr;
+    overflow-y: auto;
   }
 
-  .img-container {
-    overflow: auto;
-    flex: 1 1 auto;
+  .image-panel {
+    min-height: 200px;
   }
 
-  .text-container {
-    border: 1px solid #ccc;
-    border-radius: 10px;
-    text-align: center;
-    padding-left: 5px;
-    padding-right: 5px;
-    overflow: auto;
-    flex: 1 0 auto;
+  .text-fields {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/app/plants/components/plant-edit/plant-edit.component.html
+++ b/src/app/plants/components/plant-edit/plant-edit.component.html
@@ -1,127 +1,102 @@
-<div class="container-fluid h-100 d-flex flex-column">
+<div class="plant-edit" [class.edit-mode]="isEditMode">
 
-  <!--  Header-->
-  <div class="row py-1">
-    <div class="col-10">
-      <h2 class="plant-name">{{ plant?.name }}</h2>
-    </div>
-    <div class="col-2 d-flex justify-content-end align-items-center p-0">
+  <!-- Header -->
+  <header class="edit-header">
+    <span class="plant-name">{{ plant?.name }}</span>
+    <div class="header-actions">
       <ng-container *ngIf="isEditMode">
-        <button mat-mini-fab (click)="saveChanges()" class="save-button">
+        <button class="icon-btn save-btn" (click)="saveChanges()">
           <mat-icon>download_done</mat-icon>
         </button>
       </ng-container>
-      <button mat-mini-fab (click)="toggleEditMode()">
-        <mat-icon *ngIf="!isEditMode;else editIconButton">construction</mat-icon>
+      <button class="icon-btn toggle-btn" [class.active]="isEditMode" (click)="toggleEditMode()">
+        <mat-icon *ngIf="!isEditMode; else editIconButton">construction</mat-icon>
         <ng-template #editIconButton>
           <mat-icon>close</mat-icon>
         </ng-template>
       </button>
     </div>
-  </div>
+  </header>
 
-  <!--  Content-->
-  <div class="row-md d-flex flex-column flex-md-row flex-grow-1 gap-md-5">
+  <!-- Body -->
+  <div class="edit-body">
 
-    <!--    Image-->
-    <div class="col-md d-flex flex-column justify-content-center pb-3">
-      <div class="d-flex flex-column img-container">
-        <ng-container *ngIf="!isEditMode; else editImage">
-          <img *ngIf="plant?.image && imageUrl" [src]="imageUrl" alt="Plant image" class="img-fluid img rounded-3"/>
-        </ng-container>
-        <ng-template #editImage>
-          <form>
-            <input type="file" (change)="onFileSelected($event)" required/>
-          </form>
-        </ng-template>
-      </div>
+    <!-- Image -->
+    <div class="image-panel">
+      <ng-container *ngIf="!isEditMode; else editImage">
+        <img *ngIf="plant?.image && imageUrl" [src]="imageUrl" alt="Plant image" class="plant-img"/>
+      </ng-container>
+      <ng-template #editImage>
+        <form class="file-form">
+          <input type="file" (change)="onFileSelected($event)"/>
+        </form>
+      </ng-template>
     </div>
 
-    <!--    Infos-->
-    <div
-      *ngIf="plant"
-      class="col-md d-flex flex-column pb-3"
-      [ngClass]="{'bg-info': isEditMode}"
-    >
-      <div
-        class="d-flex flex-column flex-grow-1"
-        [ngClass]="{
-          'description-care-container-edit': isEditMode,
-          'description-care-container': !isEditMode
-          }"
-      >
+    <!-- Details -->
+    <div *ngIf="plant" class="details-panel" [class.edit-mode]="isEditMode">
 
-        <div class="description-container">
-          <mat-label>Description</mat-label>
-          <div class="text-container">
-            <div *ngIf="!isEditMode; else editDescription" class="description">{{ plant.description }}</div>
-          </div>
+      <div class="text-fields">
+
+        <div class="field-group">
+          <span class="field-label">Description</span>
+          <div *ngIf="!isEditMode; else editDescription" class="field-value field-text">{{ plant.description }}</div>
           <ng-template #editDescription>
             <ng-container *ngIf="tempPlant">
-              <textarea [(ngModel)]="tempPlant.description" class="text-start" rows="6" cols="80"></textarea>
+              <textarea [(ngModel)]="tempPlant.description" rows="5" class="field-input"></textarea>
             </ng-container>
           </ng-template>
         </div>
 
-        <div class="care-container">
-          <mat-label>Care instructions</mat-label>
-          <div class="text-container">
-            <div
-              *ngIf="!isEditMode; else editCareInstructions"
-              class="care-instruction"
-            >{{ plant.careInstructions }}</div>
-          </div>
+        <div class="field-group">
+          <span class="field-label">Care instructions</span>
+          <div *ngIf="!isEditMode; else editCareInstructions" class="field-value field-text">{{ plant.careInstructions }}</div>
           <ng-template #editCareInstructions>
             <ng-container *ngIf="tempPlant">
-              <textarea [(ngModel)]="tempPlant.careInstructions" class="text-start" rows="6" cols="80"></textarea>
+              <textarea [(ngModel)]="tempPlant.careInstructions" rows="5" class="field-input"></textarea>
             </ng-container>
           </ng-template>
         </div>
+
       </div>
 
-      <div class="d-flex flex-column flex-md-row gap-1">
+      <div class="meta-grid">
 
-        <div class="w-100 d-flex flex-column">
-          <mat-label>Species</mat-label>
+        <div class="field-group">
+          <span class="field-label">Species</span>
           <ng-container *ngIf="!isEditMode; else editSpecies">
-            <span class="meta species">{{ plant.species }}</span>
+            <span class="field-value">{{ plant.species }}</span>
           </ng-container>
           <ng-template #editSpecies>
             <ng-container *ngIf="tempPlant">
-              <input [(ngModel)]="tempPlant.species" class="meta species"/>
+              <input [(ngModel)]="tempPlant.species" class="field-input"/>
             </ng-container>
           </ng-template>
         </div>
 
-        <div class="w-100 d-flex flex-column">
-          <mat-label>Room</mat-label>
+        <div class="field-group">
+          <span class="field-label">Room</span>
           <ng-container *ngIf="!isEditMode; else editLocation">
-            <span class="meta location">{{ plant.location }}</span>
+            <span class="field-value">{{ plant.location }}</span>
           </ng-container>
           <ng-template #editLocation>
             <ng-container *ngIf="tempPlant">
-              <mat-select [(ngModel)]="tempPlant.location" class="meta location">
-                <mat-option *ngFor="let loc of plantLocationOptions" [value]="loc">
-                  {{ loc }}
-                </mat-option>
+              <mat-select [(ngModel)]="tempPlant.location" class="field-select">
+                <mat-option *ngFor="let loc of plantLocationOptions" [value]="loc">{{ loc }}</mat-option>
               </mat-select>
             </ng-container>
           </ng-template>
         </div>
-      </div>
 
-      <div class="d-flex flex-column flex-md-row gap-1">
-
-        <div class="col w-100 d-flex flex-column">
-          <mat-label>Last watered</mat-label>
+        <div class="field-group">
+          <span class="field-label">Last watered</span>
           <ng-container *ngIf="!isEditMode; else editLastWatered">
-            <span class="meta last-watered">{{ plant.lastWateredDate }}</span>
+            <span class="field-value">{{ plant.lastWateredDate }}</span>
           </ng-container>
           <ng-template #editLastWatered>
             <ng-container *ngIf="tempPlant">
-              <div class="w-100 d-flex align-items-center">
-                <input matInput [matDatepicker]="picker" [(ngModel)]="tmpLastWatered"
-                       class="last-watered-edit"/>
+              <div class="date-input-wrap">
+                <input matInput [matDatepicker]="picker" [(ngModel)]="tmpLastWatered" class="field-input"/>
                 <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
                 <mat-datepicker #picker></mat-datepicker>
               </div>
@@ -129,31 +104,27 @@
           </ng-template>
         </div>
 
-        <div class="col w-100 d-flex flex-column">
-          <mat-label>Watering frequency</mat-label>
+        <div class="field-group">
+          <span class="field-label">Watering frequency</span>
           <ng-container *ngIf="!isEditMode; else editWateringFrequency">
-            <span class="meta watering-frequency">{{ plant.wateringFrequency }}</span>
+            <span class="field-value">{{ plant.wateringFrequency }}</span>
           </ng-container>
           <ng-template #editWateringFrequency>
             <ng-container *ngIf="tempPlant">
-              <input [(ngModel)]="tempPlant.wateringFrequency" class="meta watering-frequency"/>
+              <input [(ngModel)]="tempPlant.wateringFrequency" class="field-input"/>
             </ng-container>
           </ng-template>
         </div>
-      </div>
 
-      <div class="d-flex flex-column flex-md-row gap-1">
-
-        <div class="col w-100 d-flex flex-column">
-          <mat-label>Last fertilized</mat-label>
+        <div class="field-group">
+          <span class="field-label">Last fertilized</span>
           <ng-container *ngIf="!isEditMode; else editLastFertilized">
-            <span class="meta last-fertilized">{{ plant.lastFertilizedDate ?? '-' }}</span>
+            <span class="field-value">{{ plant.lastFertilizedDate ?? '-' }}</span>
           </ng-container>
           <ng-template #editLastFertilized>
             <ng-container *ngIf="tempPlant">
-              <div class="w-100 d-flex align-items-center">
-                <input matInput [matDatepicker]="fertilizedPicker" [(ngModel)]="tmpLastFertilized"
-                       class="last-fertilized-edit"/>
+              <div class="date-input-wrap">
+                <input matInput [matDatepicker]="fertilizedPicker" [(ngModel)]="tmpLastFertilized" class="field-input"/>
                 <mat-datepicker-toggle matIconSuffix [for]="fertilizedPicker"></mat-datepicker-toggle>
                 <mat-datepicker #fertilizedPicker></mat-datepicker>
               </div>
@@ -161,19 +132,19 @@
           </ng-template>
         </div>
 
-        <div class="col w-100 d-flex flex-column">
-          <mat-label>Fertilizing frequency</mat-label>
+        <div class="field-group">
+          <span class="field-label">Fertilizing frequency</span>
           <ng-container *ngIf="!isEditMode; else editFertilizingFrequency">
-            <span class="meta fertilizing-frequency">{{ plant.fertilizingFrequency ?? '-' }}</span>
+            <span class="field-value">{{ plant.fertilizingFrequency ?? '-' }}</span>
           </ng-container>
           <ng-template #editFertilizingFrequency>
             <ng-container *ngIf="tempPlant">
-              <input [(ngModel)]="tempPlant.fertilizingFrequency" class="meta fertilizing-frequency"/>
+              <input [(ngModel)]="tempPlant.fertilizingFrequency" class="field-input"/>
             </ng-container>
           </ng-template>
         </div>
-      </div>
 
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/plants/components/plant-gallery/plant-gallery.component.css
+++ b/src/app/plants/components/plant-gallery/plant-gallery.component.css
@@ -1,27 +1,156 @@
-.mat-mdc-card-image {
-  height: 35%;
-  border-radius: 10px;
-  margin: 5px;
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(16px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
-.sub-header {
-  padding-top: 1px;
+:host {
+  display: block;
+  height: 100%;
+  overflow: hidden;
 }
 
-.plant-link {
+.gallery {
+  height: 100%;
+  overflow-y: auto;
+  padding: 24px;
+}
+
+.gallery__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 20px;
+  align-items: start;
+}
+
+/* Plant card */
+.plant-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  opacity: 0;
+  animation: fadeUp 0.45s ease forwards;
+}
+
+.plant-card--water {
+  border-left: 3px solid var(--c-e);
+  background: linear-gradient(135deg, rgba(251,113,133,0.05) 0%, var(--surface) 40%);
+}
+
+.plant-card--fertilize {
+  border-left: 3px solid var(--c-v);
+  background: linear-gradient(135deg, rgba(251,191,36,0.05) 0%, var(--surface) 40%);
+}
+
+/* Header */
+.plant-card__header {
+  padding: 14px 16px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.plant-card__name {
+  font-family: 'Outfit', sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.plant-card__name:hover {
+  color: var(--c-p);
+}
+
+.plant-card__species {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+}
+
+/* Image */
+.plant-card__image {
+  height: 180px;
+  overflow: hidden;
+}
+
+.plant-card__image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+/* Info grid */
+.plant-card__info {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  padding: 12px 14px;
+  flex: 1;
+}
+
+.info-tile {
+  background: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.info-tile--full {
+  grid-column: 1 / -1;
+}
+
+.info-tile__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.55rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+}
+
+.info-tile__value {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.68rem;
+  color: var(--text);
+}
+
+/* Actions */
+.plant-card__actions {
+  display: flex;
+  gap: 8px;
+  padding: 10px 14px 14px;
+  border-top: 1px solid var(--border);
+}
+
+.action-btn {
+  flex: 1;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-muted);
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.8rem;
+  padding: 7px 12px;
   cursor: pointer;
+  transition: color 0.2s, border-color 0.2s, background 0.2s;
 }
 
-.plant-link:hover {
-  text-decoration: underline;
+.action-btn--water:hover {
+  color: var(--c-a);
+  border-color: var(--c-a);
+  background: rgba(77,166,255,0.08);
 }
 
-.info-card {
-  scroll-snap-align: start;
-}
-
-@media (max-width: 480px) {
-  .info-card {
-    flex: 0 0 100%;
-  }
+.action-btn--fertilize:hover {
+  color: var(--c-v);
+  border-color: var(--c-v);
+  background: rgba(251,191,36,0.08);
 }

--- a/src/app/plants/components/plant-gallery/plant-gallery.component.html
+++ b/src/app/plants/components/plant-gallery/plant-gallery.component.html
@@ -1,72 +1,44 @@
-<div class="container-fluid h-100 d-flex justify-content-center align-items-center">
-  <div class="row w-100 h-100 overflow-auto d-flex justify-content-center">
-    <div *ngFor="let plant of plants()" class="col-sm-12 col-md-6 col-xl-4 h-100 p-2">
-      <mat-card appearance="outlined" class="h-100" [ngClass]="{ 'bg-danger': isWateringDue(plant), 'bg-success': !isWateringDue(plant) && isFertilizingDue(plant) }">
-        <mat-card-header>
-          <mat-card-title routerLink="/plant-root/view/{{plant.id}}" class="plant-link">{{ plant.name }}
-          </mat-card-title>
-          <mat-card-subtitle>{{ plant.species }}</mat-card-subtitle>
-        </mat-card-header>
-        <img mat-card-image [src]="getImageUrl(plant)" alt="{{ plant.name }}">
-        <mat-card-content class="d-flex flex-column justify-content-center">
-          <div class="row g-2 mb-2">
-            <div class="col-6">
-              <mat-card appearance="outlined" class="d-flex flex-column align-items-center">
-                <mat-card-header class="sub-header">
-                  <mat-card-title class="fs-6">Last watered</mat-card-title>
-                </mat-card-header>
-                <mat-card-content class="pb-2">
-                  {{ plant.lastWateredDate }}
-                </mat-card-content>
-              </mat-card>
-            </div>
-            <div class="col-6">
-              <mat-card appearance="outlined" class="d-flex flex-column align-items-center">
-                <mat-card-header class="sub-header">
-                  <mat-card-title class="fs-6">Next watered</mat-card-title>
-                </mat-card-header>
-                <mat-card-content class="pb-2">
-                  {{ (plant?.nextWateredDate) ?? 'n/a' }}
-                </mat-card-content>
-              </mat-card>
-            </div>
+<div class="gallery">
+  <div class="gallery__grid">
+    @for (plant of plants(); track plant.id; let i = $index) {
+      <div class="plant-card"
+           [class.plant-card--water]="isWateringDue(plant)"
+           [class.plant-card--fertilize]="!isWateringDue(plant) && isFertilizingDue(plant)"
+           [style.animation-delay]="(i * 0.07) + 's'">
+        <div class="plant-card__header">
+          <a class="plant-card__name" routerLink="/plant-root/view/{{plant.id}}">{{ plant.name }}</a>
+          <span class="plant-card__species">{{ plant.species }}</span>
+        </div>
+        <div class="plant-card__image">
+          <img [src]="getImageUrl(plant)" alt="{{ plant.name }}">
+        </div>
+        <div class="plant-card__info">
+          <div class="info-tile">
+            <span class="info-tile__label">Last watered</span>
+            <span class="info-tile__value">{{ plant.lastWateredDate }}</span>
           </div>
-          <div class="row g-2 mb-2">
-            <div class="col-6">
-              <mat-card appearance="outlined" class="d-flex flex-column align-items-center">
-                <mat-card-header class="sub-header">
-                  <mat-card-title class="fs-6">Last fertilized</mat-card-title>
-                </mat-card-header>
-                <mat-card-content class="pb-2">
-                  {{ plant.lastFertilizedDate ?? 'n/a' }}
-                </mat-card-content>
-              </mat-card>
-            </div>
-            <div class="col-6">
-              <mat-card appearance="outlined" class="d-flex flex-column align-items-center">
-                <mat-card-header class="sub-header">
-                  <mat-card-title class="fs-6">Next fertilized</mat-card-title>
-                </mat-card-header>
-                <mat-card-content class="pb-2">
-                  {{ (plant?.nextFertilizedDate) ?? 'n/a' }}
-                </mat-card-content>
-              </mat-card>
-            </div>
+          <div class="info-tile">
+            <span class="info-tile__label">Next watered</span>
+            <span class="info-tile__value">{{ plant.nextWateredDate ?? 'n/a' }}</span>
           </div>
-          <div class="row g-2">
-            <div class="col-12">
-              <mat-card appearance="outlined" class="d-flex flex-row justify-content-center">
-                <span class="fs-6 me-1">Location:</span>
-                <span>{{ plant.location }}</span>
-              </mat-card>
-            </div>
+          <div class="info-tile">
+            <span class="info-tile__label">Last fertilized</span>
+            <span class="info-tile__value">{{ plant.lastFertilizedDate ?? 'n/a' }}</span>
           </div>
-        </mat-card-content>
-        <mat-card-actions class="d-flex justify-content-center py-sm-0 py-md-2">
-          <button mat-button (click)="setWateredNow(plant)">Watered</button>
-          <button mat-button (click)="setFertilizedNow(plant)">Fertilized</button>
-        </mat-card-actions>
-      </mat-card>
-    </div>
+          <div class="info-tile">
+            <span class="info-tile__label">Next fertilized</span>
+            <span class="info-tile__value">{{ plant.nextFertilizedDate ?? 'n/a' }}</span>
+          </div>
+          <div class="info-tile info-tile--full">
+            <span class="info-tile__label">Location</span>
+            <span class="info-tile__value">{{ plant.location }}</span>
+          </div>
+        </div>
+        <div class="plant-card__actions">
+          <button class="action-btn action-btn--water" (click)="setWateredNow(plant)">Watered</button>
+          <button class="action-btn action-btn--fertilize" (click)="setFertilizedNow(plant)">Fertilized</button>
+        </div>
+      </div>
+    }
   </div>
 </div>

--- a/src/app/plants/components/plant-gallery/plant-gallery.component.ts
+++ b/src/app/plants/components/plant-gallery/plant-gallery.component.ts
@@ -1,7 +1,6 @@
 import {Component, OnInit, signal} from '@angular/core';
-import {DatePipe, NgClass, NgForOf} from '@angular/common';
+import {DatePipe} from '@angular/common';
 import {MatButtonModule} from '@angular/material/button';
-import {MatCardModule} from '@angular/material/card';
 import {PlantService} from '../../services/plant.service';
 import {Plant} from '../../models/plant.model';
 import {MatSnackBar} from '@angular/material/snack-bar';
@@ -11,7 +10,7 @@ import {RouterLink} from '@angular/router';
 
 @Component({
   selector: 'app-plant-gallery',
-  imports: [MatCardModule, MatButtonModule, NgForOf, RouterLink, NgClass],
+  imports: [MatButtonModule, RouterLink],
   templateUrl: './plant-gallery.component.html',
   styleUrl: './plant-gallery.component.css',
   providers: [DatePipe]

--- a/src/app/plants/components/plant-home/plant-home.component.css
+++ b/src/app/plants/components/plant-home/plant-home.component.css
@@ -1,33 +1,184 @@
-.plant-card-container {
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+/* ── Design Tokens ───────────────────────────────── */
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-a:  #4da6ff;  --cg-a: rgba(77,  166, 255, 0.18);
+  --c-p:  #22d35e;  --cg-p: rgba(34,  211,  94, 0.18);
+  --c-v:  #fbbf24;  --cg-v: rgba(251, 191,  36, 0.18);
+  --c-m:  #a78bfa;  --cg-m: rgba(167, 139, 250, 0.18);
+  --c-e:  #fb7185;  --cg-e: rgba(251, 113, 133, 0.18);
+
+  display: block;
   height: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 15px;
-  padding: 15px;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
 }
 
-.plant-card {
-  width: 50%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: 15px;
-  flex: 1 0 0;
-  border: 1px solid #ccc;
-  border-radius: 10px;
-  text-align: center;
-  cursor: pointer;
-  transition: box-shadow 0.3s ease;
+/* ── Nav Grid ────────────────────────────────────── */
+.navgrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.75rem;
+  padding: 1rem;
+  max-width: 640px;
+  margin: 0 auto;
+  box-sizing: border-box;
 }
 
-.plant-card:hover {
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.15);
+@media (min-width: 640px) {
+  .navgrid { gap: 1rem; padding: 1.5rem; }
 }
 
-@media (max-width: 480px) {
-  .plant-card {
-    width: 90%;
+/* Last odd card: centered, not stretched */
+.navcard:last-child:nth-child(odd) {
+  grid-column: 1 / -1;
+  justify-self: center;
+  width: calc(50% - 0.375rem);
+}
+
+@media (min-width: 640px) {
+  .navcard:last-child:nth-child(odd) {
+    width: calc(50% - 0.5rem);
   }
 }
+
+/* ── Nav Cards ───────────────────────────────────── */
+.navcard {
+  position: relative;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.1rem 1rem 1.75rem;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  min-height: 140px;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
+  animation: fadeUp 0.5s ease both;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Radial glow overlay on hover */
+.navcard::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 0% 0%, var(--cc-glow, transparent) 0%, transparent 65%);
+  opacity: 0;
+  transition: opacity 0.25s;
+  pointer-events: none;
+}
+
+/* Left accent stripe */
+.navcard::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 22%;
+  bottom: 22%;
+  width: 2px;
+  background: var(--cc, transparent);
+  border-radius: 0 2px 2px 0;
+  opacity: 0.35;
+  transition: opacity 0.2s, top 0.2s, bottom 0.2s;
+}
+
+.navcard:hover {
+  border-color: var(--cc);
+  box-shadow: 0 8px 28px var(--cc-glow);
+  transform: translateY(-3px);
+}
+
+.navcard:hover::before { opacity: 1; }
+
+.navcard:hover::after {
+  opacity: 0.9;
+  top: 12%;
+  bottom: 12%;
+}
+
+.navcard:active { transform: translateY(-1px); }
+
+/* ── Card Accent Variants ────────────────────────── */
+.navcard--a { --cc: var(--c-a); --cc-glow: var(--cg-a); }
+.navcard--p { --cc: var(--c-p); --cc-glow: var(--cg-p); }
+.navcard--v { --cc: var(--c-v); --cc-glow: var(--cg-v); }
+
+/* ── Card Mark ───────────────────────────────────── */
+.navcard__mark {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--cc) 40%, transparent);
+  background: color-mix(in srgb, var(--cc) 10%, transparent);
+  display: grid;
+  place-items: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--cc);
+  flex-shrink: 0;
+  transition: background 0.2s;
+}
+
+.navcard:hover .navcard__mark {
+  background: color-mix(in srgb, var(--cc) 20%, transparent);
+}
+
+/* ── Card Text ───────────────────────────────────── */
+.navcard__title {
+  margin: 0;
+  font-size: clamp(0.95rem, 2.5vw, 1.1rem);
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1.25;
+  letter-spacing: 0.01em;
+}
+
+.navcard__sub {
+  margin: 0;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+  font-weight: 400;
+}
+
+/* ── Card Arrow ──────────────────────────────────── */
+.navcard__arrow {
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.875rem;
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  line-height: 1;
+  transition: color 0.2s, transform 0.2s;
+}
+
+.navcard:hover .navcard__arrow {
+  color: var(--cc);
+  transform: translate(2px, -2px);
+}
+
+/* ── Entrance Animations ─────────────────────────── */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.navcard:nth-child(1) { animation-delay: 0.05s; }
+.navcard:nth-child(2) { animation-delay: 0.12s; }
+.navcard:nth-child(3) { animation-delay: 0.19s; }

--- a/src/app/plants/components/plant-home/plant-home.component.html
+++ b/src/app/plants/components/plant-home/plant-home.component.html
@@ -1,14 +1,24 @@
-<div class="plant-card-container">
-  <div class="plant-card" routerLink="/plant-root/gallery">
-    <h2>Show</h2>
-    <span>Show the plants!</span>
-  </div>
-  <div class="plant-card" routerLink="/plant-root/management">
-    <h2>Edit</h2>
-    <span>List and edit the plants!</span>
-  </div>
-  <div class="plant-card" routerLink="/plant-root/create">
-    <h2>Create</h2>
-    <span>Create a plant!</span>
-  </div>
+<div class="navgrid">
+
+  <a class="navcard navcard--p" routerLink="/plant-root/gallery">
+    <div class="navcard__mark">S</div>
+    <h2 class="navcard__title">Show</h2>
+    <p class="navcard__sub">Show the plants!</p>
+    <span class="navcard__arrow" aria-hidden="true">↗</span>
+  </a>
+
+  <a class="navcard navcard--v" routerLink="/plant-root/management">
+    <div class="navcard__mark">E</div>
+    <h2 class="navcard__title">Edit</h2>
+    <p class="navcard__sub">List and edit the plants!</p>
+    <span class="navcard__arrow" aria-hidden="true">↗</span>
+  </a>
+
+  <a class="navcard navcard--a" routerLink="/plant-root/create">
+    <div class="navcard__mark">C</div>
+    <h2 class="navcard__title">Create</h2>
+    <p class="navcard__sub">Create a plant!</p>
+    <span class="navcard__arrow" aria-hidden="true">↗</span>
+  </a>
+
 </div>

--- a/src/app/plants/components/plant-layout/plant-layout.component.css
+++ b/src/app/plants/components/plant-layout/plant-layout.component.css
@@ -1,41 +1,126 @@
-.header-button {
-  height: 35px;
-  width: 35px;
-}
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
 
-.plant-layout-header-title {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-}
+/* ── Design Tokens ───────────────────────────────── */
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
 
-.plant-root-image {
-  background-image: url('../../../../../public/roomplants.jpg');
-  background-size: cover;
-  background-position: center;
-  color: white;
-}
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
 
-.header-row {
-  height: 10%;
-}
+  --c-a:  #4da6ff;  --cg-a: rgba(77,  166, 255, 0.18);
+  --c-p:  #22d35e;  --cg-p: rgba(34,  211,  94, 0.18);
+  --c-v:  #fbbf24;  --cg-v: rgba(251, 191,  36, 0.18);
+  --c-m:  #a78bfa;  --cg-m: rgba(167, 139, 250, 0.18);
+  --c-e:  #fb7185;  --cg-e: rgba(251, 113, 133, 0.18);
 
-.image-row {
-  height: 20%;
-}
-
-.data-row {
-  height: 70%;
-}
-
-.mat-mdc-menu-content {
   display: flex;
   flex-direction: column;
+  min-height: 100dvh;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+  background-color: var(--bg);
+  background-image:
+    radial-gradient(ellipse 70% 35% at 0% 0%,    rgba(34,  211,  94, 0.04) 0%, transparent 100%),
+    radial-gradient(ellipse 50% 35% at 100% 100%, rgba(77,  166, 255, 0.04) 0%, transparent 100%),
+    radial-gradient(circle, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+  background-size: auto, auto, 28px 28px;
 }
 
-@media (min-width: 480px) {
-  .header-button {
-    height: 50px;
-    width: 50px;
-  }
+/* ── Layout ──────────────────────────────────────── */
+.plant-layout {
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+}
+
+/* ── Topbar ──────────────────────────────────────── */
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: max(0.5rem, env(safe-area-inset-top)) max(1rem, env(safe-area-inset-right)) 0.5rem max(1rem, env(safe-area-inset-left));
+  background: rgba(6, 8, 14, 0.88);
+  border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  box-shadow: 0 1px 0 rgba(34, 211, 94, 0.06);
+}
+
+.topbar__left {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.topbar__right {
+  width: 80px;
+}
+
+.topbar__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  color: var(--text-muted);
+}
+
+.topbar__hex {
+  color: var(--c-p);
+  font-size: 0.9rem;
+  filter: drop-shadow(0 0 6px rgba(34, 211, 94, 0.5));
+}
+
+/* ── Nav Buttons ─────────────────────────────────── */
+.nav-btn {
+  color: var(--text-muted) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: 8px !important;
+  width: 36px !important;
+  height: 36px !important;
+  transition: color 0.2s, border-color 0.2s, box-shadow 0.2s !important;
+}
+
+.nav-btn:hover {
+  color: var(--c-p) !important;
+  border-color: var(--c-p) !important;
+  box-shadow: 0 0 10px rgba(34, 211, 94, 0.2) !important;
+}
+
+/* ── Content ─────────────────────────────────────── */
+.content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* ── Menu Panel ──────────────────────────────────── */
+::ng-deep .mat-mdc-menu-panel {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 8px !important;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5) !important;
+}
+
+::ng-deep .mat-mdc-menu-item {
+  color: var(--text) !important;
+  font-family: 'Outfit', sans-serif !important;
+}
+
+::ng-deep .mat-mdc-menu-item:hover .mdc-list-item__primary-text {
+  color: var(--c-p) !important;
+}
+
+::ng-deep .mat-mdc-menu-item:hover {
+  background: var(--raised) !important;
 }

--- a/src/app/plants/components/plant-layout/plant-layout.component.html
+++ b/src/app/plants/components/plant-layout/plant-layout.component.html
@@ -1,10 +1,10 @@
-<div class="container h-100 d-flex flex-column">
-  <header class="row header-row p-2">
-    <div class="col-4 col-sm-2 d-flex justify-content-between align-items-center">
-      <button mat-fab [routerLink]="homeLink" class="header-button">
+<div class="plant-layout">
+  <header class="topbar">
+    <div class="topbar__left">
+      <button mat-icon-button [routerLink]="homeLink" class="nav-btn" aria-label="Go home">
         <mat-icon>home</mat-icon>
       </button>
-      <button mat-fab [matMenuTriggerFor]="menu" class="header-button">
+      <button mat-icon-button [matMenuTriggerFor]="menu" class="nav-btn" aria-label="Open menu">
         <mat-icon>more_vert</mat-icon>
       </button>
       <mat-menu #menu="matMenu">
@@ -22,13 +22,16 @@
         </button>
       </mat-menu>
     </div>
-    <div class="col-8 col-sm-10 d-flex flex-column justify-content-center align-items-center">
-      <h1 class="plant-layout-header-title">Plants</h1>
+
+    <div class="topbar__brand">
+      <span class="topbar__hex">⬡</span>
+      <span class="topbar__name">PLANTS</span>
     </div>
+
+    <div class="topbar__right"></div>
   </header>
-  <main class="row data-row flex-grow-1">
-    <div class="col h-100">
-      <router-outlet></router-outlet>
-    </div>
+
+  <main class="content">
+    <router-outlet></router-outlet>
   </main>
 </div>

--- a/src/app/plants/components/plant-layout/plant-layout.component.ts
+++ b/src/app/plants/components/plant-layout/plant-layout.component.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {MatFabButton} from "@angular/material/button";
+import {MatIconButton} from "@angular/material/button";
 import {MatIcon} from "@angular/material/icon";
 import {ActivatedRoute, NavigationEnd, Router, RouterLink, RouterOutlet} from "@angular/router";
 import {filter} from 'rxjs';
@@ -8,7 +8,7 @@ import {MatMenu, MatMenuItem, MatMenuTrigger} from '@angular/material/menu';
 @Component({
   selector: 'app-plant-layout',
   imports: [
-    MatFabButton,
+    MatIconButton,
     MatIcon,
     RouterLink,
     RouterOutlet,

--- a/src/app/plants/components/plant-table/plant-table.component.css
+++ b/src/app/plants/components/plant-table/plant-table.component.css
@@ -1,36 +1,178 @@
-.table-container {
+:host {
+  display: block;
+  min-height: 100%;
+  background: var(--bg);
+  background-image:
+    radial-gradient(ellipse 80% 50% at 50% -10%, rgba(34, 211, 94, 0.06) 0%, transparent 70%),
+    radial-gradient(circle at 85% 85%, rgba(77, 166, 255, 0.04) 0%, transparent 50%);
+  background-attachment: fixed;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+  position: relative;
+}
+
+:host::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image: radial-gradient(circle, rgba(255,255,255,0.03) 1px, transparent 1px);
+  background-size: 28px 28px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.plant-table {
+  position: relative;
+  z-index: 1;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  padding: 2% 10% 0 10%;
-  position: relative; /* Required for positioning the preview */
-  max-height: 80vh;
-  overflow-y: auto;
+  padding: 2rem 4rem;
+  gap: 1rem;
 }
 
+/* Header */
+.table-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.table-header__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--c-p);
+  box-shadow: 0 0 6px var(--c-p);
+  animation: blink 2s ease-in-out infinite;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+.table-header__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+}
+
+/* Table container */
+.table-container {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  max-height: 75vh;
+  overflow-y: auto;
+  position: relative;
+}
+
+.table-container::-webkit-scrollbar {
+  width: 4px;
+}
+.table-container::-webkit-scrollbar-track {
+  background: var(--surface);
+}
+.table-container::-webkit-scrollbar-thumb {
+  background: var(--border-mid);
+  border-radius: 2px;
+}
+
+/* Material table overrides */
+table {
+  width: 100%;
+  background: transparent !important;
+}
+
+.col-header {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.6rem !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.12em !important;
+  text-transform: uppercase !important;
+  color: var(--text-dim) !important;
+  background: var(--raised) !important;
+  border-bottom: 1px solid var(--border-mid) !important;
+  height: 36px !important;
+  padding: 0 16px !important;
+}
+
+::ng-deep .mat-mdc-header-row {
+  background: var(--raised) !important;
+}
+
+::ng-deep .mat-mdc-cell {
+  font-size: 0.8rem !important;
+  color: var(--text) !important;
+  background: transparent !important;
+  border-bottom: 1px solid var(--border) !important;
+}
+
+/* Clickable rows */
 .clickable-row {
   cursor: pointer;
-  transition: background-color 0.3s ease, transform 0.2s ease, box-shadow 0.2s ease;
-
-  &:hover {
-    background-color: rgba(63, 81, 181, 0.1);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-    transform: scale(1.01);
-    z-index: 1;
-    position: relative;
-  }
+  transition: background-color 0.2s ease;
 }
 
+.clickable-row:hover {
+  background-color: rgba(34, 211, 94, 0.08) !important;
+}
+
+.clickable-row:hover ::ng-deep .mat-mdc-cell {
+  background-color: transparent !important;
+}
+
+/* Column widths */
 .mat-column-image,
 .mat-column-delete {
   width: 10%;
 }
 
-/* Preview container styles */
+/* Icon buttons */
+.icon-btn {
+  width: 32px !important;
+  height: 32px !important;
+  line-height: 32px !important;
+  border-radius: 8px !important;
+  border: 1px solid var(--border) !important;
+  background: transparent !important;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.icon-btn mat-icon {
+  font-size: 18px !important;
+  width: 18px !important;
+  height: 18px !important;
+}
+
+.icon-btn--blue mat-icon {
+  color: var(--c-a) !important;
+}
+
+.icon-btn--blue:hover {
+  background: rgba(77, 166, 255, 0.1) !important;
+  border-color: var(--c-a) !important;
+}
+
+.icon-btn--pink mat-icon {
+  color: var(--c-e) !important;
+}
+
+.icon-btn--pink:hover {
+  background: rgba(251, 113, 133, 0.1) !important;
+  border-color: var(--c-e) !important;
+}
+
+/* Preview container */
 .plant-preview-container {
   position: absolute;
   z-index: 1000;
-  pointer-events: auto; /* Enable interaction with the preview */
+  pointer-events: auto;
   animation: fadeInScale 0.2s ease-out;
 }
 

--- a/src/app/plants/components/plant-table/plant-table.component.html
+++ b/src/app/plants/components/plant-table/plant-table.component.html
@@ -1,52 +1,57 @@
-<div class="table-container">
-  <table mat-table [dataSource]="plants">
+<div class="plant-table">
+  <header class="table-header">
+    <span class="table-header__dot"></span>
+    <span class="table-header__label">MANAGEMENT</span>
+  </header>
 
-    <ng-container matColumnDef="name">
-      <th mat-header-cell *matHeaderCellDef>Name</th>
-      <td mat-cell *matCellDef="let plant">{{ plant.name }}</td>
-    </ng-container>
+  <div class="table-container">
+    <table mat-table [dataSource]="plants">
 
-    <ng-container matColumnDef="species">
-      <th mat-header-cell *matHeaderCellDef>Species</th>
-      <td mat-cell *matCellDef="let plant">{{ plant.species }}</td>
-    </ng-container>
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef class="col-header">Name</th>
+        <td mat-cell *matCellDef="let plant">{{ plant.name }}</td>
+      </ng-container>
 
-    <ng-container matColumnDef="image">
-      <th mat-header-cell *matHeaderCellDef>Image</th>
-      <td mat-cell *matCellDef="let plant">
-        @if (plant.image) {
-          <div>
-            <button mat-icon-button (click)="openImageDialog(plant); $event.stopPropagation()">
+      <ng-container matColumnDef="species">
+        <th mat-header-cell *matHeaderCellDef class="col-header">Species</th>
+        <td mat-cell *matCellDef="let plant">{{ plant.species }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="image">
+        <th mat-header-cell *matHeaderCellDef class="col-header">Image</th>
+        <td mat-cell *matCellDef="let plant">
+          @if (plant.image) {
+            <button class="icon-btn icon-btn--blue" mat-icon-button (click)="openImageDialog(plant); $event.stopPropagation()">
               <mat-icon>image</mat-icon>
             </button>
-          </div>
-        } @else {
-          <button mat-icon-button (click)="openCreateImageDialog(plant); $event.stopPropagation()">
-            <mat-icon fontIcon="broken_image"></mat-icon>
+          } @else {
+            <button class="icon-btn icon-btn--blue" mat-icon-button (click)="openCreateImageDialog(plant); $event.stopPropagation()">
+              <mat-icon fontIcon="broken_image"></mat-icon>
+            </button>
+          }
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="delete">
+        <th mat-header-cell *matHeaderCellDef class="col-header">Delete</th>
+        <td mat-cell *matCellDef="let plant">
+          <button class="icon-btn icon-btn--pink" mat-icon-button (click)="openDeletePlantDialog(plant); $event.stopPropagation()">
+            <mat-icon>delete</mat-icon>
           </button>
-        }
-      </td>
-    </ng-container>
+        </td>
+      </ng-container>
 
-    <ng-container matColumnDef="delete">
-      <th mat-header-cell *matHeaderCellDef>Delete</th>
-      <td mat-cell *matCellDef="let plant">
-        <button mat-icon-button (click)="openDeletePlantDialog(plant); $event.stopPropagation()">
-          <mat-icon>delete</mat-icon>
-        </button>
-      </td>
-    </ng-container>
+      <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
+      <tr
+        mat-row *matRowDef="let plant; columns: columnsToDisplay;"
+        class="clickable-row"
+        (click)="navigateToPlant(plant.id)"
+        (mouseenter)="showPlantPreview(plant, $event)"
+        (mouseleave)="hidePlantPreview()">
+      </tr>
 
-    <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
-    <tr
-      mat-row *matRowDef="let plant; columns: columnsToDisplay;"
-      class="clickable-row"
-      (click)="navigateToPlant(plant.id)"
-      (mouseenter)="showPlantPreview(plant, $event)"
-      (mouseleave)="hidePlantPreview()">
-    </tr>
-
-  </table>
+    </table>
+  </div>
 
   <!-- Plant Preview Container -->
   @if (previewVisible) {

--- a/src/app/plants/components/plant-view/plant-view.component.css
+++ b/src/app/plants/components/plant-view/plant-view.component.css
@@ -1,18 +1,167 @@
-img {
-  height: 400px;
+:host {
+  display: block;
+  min-height: 100%;
+  background: var(--bg);
+  background-image:
+    radial-gradient(ellipse 80% 50% at 50% -10%, rgba(34, 211, 94, 0.06) 0%, transparent 70%),
+    radial-gradient(circle at 85% 85%, rgba(77, 166, 255, 0.04) 0%, transparent 50%);
+  background-attachment: fixed;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+  position: relative;
 }
 
-span {
+:host::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image: radial-gradient(circle, rgba(255,255,255,0.03) 1px, transparent 1px);
+  background-size: 28px 28px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.plant-view {
+  position: relative;
+  z-index: 1;
+  padding: 2rem 4rem;
+}
+
+/* Card */
+.view-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  animation: fadeUp 0.4s ease both;
+}
+
+@keyframes fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Header */
+.view-card__header {
   display: flex;
-  flex: 1 1 0;
+  align-items: center;
+  justify-content: center;
+  padding: 1.25rem 2rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--raised);
+}
+
+.view-card__name {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: 0.04em;
+}
+
+/* Body */
+.view-card__body {
+  display: grid;
+  grid-template-columns: 2fr 3fr;
+  gap: 0;
+}
+
+/* Image column */
+.view-card__image-col {
+  border-right: 1px solid var(--border);
+  padding: 1.5rem;
+  display: flex;
+  align-items: flex-start;
   justify-content: center;
 }
 
-.plant-card-header {
-  height: 10%;
+.view-card__img {
+  width: 100%;
+  max-height: 400px;
+  object-fit: cover;
+  border-radius: 8px;
 }
 
-.care-instructions,
-.description {
+/* Detail column */
+.view-card__detail-col {
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem;
+  gap: 1.25rem;
+}
+
+/* Info badges */
+.info-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.info-badge {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  background: var(--raised);
+  border: 1px solid var(--border-mid);
+  border-radius: 6px;
+  padding: 0.4rem 0.75rem;
+  flex: 1 1 120px;
+}
+
+.info-badge__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.55rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.info-badge__value {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.78rem;
+  color: var(--text);
+}
+
+/* Tabs */
+::ng-deep .view-tabs .mat-mdc-tab-label-container {
+  background: transparent !important;
+  border-bottom: 1px solid var(--border) !important;
+}
+
+::ng-deep .view-tabs .mat-mdc-tab .mdc-tab__text-label {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.85rem !important;
+}
+
+::ng-deep .view-tabs .mat-mdc-tab.mdc-tab--active .mdc-tab__text-label {
+  color: var(--c-p) !important;
+}
+
+::ng-deep .view-tabs .mdc-tab-indicator__content--underline {
+  border-color: var(--c-p) !important;
+}
+
+::ng-deep .view-tabs .mat-mdc-tab-body-wrapper {
+  background: transparent !important;
+}
+
+.tab-content {
+  background: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1rem;
+  margin-top: 0.75rem;
+  color: var(--text);
+  font-size: 0.875rem;
+  line-height: 1.6;
   white-space: pre-wrap;
+  min-height: 80px;
 }

--- a/src/app/plants/components/plant-view/plant-view.component.html
+++ b/src/app/plants/components/plant-view/plant-view.component.html
@@ -1,42 +1,41 @@
-<div class="container h-100 pt-2">
-  <mat-card appearance="raised" *ngIf="plant"
-            class="d-flex flex-column align-items-center plant-card h-100 overflow-auto">
-    <mat-card-header class="d-flex justify-content-center align-items-center py-2 plant-card-header">
-      <mat-card-title class="fs-1">{{ plant.name }}</mat-card-title>
-    </mat-card-header>
-    <div class="container row">
-      <div class="col-md-5">
-        <img mat-card-image [src]="getImageUrl(plant)" alt="{{ plant.name }}" class="img-fluid py-2">
+<div class="plant-view">
+  @if (plant) {
+    <div class="view-card">
+      <div class="view-card__header">
+        <span class="view-card__name">{{ plant.name }}</span>
       </div>
-      <div class="col-md-7">
-        <div class="row">
-          <mat-card-content
-            class="
-                    d-flex flex-column justify-content-between align-items-center
-                    flex-md-row
-                  ">
-            <span matTooltip="Spezies" matTooltipPosition="below" class="shadow p-1 rounded w-100">
-              {{ plant.species }}
-            </span>
-            <span matTooltip="Standort" matTooltipPosition="below" class="shadow p-1 rounded w-100">
-              {{ plant.location }}
-            </span>
-            <span matTooltip="Zuletzt gewässert" matTooltipPosition="below" class="shadow p-1 rounded w-100">
-              {{ plant.lastWateredDate | date: 'dd.MM.yyyy' }}
-            </span>
-          </mat-card-content>
+
+      <div class="view-card__body">
+        <div class="view-card__image-col">
+          <img [src]="getImageUrl(plant)" alt="{{ plant.name }}" class="view-card__img">
         </div>
-        <div class="row">
-          <mat-tab-group>
+
+        <div class="view-card__detail-col">
+          <div class="info-badges">
+            <div class="info-badge">
+              <span class="info-badge__label">Species</span>
+              <span class="info-badge__value">{{ plant.species }}</span>
+            </div>
+            <div class="info-badge">
+              <span class="info-badge__label">Location</span>
+              <span class="info-badge__value">{{ plant.location }}</span>
+            </div>
+            <div class="info-badge">
+              <span class="info-badge__label">Last Watered</span>
+              <span class="info-badge__value">{{ plant.lastWateredDate | date: 'dd.MM.yyyy' }}</span>
+            </div>
+          </div>
+
+          <mat-tab-group class="view-tabs">
             <mat-tab label="Beschreibung">
-              <div class="p-2 description">{{ plant.description }}</div>
+              <div class="tab-content">{{ plant.description }}</div>
             </mat-tab>
             <mat-tab label="Pflegehinweise">
-              <div class="p-2 care-instructions">{{ plant.careInstructions }}</div>
+              <div class="tab-content">{{ plant.careInstructions }}</div>
             </mat-tab>
           </mat-tab-group>
         </div>
       </div>
     </div>
-  </mat-card>
+  }
 </div>

--- a/src/app/plants/components/plant-view/plant-view.component.ts
+++ b/src/app/plants/components/plant-view/plant-view.component.ts
@@ -3,24 +3,15 @@ import {Plant} from '../../models/plant.model';
 import {ActivatedRoute} from '@angular/router';
 import {environment} from '../../../../environments/environment';
 import {PlantService} from '../../services/plant.service';
-import {MatCard, MatCardContent, MatCardHeader, MatCardImage, MatCardTitle} from '@angular/material/card';
-import {DatePipe, NgIf} from '@angular/common';
+import {DatePipe} from '@angular/common';
 import {MatTab, MatTabGroup} from '@angular/material/tabs';
-import {MatTooltip} from '@angular/material/tooltip';
 
 @Component({
   selector: 'app-plant-view',
   imports: [
-    MatCard,
-    MatCardHeader,
-    MatCardTitle,
-    NgIf,
-    MatCardImage,
-    MatCardContent,
     MatTabGroup,
     MatTab,
     DatePipe,
-    MatTooltip
   ],
   templateUrl: './plant-view.component.html',
   styleUrl: './plant-view.component.css'

--- a/src/app/plants/dialogs/delete-confirmation-dialog/delete-confirmation-dialog.component.css
+++ b/src/app/plants/dialogs/delete-confirmation-dialog/delete-confirmation-dialog.component.css
@@ -1,0 +1,60 @@
+::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-dialog-title {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
+  color: var(--text) !important;
+  letter-spacing: 0.03em;
+}
+
+::ng-deep .mat-mdc-dialog-content {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.9rem !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions {
+  gap: 10px;
+  padding-bottom: 16px !important;
+  justify-content: center !important;
+}
+
+.btn-confirm {
+  background: rgba(34, 211, 94, 0.10) !important;
+  border: 1px solid rgba(34, 211, 94, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-p) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-confirm:hover {
+  background: rgba(34, 211, 94, 0.18) !important;
+  box-shadow: 0 0 12px rgba(34, 211, 94, 0.25) !important;
+}
+
+.btn-confirm mat-icon {
+  color: var(--c-p) !important;
+}
+
+.btn-cancel {
+  background: rgba(251, 113, 133, 0.10) !important;
+  border: 1px solid rgba(251, 113, 133, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-e) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-cancel:hover {
+  background: rgba(251, 113, 133, 0.18) !important;
+  box-shadow: 0 0 12px rgba(251, 113, 133, 0.25) !important;
+}
+
+.btn-cancel mat-icon {
+  color: var(--c-e) !important;
+}

--- a/src/app/plants/dialogs/delete-confirmation-dialog/delete-confirmation-dialog.component.html
+++ b/src/app/plants/dialogs/delete-confirmation-dialog/delete-confirmation-dialog.component.html
@@ -5,10 +5,10 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="center">
-  <button mat-mini-fab mat-dialog-close (click)="deletePlant()">
+  <button mat-mini-fab mat-dialog-close class="btn-confirm" (click)="deletePlant()">
     <mat-icon>check_circle</mat-icon>
   </button>
-  <button mat-mini-fab mat-dialog-close>
+  <button mat-mini-fab mat-dialog-close class="btn-cancel">
     <mat-icon>close</mat-icon>
   </button>
 </mat-dialog-actions>

--- a/src/app/plants/dialogs/image-upload-dialog/image-upload-dialog.component.css
+++ b/src/app/plants/dialogs/image-upload-dialog/image-upload-dialog.component.css
@@ -1,0 +1,96 @@
+::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-dialog-title {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
+  color: var(--text) !important;
+  letter-spacing: 0.03em;
+}
+
+::ng-deep .mat-mdc-dialog-content {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions {
+  gap: 8px;
+  padding: 8px 24px 16px !important;
+}
+
+.file-input {
+  display: block;
+  width: 100%;
+  padding: 8px 12px;
+  background: var(--raised);
+  border: 1px solid var(--border-mid);
+  border-radius: 8px;
+  color: var(--text);
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: border-color 0.2s;
+}
+
+.file-input:hover {
+  border-color: var(--c-a);
+}
+
+.file-input::file-selector-button {
+  background: var(--raised);
+  border: 1px solid var(--border-mid);
+  border-radius: 6px;
+  color: var(--text-muted);
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.8rem;
+  padding: 4px 10px;
+  margin-right: 10px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.file-input::file-selector-button:hover {
+  background: rgba(77, 166, 255, 0.1);
+  color: var(--c-a);
+}
+
+.btn-cancel {
+  background: transparent !important;
+  border: 1px solid var(--border) !important;
+  border-radius: 8px !important;
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.85rem !important;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.btn-cancel:hover {
+  background: rgba(255, 255, 255, 0.05) !important;
+  border-color: var(--border-mid) !important;
+}
+
+.btn-upload {
+  background: rgba(77, 166, 255, 0.15) !important;
+  border: 1px solid rgba(77, 166, 255, 0.35) !important;
+  border-radius: 8px !important;
+  color: var(--c-a) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.85rem !important;
+  font-weight: 600 !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-upload:hover:not([disabled]) {
+  background: rgba(77, 166, 255, 0.25) !important;
+  box-shadow: 0 0 14px rgba(77, 166, 255, 0.3) !important;
+}
+
+.btn-upload[disabled] {
+  opacity: 0.4 !important;
+  cursor: not-allowed !important;
+}

--- a/src/app/plants/dialogs/image-upload-dialog/image-upload-dialog.component.html
+++ b/src/app/plants/dialogs/image-upload-dialog/image-upload-dialog.component.html
@@ -2,11 +2,11 @@
 
 <mat-dialog-content>
   <form (ngSubmit)="onSubmit()">
-    <input type="file" (change)="onFileSelected($event)" required/>
+    <input type="file" class="file-input" (change)="onFileSelected($event)" required/>
   </form>
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">
-  <button mat-button (click)="dialogRef.close()">Cancel</button>
-  <button mat-raised-button color="primary" (click)="onSubmit()" [disabled]="!selectedFile">Upload</button>
+  <button mat-button class="btn-cancel" (click)="dialogRef.close()">Cancel</button>
+  <button mat-button class="btn-upload" (click)="onSubmit()" [disabled]="!selectedFile">Upload</button>
 </mat-dialog-actions>

--- a/src/app/plants/dialogs/image-view-dialog/image-view-dialog.component.css
+++ b/src/app/plants/dialogs/image-view-dialog/image-view-dialog.component.css
@@ -1,5 +1,42 @@
+::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-dialog-title {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
+  color: var(--text) !important;
+  letter-spacing: 0.03em;
+}
+
+::ng-deep .mat-mdc-dialog-actions {
+  padding: 8px 24px 16px !important;
+  justify-content: flex-end;
+}
+
 .image {
   width: 100%;
-  max-height: 400px;
+  max-height: 480px;
   object-fit: contain;
+  border-radius: 8px;
+  display: block;
+}
+
+.btn-close {
+  background: transparent !important;
+  border: 1px solid var(--border) !important;
+  border-radius: 8px !important;
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.85rem !important;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.btn-close:hover {
+  background: rgba(255, 255, 255, 0.05) !important;
+  border-color: var(--border-mid) !important;
 }

--- a/src/app/plants/dialogs/image-view-dialog/image-view-dialog.component.html
+++ b/src/app/plants/dialogs/image-view-dialog/image-view-dialog.component.html
@@ -5,5 +5,5 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">
-  <button mat-button mat-dialog-close>Close</button>
+  <button mat-button mat-dialog-close class="btn-close">Close</button>
 </mat-dialog-actions>

--- a/src/app/plants/dialogs/plant-preview/plant-preview.component.css
+++ b/src/app/plants/dialogs/plant-preview/plant-preview.component.css
@@ -1,41 +1,82 @@
 .plant-box {
-  height: 250px;
-  width: 250px;
-  background: linear-gradient(135deg, #a1c4fd, #c2e9fb);
-  padding: 15px;
-  border-radius: 20px;
-  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12), 0 4px 10px rgba(0, 0, 0, 0.08);
+  height: 220px;
+  width: 280px;
+  background: var(--surface);
+  border: 1px solid var(--border-mid);
+  border-radius: 12px;
+  padding: 14px 16px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6), 0 0 0 1px var(--border);
+  backdrop-filter: blur(16px);
   overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  backdrop-filter: blur(10px);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
-.plant-box-info {
-  padding: 10px;
-  color: #003366;
-}
-
-.plant-box-name {
-  font-size: 1.5rem;
-  font-weight: bold;
-  margin-bottom: 30px;
-}
-
-.plant-meta {
+.preview-name {
+  font-family: 'JetBrains Mono', monospace;
   font-size: 1rem;
-  opacity: 0.8;
+  font-weight: 700;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.plant-box-image {
-  padding-left: 15px;
+.preview-body {
+  display: flex;
+  gap: 12px;
+  flex: 1;
+  min-height: 0;
+}
+
+.preview-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.meta-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.meta-icon {
+  font-size: 1rem;
+  width: 1rem;
+  height: 1rem;
+  color: var(--c-p);
+  flex-shrink: 0;
+}
+
+.meta-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  display: block;
+}
+
+.meta-text {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.preview-image {
+  flex-shrink: 0;
 }
 
 .plant-img {
-  border-radius: 15px;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
-}
-
-mat-icon {
-  font-size: 1.5rem;
-  vertical-align: middle;
+  width: 110px;
+  height: 140px;
+  object-fit: cover;
+  border-radius: 8px;
+  display: block;
 }

--- a/src/app/plants/dialogs/plant-preview/plant-preview.component.html
+++ b/src/app/plants/dialogs/plant-preview/plant-preview.component.html
@@ -1,24 +1,22 @@
 <div class="plant-box" *ngIf="plant">
 
-  <div class="container">
+  <div class="preview-name">{{ plant!.name }}</div>
 
-    <div class="row">
-      <div class="col d-flex flex-column align-items-center">
-        <h4 class="plant-box-name">{{ plant!.name }}</h4>
-      </div>
+  <div class="preview-body">
+    <div class="preview-meta">
+      <span class="meta-item">
+        <mat-icon class="meta-icon">{{ getIcon(plant!) }}</mat-icon>
+        <span class="meta-text">{{ plant!.location }}</span>
+      </span>
+      <span class="meta-item">
+        <span class="meta-label">Species</span>
+        <span class="meta-text">{{ plant!.species }}</span>
+      </span>
     </div>
 
-    <div class="row">
-      <div class="col d-flex flex-column align-items-start justify-content-around plant-box-info">
-        <span class="plant-meta">Room: <mat-icon>{{ getIcon(plant!) }}</mat-icon></span>
-        <span class="plant-meta">Species: {{ plant!.species }}</span>
-      </div>
-
-      <div class="col plant-box-image" *ngIf="imageUrl">
-        <img [src]="imageUrl" alt="Plant image" class="plant-img img-fluid"/>
-      </div>
+    <div class="preview-image" *ngIf="imageUrl">
+      <img [src]="imageUrl" alt="Plant image" class="plant-img"/>
     </div>
-
   </div>
 
 </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,5 +1,25 @@
 @use '@angular/material' as mat;
 
+/* ── Global Design Tokens ────────────────────────── */
+/* Promoted to :root so CDK overlays (dialogs, menus) can access them. */
+:root {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-a:  #4da6ff;  --cg-a: rgba(77,  166, 255, 0.18);
+  --c-p:  #22d35e;  --cg-p: rgba(34,  211,  94, 0.18);
+  --c-v:  #fbbf24;  --cg-v: rgba(251, 191,  36, 0.18);
+  --c-m:  #a78bfa;  --cg-m: rgba(167, 139, 250, 0.18);
+  --c-e:  #fb7185;  --cg-e: rgba(251, 113, 133, 0.18);
+}
+
 html, body { height: 100vh; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 


### PR DESCRIPTION
## Summary

- Promotes shared design tokens (`--bg`, `--surface`, `--text`, accent colors, etc.) to `:root` in `styles.css` so CDK overlays (dialogs, menus) can access them
- Restyles `plant-layout` component: replaces Bootstrap grid header with a sticky dark topbar matching the home/bookings aesthetic — flat icon nav buttons with green glow, `⬡ PLANTS` brand, dot-grid background

## Test plan

- [ ] Navigate to `/plant-root` — verify dark background with dot-grid pattern
- [ ] Verify topbar is sticky and blurs content beneath on scroll
- [ ] Verify home and menu icon buttons show green glow on hover
- [ ] Open the menu — verify dark surface background with `--border-mid` border
- [ ] Check DevTools that `--bg`, `--c-p` etc. are available on `:root`

🤖 Generated with [Claude Code](https://claude.com/claude-code)