### PR TITLE
Feature: reduce CPU priority during builds to prevent host freezing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN npm install
 COPY . .
 
 RUN npm run env:production
-RUN npm run build --production
+RUN npm run build:nice
 
 FROM nginx:1.25 AS production-stage
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN npm install
 COPY . .
 
 RUN npm run env:production
-RUN npm run build
+RUN npm run build:nice
 
 FROM nginx:1.25 AS production-stage
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN npm install
 COPY . .
 
 RUN npm run env:production
-RUN npm run build:nice
+RUN npm run build
 
 FROM nginx:1.25 AS production-stage
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,7 +7,7 @@ IMAGE_TAG=latest
 REGISTRY=192.168.178.29:5000
 
 echo "Building Docker image: $REGISTRY/$IMAGE_NAME:$IMAGE_TAG..."
-docker build -t "$REGISTRY/$IMAGE_NAME:$IMAGE_TAG" .
+nice -n 15 docker build -t "$REGISTRY/$IMAGE_NAME:$IMAGE_TAG" .
 
 echo "Pushing Docker image to $REGISTRY..."
 docker push "$REGISTRY/$IMAGE_NAME:$IMAGE_TAG"

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,7 +7,7 @@ IMAGE_TAG=latest
 REGISTRY=192.168.178.29:5000
 
 echo "Building Docker image: $REGISTRY/$IMAGE_NAME:$IMAGE_TAG..."
-nice -n 15 docker build -t "$REGISTRY/$IMAGE_NAME:$IMAGE_TAG" .
+docker build -t "$REGISTRY/$IMAGE_NAME:$IMAGE_TAG" .
 
 echo "Pushing Docker image to $REGISTRY..."
 docker push "$REGISTRY/$IMAGE_NAME:$IMAGE_TAG"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "build:nice": "nice -n 15 ng build",
+    "build:nice": "nice -n 15 ng build --configuration production",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "build:nice": "nice -n 15 ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary
- Add `build:nice` npm script (`nice -n 15 ng build`) for CPU-friendly local builds
- Update `Dockerfile` to use `build:nice` so container builds don't saturate the host
- Apply `nice -n 15` to `docker build` in `deploy.sh` for the same reason

## Test plan
- [ ] Run `npm run build:nice` locally — build completes without freezing host
- [ ] Run `./deploy.sh` — Docker image builds and pushes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)