### PR TITLE
Style: center icons in plant table and layout nav buttons

### DIFF
--- a/src/app/plants/components/plant-layout/plant-layout.component.css
+++ b/src/app/plants/components/plant-layout/plant-layout.component.css
@@ -82,6 +82,9 @@
 
 /* ── Nav Buttons ─────────────────────────────────── */
 .nav-btn {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
   color: var(--text-muted) !important;
   border: 1px solid var(--border) !important;
   border-radius: 8px !important;

--- a/src/app/plants/components/plant-layout/plant-layout.component.css
+++ b/src/app/plants/components/plant-layout/plant-layout.component.css
@@ -85,6 +85,7 @@
   display: inline-flex !important;
   align-items: center !important;
   justify-content: center !important;
+  padding: 0 !important;
   color: var(--text-muted) !important;
   border: 1px solid var(--border) !important;
   border-radius: 8px !important;

--- a/src/app/plants/components/plant-table/plant-table.component.css
+++ b/src/app/plants/components/plant-table/plant-table.component.css
@@ -135,9 +135,11 @@ table {
 
 /* Icon buttons */
 .icon-btn {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
   width: 32px !important;
   height: 32px !important;
-  line-height: 32px !important;
   border-radius: 8px !important;
   border: 1px solid var(--border) !important;
   background: transparent !important;

--- a/src/app/plants/components/plant-table/plant-table.component.css
+++ b/src/app/plants/components/plant-table/plant-table.component.css
@@ -138,6 +138,7 @@ table {
   display: inline-flex !important;
   align-items: center !important;
   justify-content: center !important;
+  padding: 0 !important;
   width: 32px !important;
   height: 32px !important;
   border-radius: 8px !important;


### PR DESCRIPTION
## Summary
- Replace `line-height` centering with `display: inline-flex` + `align-items: center` + `justify-content: center` on `.icon-btn` (plant-table image/delete buttons)
- Apply the same flex centering to `.nav-btn` (plant-layout home/menu buttons)

## Test plan
- [ ] Verify image and delete button icons are centered in the plant management table
- [ ] Verify home and menu button icons are centered in the plant layout topbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)