### PR TITLE
Fix: suppress plant preview popup when hovering over image/delete buttons

### DIFF
--- a/src/app/plants/components/plant-table/plant-table.component.html
+++ b/src/app/plants/components/plant-table/plant-table.component.html
@@ -19,13 +19,13 @@
 
       <ng-container matColumnDef="image">
         <th mat-header-cell *matHeaderCellDef class="col-header">Image</th>
-        <td mat-cell *matCellDef="let plant" (mouseenter)="hidePlantPreview()" (mouseleave)="showPlantPreview(plant, $event)">
+        <td mat-cell *matCellDef="let plant">
           @if (plant.image) {
-            <button class="icon-btn icon-btn--blue" mat-icon-button (click)="openImageDialog(plant); $event.stopPropagation()">
+            <button class="icon-btn icon-btn--blue" mat-icon-button (click)="openImageDialog(plant); $event.stopPropagation()" (mouseenter)="hidePlantPreview()" (mouseleave)="showPlantPreview(plant, $event)">
               <mat-icon>image</mat-icon>
             </button>
           } @else {
-            <button class="icon-btn icon-btn--blue" mat-icon-button (click)="openCreateImageDialog(plant); $event.stopPropagation()">
+            <button class="icon-btn icon-btn--blue" mat-icon-button (click)="openCreateImageDialog(plant); $event.stopPropagation()" (mouseenter)="hidePlantPreview()" (mouseleave)="showPlantPreview(plant, $event)">
               <mat-icon fontIcon="broken_image"></mat-icon>
             </button>
           }
@@ -34,8 +34,8 @@
 
       <ng-container matColumnDef="delete">
         <th mat-header-cell *matHeaderCellDef class="col-header">Delete</th>
-        <td mat-cell *matCellDef="let plant" (mouseenter)="hidePlantPreview()" (mouseleave)="showPlantPreview(plant, $event)">
-          <button class="icon-btn icon-btn--pink" mat-icon-button (click)="openDeletePlantDialog(plant); $event.stopPropagation()">
+        <td mat-cell *matCellDef="let plant">
+          <button class="icon-btn icon-btn--pink" mat-icon-button (click)="openDeletePlantDialog(plant); $event.stopPropagation()" (mouseenter)="hidePlantPreview()" (mouseleave)="showPlantPreview(plant, $event)">
             <mat-icon>delete</mat-icon>
           </button>
         </td>

--- a/src/app/plants/components/plant-table/plant-table.component.html
+++ b/src/app/plants/components/plant-table/plant-table.component.html
@@ -19,7 +19,7 @@
 
       <ng-container matColumnDef="image">
         <th mat-header-cell *matHeaderCellDef class="col-header">Image</th>
-        <td mat-cell *matCellDef="let plant" (mouseenter)="hidePlantPreview()">
+        <td mat-cell *matCellDef="let plant" (mouseenter)="hidePlantPreview()" (mouseleave)="showPlantPreview(plant, $event)">
           @if (plant.image) {
             <button class="icon-btn icon-btn--blue" mat-icon-button (click)="openImageDialog(plant); $event.stopPropagation()">
               <mat-icon>image</mat-icon>
@@ -34,7 +34,7 @@
 
       <ng-container matColumnDef="delete">
         <th mat-header-cell *matHeaderCellDef class="col-header">Delete</th>
-        <td mat-cell *matCellDef="let plant" (mouseenter)="hidePlantPreview()">
+        <td mat-cell *matCellDef="let plant" (mouseenter)="hidePlantPreview()" (mouseleave)="showPlantPreview(plant, $event)">
           <button class="icon-btn icon-btn--pink" mat-icon-button (click)="openDeletePlantDialog(plant); $event.stopPropagation()">
             <mat-icon>delete</mat-icon>
           </button>

--- a/src/app/plants/components/plant-table/plant-table.component.html
+++ b/src/app/plants/components/plant-table/plant-table.component.html
@@ -19,7 +19,7 @@
 
       <ng-container matColumnDef="image">
         <th mat-header-cell *matHeaderCellDef class="col-header">Image</th>
-        <td mat-cell *matCellDef="let plant">
+        <td mat-cell *matCellDef="let plant" (mouseenter)="hidePlantPreview()">
           @if (plant.image) {
             <button class="icon-btn icon-btn--blue" mat-icon-button (click)="openImageDialog(plant); $event.stopPropagation()">
               <mat-icon>image</mat-icon>
@@ -34,7 +34,7 @@
 
       <ng-container matColumnDef="delete">
         <th mat-header-cell *matHeaderCellDef class="col-header">Delete</th>
-        <td mat-cell *matCellDef="let plant">
+        <td mat-cell *matCellDef="let plant" (mouseenter)="hidePlantPreview()">
           <button class="icon-btn icon-btn--pink" mat-icon-button (click)="openDeletePlantDialog(plant); $event.stopPropagation()">
             <mat-icon>delete</mat-icon>
           </button>


### PR DESCRIPTION
## Summary
- The plant details preview popup was appearing when hovering over the image and delete button cells in the plant table
- Added `(mouseenter)="hidePlantPreview()"` to the `td` elements of the image and delete columns
- When the mouse enters a button cell, both the row's `mouseenter` (which schedules the popup after 300ms) and the cell's `mouseenter` fire synchronously — the cell handler cancels the show-timeout immediately, preventing the popup from opening

## Test plan
- [ ] Hover over a plant row name/species cell → preview popup should appear
- [ ] Hover directly over the image button → preview popup should NOT appear
- [ ] Hover directly over the delete button → preview popup should NOT appear
- [ ] Hover over the preview popup itself → popup should stay visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)