### PR TITLE
Style: fix plant-edit image overflow and fill details panel layout

### DIFF
--- a/src/app/plants/components/plant-edit/plant-edit.component.css
+++ b/src/app/plants/components/plant-edit/plant-edit.component.css
@@ -92,9 +92,11 @@
 .edit-body {
   display: grid;
   grid-template-columns: 1fr 1.4fr;
+  grid-template-rows: 1fr;
   gap: 16px;
   padding: 16px;
   flex: 1;
+  min-height: 0;
   overflow: hidden;
 }
 
@@ -139,8 +141,6 @@
   gap: 12px;
   padding: 16px;
   overflow: hidden;
-  height: 100%;
-  box-sizing: border-box;
   min-height: 0;
   transition: border-left-color 0.2s ease;
 }

--- a/src/app/plants/components/plant-edit/plant-edit.component.css
+++ b/src/app/plants/components/plant-edit/plant-edit.component.css
@@ -107,12 +107,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  min-height: 0;
 }
 
 .plant-img {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
 }
 
 .file-form {
@@ -137,7 +138,10 @@
   flex-direction: column;
   gap: 12px;
   padding: 16px;
-  overflow: auto;
+  overflow: hidden;
+  height: 100%;
+  box-sizing: border-box;
+  min-height: 0;
   transition: border-left-color 0.2s ease;
 }
 
@@ -149,8 +153,10 @@
 .text-fields {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr;
   gap: 12px;
-  flex-shrink: 0;
+  flex: 0 0 50%;
+  min-height: 0;
 }
 
 /* Meta grid */
@@ -158,6 +164,8 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 10px;
+  flex: 1;
+  min-height: 0;
 }
 
 /* Field group */
@@ -165,6 +173,7 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
+  min-height: 0;
 }
 
 .field-label {
@@ -188,8 +197,7 @@
 
 .field-text {
   white-space: pre-wrap;
-  min-height: 80px;
-  max-height: 180px;
+  flex: 1;
   overflow-y: auto;
   text-align: left;
   font-family: 'Outfit', sans-serif;
@@ -216,8 +224,8 @@
 }
 
 textarea.field-input {
-  min-height: 100px;
-  resize: vertical;
+  flex: 1;
+  resize: none;
 }
 
 /* Date input */

--- a/src/app/plants/components/plant-layout/plant-layout.component.css
+++ b/src/app/plants/components/plant-layout/plant-layout.component.css
@@ -20,7 +20,8 @@
 
   display: flex;
   flex-direction: column;
-  min-height: 100dvh;
+  height: 100dvh;
+  overflow: hidden;
   font-family: 'Outfit', sans-serif;
   color: var(--text);
   background-color: var(--bg);
@@ -35,7 +36,7 @@
 .plant-layout {
   display: flex;
   flex-direction: column;
-  min-height: 100dvh;
+  height: 100%;
 }
 
 /* ── Topbar ──────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Fix image overflowing the y-axis in plant-edit by adding `min-height: 0` to `.image-panel` and switching to `object-fit: contain`
- Details panel now fills 100% of its grid column (`height: 100%`, `overflow: hidden`)
- Text fields section (description + care instructions) takes exactly 50% of the panel height (`flex: 0 0 50%`); meta grid takes the remaining 50% (`flex: 1`)
- `.field-text` and `textarea.field-input` grow to fill available space (`flex: 1`), keeping view and edit mode boxes the same size

## Test plan
- [ ] Open a plant detail page and verify the image no longer overflows vertically
- [ ] Verify the full image is visible without cropping
- [ ] Verify the right panel fills the full height of the container
- [ ] Verify description and care instructions occupy ~50% of the panel height
- [ ] Switch to edit mode and verify textareas match the height of the view-mode fields
- [ ] Check responsive layout at ≤768px still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)