### PR TITLE
Style: vocabulary module dark-theme restyle (steps 1–4)

### DIFF
--- a/src/app/vocabulary/components/add-word/add-word.component.css
+++ b/src/app/vocabulary/components/add-word/add-word.component.css
@@ -1,169 +1,354 @@
-.add-word-container,
-.add-word-main {
-  width: 100%;
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;700&display=swap');
+
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255,255,255,0.07);
+  --border-mid:  rgba(255,255,255,0.13);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+  --c-v:         #fbbf24;
+  --cg-v:        rgba(251,191,36,0.18);
+
+  display: flex;
+  flex-direction: column;
   height: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  background: var(--bg);
+  background-image:
+    radial-gradient(ellipse 80% 50% at 50% -10%, rgba(251,191,36,0.05) 0%, transparent 70%);
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+  overflow: hidden;
 }
 
-.search-input-wrapper {
+/* Search bar */
+.search-bar {
   display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+}
+
+.search-bar mat-form-field {
+  flex: 1;
+}
+
+/* Icon buttons */
+.icon-btn {
+  display: flex;
+  align-items: center;
   justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all 0.2s ease;
 }
 
-.save-word-section {
-  width: 100%;
+.icon-btn--yellow {
+  color: var(--c-v);
+  border-color: rgba(251,191,36,0.3);
+}
+
+.icon-btn--yellow:hover {
+  background: var(--cg-v);
+  box-shadow: 0 0 12px rgba(251,191,36,0.2);
+}
+
+/* Panel header */
+.panel-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  flex-shrink: 0;
+}
+
+.panel-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--c-v);
+  box-shadow: 0 0 6px var(--c-v);
+  animation: blink 2s ease-in-out infinite;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.3; }
+}
+
+.panel-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+}
+
+/* Main layout */
+.add-word-container {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  padding: 10px 10px 0 10px;
+  height: 100%;
+  overflow: hidden;
 }
 
-.save-word-content {
-  width: 100%;
+.add-word-main {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  padding: 1rem;
+  gap: 1rem;
+}
+
+/* Dictionary section */
+.dictionary-section {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  flex: 1.5;
+  min-height: 0;
 }
 
-.part-of-speech-toggle-group {
-  display: flex;
-  justify-content: center;
-}
-
-.mat-mdc-form-field {
-  width: 100%;
-}
-
-.dictionary-results-section {
-  display: flex;
-  width: 90%;
-  flex-direction: column;
-  align-items: center;
-}
-
-.translation-section {
-  width: 100%;
-  padding-top: 10px;
-
-  button {
-    width: 25%;
-  }
-}
-
-.translation-result {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-top: 10px;
-  background-color: lightgreen;
-  border-radius: 15px;
-}
-
-.word-entries-container {
-  width: 100%;
-  max-height: 80vh;
+/* Entries container */
+.entries-container {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
   overflow-y: auto;
-  border-radius: 10px;
+  flex: 1;
+  min-height: 0;
 }
+
+.entries-container::-webkit-scrollbar        { width: 4px; }
+.entries-container::-webkit-scrollbar-track  { background: var(--surface); }
+.entries-container::-webkit-scrollbar-thumb  { background: var(--border-mid); border-radius: 2px; }
 
 .word-entries-list {
-  background-color: azure;
+  padding: 0.5rem;
 }
 
-.definition-item {
-  border: black solid 1px;
-  border-radius: 10px;
-  margin: 5px;
-  padding: 5px;
-}
-
-.definition-item.chosen {
-  background-color: #e3f2fd;
-  border-color: #1976d2 !important;
-  box-shadow: 0 2px 8px rgba(25, 118, 210, 0.2);
-}
-
-.definition-actions {
-  display: flex;
-  justify-content: space-around;
-
-  button:hover {
-    background-color: #f8f9fa;
-    border-color: #1976d2;
-    color: #1976d2;
-  }
-
-  button.selected {
-    background-color: #e3f2fd;
-    border-color: #1976d2;
-    color: #1976d2;
-    font-weight: 500;
-  }
-}
-
+/* Part-of-speech badge */
 .part-of-speech-header {
   display: flex;
-  justify-content: center;
-  font-size: larger;
-  margin-top: 15px;
+  justify-content: flex-start;
+  padding: 0.5rem 0.5rem 0.25rem;
 }
 
 .part-of-speech {
-  font-weight: bold;
-  margin-left: 15px;
-  padding: 0 15px 0 15px;
-  background-color: lightblue;
-  border-radius: 15px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--c-v);
+  background: color-mix(in srgb, var(--c-v) 12%, transparent);
+  border: 1px solid rgba(251,191,36,0.3);
+  border-radius: 30px;
+  padding: 0.2rem 0.6rem;
+}
+
+/* Definition items */
+.definition-item {
+  background: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin: 0.375rem;
+  padding: 0.625rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.definition-item.chosen {
+  border-color: var(--c-v);
+  box-shadow: 0 0 10px var(--cg-v);
+  background: color-mix(in srgb, var(--c-v) 8%, var(--raised));
+}
+
+.definition-text {
+  font-size: 0.82rem;
+  color: var(--text);
+  margin: 0 0 0.5rem;
+  line-height: 1.5;
+}
+
+/* Definition action buttons */
+.definition-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.definition-actions button {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.625rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-dim);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.definition-actions button mat-icon {
+  font-size: 14px;
+  width: 14px;
+  height: 14px;
+}
+
+.definition-actions button:hover {
+  color: var(--c-v);
+  border-color: rgba(251,191,36,0.4);
+  background: rgba(251,191,36,0.05);
+}
+
+.definition-actions button.selected {
+  color: var(--c-v);
+  border-color: rgba(251,191,36,0.5);
+  background: color-mix(in srgb, var(--c-v) 10%, var(--raised));
+}
+
+/* Translation section */
+.translation-section {
+  margin-top: 1rem;
+  flex-shrink: 0;
+}
+
+.translation-section form {
+  display: flex;
+  flex-direction: column;
+}
+
+.translation-result {
+  background: var(--raised);
+  border-left: 3px solid var(--c-v);
+  border-radius: 0 8px 8px 0;
+  color: var(--text);
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+}
+
+/* Save word section */
+.save-word-section {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.save-word-section::-webkit-scrollbar        { width: 4px; }
+.save-word-section::-webkit-scrollbar-track  { background: transparent; }
+.save-word-section::-webkit-scrollbar-thumb  { background: var(--border-mid); border-radius: 2px; }
+
+.save-word-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .part-of-speech-toggle-group {
-  padding: 10px;
+  display: flex;
+  justify-content: center;
+  padding: 0.5rem 0;
 }
 
-form {
+.save-word-section form {
   display: flex;
   flex-direction: column;
-  align-items: center;
+}
+
+/* Material form-field dark overrides */
+::ng-deep .search-bar .mat-mdc-form-field,
+::ng-deep .dictionary-section .mat-mdc-form-field,
+::ng-deep .translation-section .mat-mdc-form-field,
+::ng-deep .save-word-section .mat-mdc-form-field {
+  --mdc-outlined-text-field-outline-color:        var(--border-mid);
+  --mdc-outlined-text-field-hover-outline-color:  var(--c-v);
+  --mdc-outlined-text-field-focus-outline-color:  var(--c-v);
+  --mdc-outlined-text-field-label-text-color:     var(--text-muted);
+  --mdc-outlined-text-field-focus-label-text-color: var(--c-v);
+  --mdc-outlined-text-field-input-text-color:     var(--text);
+  --mdc-outlined-text-field-container-shape:      8px;
   width: 100%;
 }
 
-button {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border-radius: 10px;
-  margin: 0 2px 0 2px;
-  font-size: small;
+::ng-deep .search-bar .mat-mdc-text-field-wrapper,
+::ng-deep .dictionary-section .mat-mdc-text-field-wrapper,
+::ng-deep .translation-section .mat-mdc-text-field-wrapper,
+::ng-deep .save-word-section .mat-mdc-text-field-wrapper {
+  background: var(--raised) !important;
 }
 
-@media (min-width: 821px) {
+/* Button toggle group dark overrides */
+::ng-deep .mat-button-toggle-group {
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 8px !important;
+  overflow: hidden;
+}
 
+::ng-deep .mat-button-toggle {
+  background: var(--raised) !important;
+  color: var(--text-muted) !important;
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.65rem !important;
+  text-transform: uppercase !important;
+  letter-spacing: 0.05em !important;
+}
+
+::ng-deep .mat-button-toggle-checked {
+  color: var(--c-v) !important;
+  background: color-mix(in srgb, var(--c-v) 15%, var(--raised)) !important;
+  border-bottom: 2px solid var(--c-v) !important;
+}
+
+/* Primary flat button (Translate / Save) */
+::ng-deep .mat-mdc-unelevated-button[color=primary] {
+  background: var(--c-v) !important;
+  color: #06080e !important;
+  font-family: 'JetBrains Mono', monospace !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.05em !important;
+  border-radius: 8px !important;
+  transition: box-shadow 0.2s ease !important;
+}
+
+::ng-deep .mat-mdc-unelevated-button[color=primary]:not([disabled]):hover {
+  box-shadow: 0 4px 14px var(--cg-v) !important;
+}
+
+::ng-deep .mat-mdc-unelevated-button[color=primary][disabled] {
+  background: var(--raised) !important;
+  color: var(--text-dim) !important;
+}
+
+/* Responsive: stacked on mobile */
+@media (max-width: 820px) {
   .add-word-main {
-    flex-direction: row;
-    align-items: start;
-    height: 100%;
-  }
-
-  .dictionary-results-section {
-    margin: 0 10px 0 10px;
-    display: flex;
     flex-direction: column;
-    height: 100%;
+    overflow-y: auto;
   }
 
-  .word-entries-container {
-    height: 60%;
-  }
-
-  .translation-section {
-    flex-grow: 1;
-  }
-
+  .dictionary-section,
   .save-word-section {
-    margin: 0 10px 0 10px;
-    padding: 0;
+    flex: none;
+    min-height: auto;
+    overflow: visible;
   }
 
+  .entries-container {
+    max-height: 50vh;
+  }
 }

--- a/src/app/vocabulary/components/add-word/add-word.component.css
+++ b/src/app/vocabulary/components/add-word/add-word.component.css
@@ -272,6 +272,7 @@
 
 /* Material form-field dark overrides */
 ::ng-deep .search-bar .mat-mdc-form-field,
+::ng-deep .search-bar .mat-mdc-form-field,
 ::ng-deep .dictionary-section .mat-mdc-form-field,
 ::ng-deep .translation-section .mat-mdc-form-field,
 ::ng-deep .save-word-section .mat-mdc-form-field {
@@ -290,6 +291,13 @@
 ::ng-deep .translation-section .mat-mdc-text-field-wrapper,
 ::ng-deep .save-word-section .mat-mdc-text-field-wrapper {
   background: var(--raised) !important;
+}
+
+::ng-deep .search-bar input.mat-mdc-input-element,
+::ng-deep .dictionary-section input.mat-mdc-input-element,
+::ng-deep .translation-section input.mat-mdc-input-element,
+::ng-deep .save-word-section input.mat-mdc-input-element {
+  color: var(--text) !important;
 }
 
 /* Button toggle group dark overrides */

--- a/src/app/vocabulary/components/add-word/add-word.component.html
+++ b/src/app/vocabulary/components/add-word/add-word.component.html
@@ -2,7 +2,7 @@
 
   @if (!isFromRouteCall) {
     <div class="search-section">
-      <div class="search-input-wrapper">
+      <div class="search-bar">
         <mat-form-field appearance="outline">
           <mat-label>Enter English word</mat-label>
           <input
@@ -16,7 +16,7 @@
         @if (word) {
           <button
               mat-icon-button
-              color="primary"
+              class="icon-btn icon-btn--yellow"
               aria-label="Search word"
               (click)="getWord(word)"
               type="button"
@@ -31,14 +31,15 @@
   <div class="add-word-main">
 
     <!-- Dictionary Results Section -->
-    <div class="dictionary-results-section">
+    <div class="dictionary-section">
       @if (wordToShow) {
-        <div class="word-header">
-          <h1 class="word-title">{{ wordToShow }}</h1>
-        </div>
+        <header class="panel-header">
+          <span class="panel-dot"></span>
+          <span class="panel-label">DICTIONARY — {{ wordToShow }}</span>
+        </header>
       }
 
-      <div class="word-entries-container">
+      <div class="entries-container">
         <div class="word-entries-list">
           @for (wordEntry of wordEntries(); track entryIndex; let entryIndex = $index) {
             <div class="word-entry">
@@ -95,9 +96,10 @@
       <!-- Translation Section -->
       @if (wordToShow) {
         <div class="translation-section">
-          <div class="translation-header">
-            <h5 class="translation-title">Translation</h5>
-          </div>
+          <header class="panel-header">
+            <span class="panel-dot"></span>
+            <span class="panel-label">TRANSLATION</span>
+          </header>
 
           <form
               [formGroup]="wordFormTranslation"
@@ -133,9 +135,10 @@
     <!-- Save Word Section -->
     <div class="save-word-section">
       @if (wordToShow) {
-        <div class="save-word-header">
-          <h1>Save Word</h1>
-        </div>
+        <header class="panel-header">
+          <span class="panel-dot"></span>
+          <span class="panel-label">SAVE WORD</span>
+        </header>
 
         <div class="save-word-content">
           <div class="part-of-speech-toggle-group">

--- a/src/app/vocabulary/components/article-dialog/article-dialog.component.css
+++ b/src/app/vocabulary/components/article-dialog/article-dialog.component.css
@@ -1,0 +1,34 @@
+::ng-deep .mdc-dialog__surface {
+  background: var(--surface, #0c1018) !important;
+  border: 1px solid var(--border-mid, rgba(255,255,255,0.13)) !important;
+  border-radius: 12px !important;
+}
+
+::ng-deep .mdc-dialog__title {
+  color: var(--text, #c8d4e8) !important;
+  font-family: 'JetBrains Mono', monospace !important;
+}
+
+.article-btn-group {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.article-btn {
+  flex: 1 1 0;
+  max-width: 25%;
+  background: var(--raised, #111826) !important;
+  color: var(--text-dim, #3d5470) !important;
+  border: 1px solid var(--border, rgba(255,255,255,0.07)) !important;
+  border-radius: 8px !important;
+  font-family: 'JetBrains Mono', monospace !important;
+  transition: color 0.2s, border-color 0.2s, box-shadow 0.2s;
+}
+
+.article-btn:hover {
+  color: var(--c-v, #fbbf24) !important;
+  border-color: var(--c-v, #fbbf24) !important;
+  box-shadow: 0 0 8px var(--cg-v, rgba(251,191,36,0.18)) !important;
+}

--- a/src/app/vocabulary/components/article-dialog/article-dialog.component.html
+++ b/src/app/vocabulary/components/article-dialog/article-dialog.component.html
@@ -1,12 +1,11 @@
 <h2 mat-dialog-title>Select an article!</h2>
 
 <mat-dialog-content>
-  <div class="d-flex justify-content-center gap-3">
+  <div class="article-btn-group">
     @for (article of articles; track $index) {
       <button
         mat-flat-button
-        style="flex: 1 1 0;
-        max-width: 25%"
+        class="article-btn"
         [mat-dialog-close]="article"
       >{{ article }}
       </button>

--- a/src/app/vocabulary/components/deck-change-name-dialog/deck-change-name-dialog.css
+++ b/src/app/vocabulary/components/deck-change-name-dialog/deck-change-name-dialog.css
@@ -1,0 +1,41 @@
+::ng-deep .mdc-dialog__surface {
+  background: var(--surface, #0c1018) !important;
+  border: 1px solid var(--border-mid, rgba(255,255,255,0.13)) !important;
+  border-radius: 12px !important;
+}
+
+::ng-deep .mdc-dialog__title {
+  color: var(--text, #c8d4e8) !important;
+  font-family: 'JetBrains Mono', monospace !important;
+}
+
+.rename-dialog {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+/* Material form field dark override */
+::ng-deep .rename-dialog .mat-mdc-form-field {
+  --mdc-outlined-text-field-outline-color: var(--border-mid, rgba(255,255,255,0.13));
+  --mdc-outlined-text-field-focus-outline-color: var(--c-v, #fbbf24);
+  --mdc-outlined-text-field-label-text-color: var(--text-muted, #7a93b0);
+  --mdc-outlined-text-field-focus-label-text-color: var(--c-v, #fbbf24);
+  --mdc-outlined-text-field-input-text-color: var(--text, #c8d4e8);
+  --mdc-outlined-text-field-container-shape: 8px;
+}
+
+::ng-deep .rename-dialog .mat-mdc-text-field-wrapper {
+  background: var(--raised, #111826) !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions .mdc-button {
+  color: var(--text-muted, #7a93b0) !important;
+  font-family: 'JetBrains Mono', monospace !important;
+  transition: color 0.2s;
+}
+
+::ng-deep .mat-mdc-dialog-actions .mdc-button:hover {
+  color: var(--c-v, #fbbf24) !important;
+}

--- a/src/app/vocabulary/components/deck-change-name-dialog/deck-change-name-dialog.html
+++ b/src/app/vocabulary/components/deck-change-name-dialog/deck-change-name-dialog.html
@@ -1,4 +1,4 @@
-<div class="flex-grow-1 d-flex flex-column justify-content-center align-items-center">
+<div class="rename-dialog">
   <mat-dialog-content>
     <mat-form-field>
       <mat-label>New Name of Deck</mat-label>

--- a/src/app/vocabulary/components/deck-management-dialog/deck-management-dialog.css
+++ b/src/app/vocabulary/components/deck-management-dialog/deck-management-dialog.css
@@ -1,0 +1,54 @@
+::ng-deep .mdc-dialog__surface {
+  background: var(--surface, #0c1018) !important;
+  border: 1px solid var(--border-mid, rgba(255,255,255,0.13)) !important;
+  border-radius: 12px !important;
+}
+
+::ng-deep .mdc-dialog__title {
+  color: var(--text, #c8d4e8) !important;
+  font-family: 'JetBrains Mono', monospace !important;
+}
+
+.deck-row {
+  width: 75%;
+  background: var(--raised, #111826);
+  border: 1px solid var(--border, rgba(255,255,255,0.07));
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.deck-row__id {
+  width: 2.5rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  color: var(--text-dim, #3d5470);
+  flex-shrink: 0;
+}
+
+.deck-row__name {
+  flex: 1 1 0;
+  color: var(--text, #c8d4e8);
+}
+
+.icon-btn--yellow {
+  color: var(--text-muted, #7a93b0) !important;
+  transition: color 0.2s, background 0.2s;
+}
+
+.icon-btn--yellow:hover {
+  color: var(--c-v, #fbbf24) !important;
+  background: rgba(251,191,36,0.1) !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions .mdc-button {
+  color: var(--text-muted, #7a93b0) !important;
+  font-family: 'JetBrains Mono', monospace !important;
+  transition: color 0.2s;
+}
+
+::ng-deep .mat-mdc-dialog-actions .mdc-button:hover {
+  color: var(--c-v, #fbbf24) !important;
+}

--- a/src/app/vocabulary/components/deck-management-dialog/deck-management-dialog.html
+++ b/src/app/vocabulary/components/deck-management-dialog/deck-management-dialog.html
@@ -1,9 +1,9 @@
 <mat-dialog-content class="flex-grow-1 d-flex flex-column justify-content-center align-items-center gap-2">
   @for (deck of decks(); track deck.id) {
-    <div class="w-75 border border-1 border-black rounded p-3 d-flex align-items-center">
-      <span class="w-25">{{ deck.id }}</span>
-      <span class="flex-grow-1">{{ deck.name }}</span>
-      <button mat-icon-button (click)="openDialog(deck)">
+    <div class="deck-row">
+      <span class="deck-row__id">{{ deck.id }}</span>
+      <span class="deck-row__name">{{ deck.name }}</span>
+      <button mat-icon-button class="icon-btn icon-btn--yellow" (click)="openDialog(deck)">
         <mat-icon>build</mat-icon>
       </button>
     </div>
@@ -12,4 +12,3 @@
 <mat-dialog-actions>
   <button matButton cdkFocusInitial [mat-dialog-close]="deck()">Ok</button>
 </mat-dialog-actions>
-

--- a/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.css
+++ b/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.css
@@ -1,77 +1,214 @@
-.vocabulary-home-container {
-  height: 100vh;
-  display: flex;
-  flex-direction: column;
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+/* ── Design Tokens ───────────────────────────────── */
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-v:  #fbbf24;
+  --cg-v: rgba(251, 191, 36, 0.18);
+
+  display: block;
+  min-height: 100vh;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+  background-color: var(--bg);
+  background-image:
+    radial-gradient(ellipse 60% 40% at 0% 0%, rgba(251, 191, 36, 0.06) 0%, transparent 70%),
+    radial-gradient(ellipse 60% 40% at 100% 100%, rgba(251, 191, 36, 0.06) 0%, transparent 70%),
+    radial-gradient(circle, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+  background-size: auto, auto, 28px 28px;
 }
 
-.vocabulary-header {
-  height: 10%;
-  display: flex;
-  padding: 5px 0 10px 0;
+/* ── Page Header ─────────────────────────────────── */
+.page-header {
+  padding: 0.75rem 1rem;
 }
 
-.home-button-section {
-  flex: 0 0 5%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+::ng-deep .home-fab.mat-mdc-fab {
+  --mdc-fab-container-color: var(--surface);
+  --mdc-fab-icon-color: var(--c-v);
+  box-shadow: none !important;
+  width: 36px;
+  height: 36px;
 }
 
-.selection-section {
-  flex-grow: 1;
-  display: flex;
-  gap: 5px
+::ng-deep .home-fab.mat-mdc-fab .mat-icon {
+  font-size: 1.1rem;
+  width: 1.1rem;
+  height: 1.1rem;
+  color: var(--c-v);
 }
 
-.manage-deck-section,
-.add-word-section,
-.list-section {
-  flex: 1 0 auto;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  margin: 0 5px 0 5px;
-  border: black solid 2px;
-  border-radius: 10px;
+/* ── Nav Grid ────────────────────────────────────── */
+.navgrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.75rem;
+  padding: 1rem;
+  max-width: 640px;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+@media (min-width: 640px) {
+  .navgrid { gap: 1rem; padding: 1.5rem; }
+}
+
+/* Last odd card: centered, not stretched */
+.navcard:last-child:nth-child(odd) {
+  grid-column: 1 / -1;
+  justify-self: center;
+  width: calc(50% - 0.375rem);
+}
+
+@media (min-width: 640px) {
+  .navcard:last-child:nth-child(odd) {
+    width: calc(50% - 0.5rem);
+  }
+}
+
+/* ── Nav Cards ───────────────────────────────────── */
+.navcard {
+  --cc: var(--c-v);
+  --cc-glow: var(--cg-v);
+
+  position: relative;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.1rem 1rem 1.75rem;
   cursor: pointer;
-  transition: background-color 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  min-height: 140px;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
+  animation: fadeUp 0.5s ease both;
+  -webkit-tap-highlight-color: transparent;
 }
 
-.manage-deck-section:hover,
-.add-word-section:hover,
-.list-section:hover {
-  background-color: #cccccc;
+/* Radial glow overlay on hover */
+.navcard::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 0% 0%, var(--cc-glow) 0%, transparent 65%);
+  opacity: 0;
+  transition: opacity 0.25s;
+  pointer-events: none;
 }
 
-.router-outlet-container {
-  flex-grow: 1;
-  height: 75%;
+/* Left accent stripe */
+.navcard::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 22%;
+  bottom: 22%;
+  width: 2px;
+  background: var(--cc);
+  border-radius: 0 2px 2px 0;
+  opacity: 0.35;
+  transition: opacity 0.2s, top 0.2s, bottom 0.2s;
 }
 
-span {
-  font-size: 20px;
-  font-weight: bold;
+.navcard:hover {
+  border-color: var(--cc);
+  box-shadow: 0 8px 28px var(--cc-glow);
+  transform: translateY(-3px);
 }
 
-@media (min-width: 821px) {
+.navcard:hover::before { opacity: 1; }
 
-  .vocabulary-header {
-    display: flex;
-    justify-content: start;
-  }
+.navcard:hover::after {
+  opacity: 0.9;
+  top: 12%;
+  bottom: 12%;
+}
 
-  .selection-section {
-    flex-direction: row;
-    align-items: center;
-    gap: 10px
-  }
+.navcard:active { transform: translateY(-1px); }
 
-  .manage-deck-section,
-  .add-word-section,
-  .list-section {
-    width: 20%;
-    align-items: center;
-  }
+.navcard--action {
+  user-select: none;
+}
 
+/* ── Card Mark ───────────────────────────────────── */
+.navcard__mark {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--cc) 40%, transparent);
+  background: color-mix(in srgb, var(--cc) 10%, transparent);
+  display: grid;
+  place-items: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--cc);
+  flex-shrink: 0;
+  transition: background 0.2s;
+}
+
+.navcard:hover .navcard__mark {
+  background: color-mix(in srgb, var(--cc) 20%, transparent);
+}
+
+/* ── Card Text ───────────────────────────────────── */
+.navcard__title {
+  margin: 0;
+  font-size: clamp(0.95rem, 2.5vw, 1.1rem);
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1.25;
+  letter-spacing: 0.01em;
+}
+
+.navcard__sub {
+  margin: 0;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+  font-weight: 400;
+}
+
+/* ── Card Arrow ──────────────────────────────────── */
+.navcard__arrow {
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.875rem;
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  line-height: 1;
+  transition: color 0.2s, transform 0.2s;
+}
+
+.navcard:hover .navcard__arrow {
+  color: var(--cc);
+  transform: translate(2px, -2px);
+}
+
+/* ── Entrance Animations ─────────────────────────── */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.navcard:nth-child(1) { animation-delay: 0.05s; }
+.navcard:nth-child(2) { animation-delay: 0.12s; }
+.navcard:nth-child(3) { animation-delay: 0.19s; }
+
+/* ── Content Area ────────────────────────────────── */
+.content-area {
+  padding: 0 1rem;
 }

--- a/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.css
+++ b/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.css
@@ -50,29 +50,16 @@
 /* ── Nav Grid ────────────────────────────────────── */
 .navgrid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(3, 1fr);
   gap: 0.75rem;
   padding: 1rem;
-  max-width: 640px;
+  max-width: 900px;
   margin: 0 auto;
   box-sizing: border-box;
 }
 
 @media (min-width: 640px) {
   .navgrid { gap: 1rem; padding: 1.5rem; }
-}
-
-/* Last odd card: centered, not stretched */
-.navcard:last-child:nth-child(odd) {
-  grid-column: 1 / -1;
-  justify-self: center;
-  width: calc(50% - 0.375rem);
-}
-
-@media (min-width: 640px) {
-  .navcard:last-child:nth-child(odd) {
-    width: calc(50% - 0.5rem);
-  }
 }
 
 /* ── Nav Cards ───────────────────────────────────── */
@@ -84,12 +71,13 @@
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 12px;
-  padding: 1.1rem 1rem 1.75rem;
+  padding: 1rem 1rem 1rem 1rem;
   cursor: pointer;
   display: flex;
-  flex-direction: column;
-  gap: 0.65rem;
-  min-height: 140px;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 72px;
   overflow: hidden;
   text-decoration: none;
   color: inherit;
@@ -164,6 +152,15 @@
   background: color-mix(in srgb, var(--cc) 20%, transparent);
 }
 
+/* ── Card Body ───────────────────────────────────── */
+.navcard__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  flex: 1;
+  min-width: 0;
+}
+
 /* ── Card Text ───────────────────────────────────── */
 .navcard__title {
   margin: 0;
@@ -184,12 +181,10 @@
 
 /* ── Card Arrow ──────────────────────────────────── */
 .navcard__arrow {
-  position: absolute;
-  bottom: 0.75rem;
-  right: 0.875rem;
   font-size: 0.8rem;
   color: var(--text-dim);
   line-height: 1;
+  flex-shrink: 0;
   transition: color 0.2s, transform 0.2s;
 }
 

--- a/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.css
+++ b/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.css
@@ -29,6 +29,9 @@
 
 /* ── Page Header ─────────────────────────────────── */
 .page-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
   padding: 0.75rem 1rem;
 }
 
@@ -52,14 +55,13 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 0.75rem;
-  padding: 1rem;
-  max-width: 900px;
-  margin: 0 auto;
+  flex: 1;
+  min-width: 0;
   box-sizing: border-box;
 }
 
 @media (min-width: 640px) {
-  .navgrid { gap: 1rem; padding: 1.5rem; }
+  .navgrid { gap: 1rem; }
 }
 
 /* ── Nav Cards ───────────────────────────────────── */

--- a/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.html
+++ b/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.html
@@ -8,22 +8,28 @@
 
   <a class="navcard" routerLink="/vocabulary/add">
     <div class="navcard__mark">+</div>
-    <h2 class="navcard__title">Add Word</h2>
-    <p class="navcard__sub">Look up and save new vocabulary</p>
+    <div class="navcard__body">
+      <h2 class="navcard__title">Add Word</h2>
+      <p class="navcard__sub">Look up and save new vocabulary</p>
+    </div>
     <span class="navcard__arrow" aria-hidden="true">↗</span>
   </a>
 
   <a class="navcard" routerLink="/vocabulary/list">
     <div class="navcard__mark">L</div>
-    <h2 class="navcard__title">List</h2>
-    <p class="navcard__sub">Browse all flashcards</p>
+    <div class="navcard__body">
+      <h2 class="navcard__title">List</h2>
+      <p class="navcard__sub">Browse all flashcards</p>
+    </div>
     <span class="navcard__arrow" aria-hidden="true">↗</span>
   </a>
 
   <div class="navcard navcard--action" (click)="openDialog()">
     <div class="navcard__mark">D</div>
-    <h2 class="navcard__title">Manage Decks</h2>
-    <p class="navcard__sub">Rename and organise decks</p>
+    <div class="navcard__body">
+      <h2 class="navcard__title">Manage Decks</h2>
+      <p class="navcard__sub">Rename and organise decks</p>
+    </div>
     <span class="navcard__arrow" aria-hidden="true">↗</span>
   </div>
 

--- a/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.html
+++ b/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.html
@@ -1,23 +1,34 @@
-<div class="vocabulary-home-container">
-  <div class="vocabulary-header">
-    <div class="home-button-section">
-      <button mat-fab routerLink="/">
-        <mat-icon>home</mat-icon>
-      </button>
-    </div>
-    <div class="selection-section">
-      <div class="add-word-section" routerLink="/vocabulary/add">
-        <span>Add Word</span>
-      </div>
-      <div class="list-section" routerLink="/vocabulary/list">
-        <span>List</span>
-      </div>
-      <div class="manage-deck-section" (click)="openDialog()">
-        <span>Manage Decks</span>
-      </div>
-    </div>
+<div class="page-header">
+  <button mat-fab routerLink="/" class="home-fab">
+    <mat-icon>home</mat-icon>
+  </button>
+</div>
+
+<main class="navgrid">
+
+  <a class="navcard" routerLink="/vocabulary/add">
+    <div class="navcard__mark">+</div>
+    <h2 class="navcard__title">Add Word</h2>
+    <p class="navcard__sub">Look up and save new vocabulary</p>
+    <span class="navcard__arrow" aria-hidden="true">↗</span>
+  </a>
+
+  <a class="navcard" routerLink="/vocabulary/list">
+    <div class="navcard__mark">L</div>
+    <h2 class="navcard__title">List</h2>
+    <p class="navcard__sub">Browse all flashcards</p>
+    <span class="navcard__arrow" aria-hidden="true">↗</span>
+  </a>
+
+  <div class="navcard navcard--action" (click)="openDialog()">
+    <div class="navcard__mark">D</div>
+    <h2 class="navcard__title">Manage Decks</h2>
+    <p class="navcard__sub">Rename and organise decks</p>
+    <span class="navcard__arrow" aria-hidden="true">↗</span>
   </div>
-  <div class="router-outlet-container">
-    <router-outlet></router-outlet>
-  </div>
+
+</main>
+
+<div class="content-area">
+  <router-outlet></router-outlet>
 </div>

--- a/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.html
+++ b/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.html
@@ -2,38 +2,38 @@
   <button mat-fab routerLink="/" class="home-fab">
     <mat-icon>home</mat-icon>
   </button>
-</div>
 
-<main class="navgrid">
+  <div class="navgrid">
 
-  <a class="navcard" routerLink="/vocabulary/add">
-    <div class="navcard__mark">+</div>
-    <div class="navcard__body">
-      <h2 class="navcard__title">Add Word</h2>
-      <p class="navcard__sub">Look up and save new vocabulary</p>
+    <a class="navcard" routerLink="/vocabulary/add">
+      <div class="navcard__mark">+</div>
+      <div class="navcard__body">
+        <h2 class="navcard__title">Add Word</h2>
+        <p class="navcard__sub">Look up and save new vocabulary</p>
+      </div>
+      <span class="navcard__arrow" aria-hidden="true">↗</span>
+    </a>
+
+    <a class="navcard" routerLink="/vocabulary/list">
+      <div class="navcard__mark">L</div>
+      <div class="navcard__body">
+        <h2 class="navcard__title">List</h2>
+        <p class="navcard__sub">Browse all flashcards</p>
+      </div>
+      <span class="navcard__arrow" aria-hidden="true">↗</span>
+    </a>
+
+    <div class="navcard navcard--action" (click)="openDialog()">
+      <div class="navcard__mark">D</div>
+      <div class="navcard__body">
+        <h2 class="navcard__title">Manage Decks</h2>
+        <p class="navcard__sub">Rename and organise decks</p>
+      </div>
+      <span class="navcard__arrow" aria-hidden="true">↗</span>
     </div>
-    <span class="navcard__arrow" aria-hidden="true">↗</span>
-  </a>
 
-  <a class="navcard" routerLink="/vocabulary/list">
-    <div class="navcard__mark">L</div>
-    <div class="navcard__body">
-      <h2 class="navcard__title">List</h2>
-      <p class="navcard__sub">Browse all flashcards</p>
-    </div>
-    <span class="navcard__arrow" aria-hidden="true">↗</span>
-  </a>
-
-  <div class="navcard navcard--action" (click)="openDialog()">
-    <div class="navcard__mark">D</div>
-    <div class="navcard__body">
-      <h2 class="navcard__title">Manage Decks</h2>
-      <p class="navcard__sub">Rename and organise decks</p>
-    </div>
-    <span class="navcard__arrow" aria-hidden="true">↗</span>
   </div>
-
-</main>
+</div>
 
 <div class="content-area">
   <router-outlet></router-outlet>

--- a/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.css
+++ b/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.css
@@ -191,6 +191,10 @@ table {
   background: var(--raised) !important;
 }
 
+::ng-deep .filter-panel input.mat-mdc-input-element {
+  color: var(--text) !important;
+}
+
 /* Mat checkbox */
 ::ng-deep .filter-panel .mat-mdc-checkbox .mdc-label {
   color: var(--text-muted);

--- a/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.css
+++ b/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.css
@@ -1,13 +1,171 @@
-.clickable-row {
-  cursor: pointer;
-  transition: background-color 0.3s ease, transform 0.2s ease, box-shadow 0.2s ease;
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;700&display=swap');
 
-  &:hover {
-    background-color: rgba(63, 81, 181, 0.1);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-  }
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255,255,255,0.07);
+  --border-mid:  rgba(255,255,255,0.13);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+  --c-v:         #fbbf24;
+  --cg-v:        rgba(251,191,36,0.18);
+
+  display: block;
+  min-height: 100%;
+  background: var(--bg);
+  background-image:
+    radial-gradient(ellipse 80% 50% at 5% 10%, rgba(251,191,36,0.06) 0%, transparent 60%),
+    radial-gradient(ellipse 60% 40% at 95% 90%, rgba(251,191,36,0.04) 0%, transparent 55%);
+  background-attachment: fixed;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+  position: relative;
 }
 
+:host::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image: radial-gradient(circle, rgba(255,255,255,0.025) 1px, transparent 1px);
+  background-size: 28px 28px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* Layout */
+.vocab-list {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 2rem 4rem;
+  gap: 1rem;
+}
+
+/* Header */
+.table-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.table-header__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--c-v);
+  box-shadow: 0 0 6px var(--c-v);
+  animation: blink 2s ease-in-out infinite;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+.table-header__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+}
+
+/* Filter panel */
+.filter-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  color: var(--text);
+}
+
+.stats-badge {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  background: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.25rem 0.625rem;
+  white-space: nowrap;
+}
+
+/* Table container */
+.table-container {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  max-height: 75vh;
+  overflow-y: auto;
+  position: relative;
+}
+
+.table-container::-webkit-scrollbar {
+  width: 4px;
+}
+.table-container::-webkit-scrollbar-track {
+  background: var(--surface);
+}
+.table-container::-webkit-scrollbar-thumb {
+  background: var(--border-mid);
+  border-radius: 2px;
+}
+
+/* Material table overrides */
+table {
+  width: 100%;
+  background: transparent !important;
+}
+
+.col-header {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.6rem !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.12em !important;
+  text-transform: uppercase !important;
+  color: var(--text-dim) !important;
+  background: var(--raised) !important;
+  border-bottom: 1px solid var(--border-mid) !important;
+  height: 36px !important;
+  padding: 0 16px !important;
+}
+
+::ng-deep .mat-mdc-header-row {
+  background: var(--raised) !important;
+}
+
+::ng-deep .mat-mdc-cell {
+  font-size: 0.8rem !important;
+  color: var(--text) !important;
+  background: transparent !important;
+  border-bottom: 1px solid var(--border) !important;
+}
+
+/* Clickable rows */
+.clickable-row {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.clickable-row:hover {
+  background-color: rgba(251,191,36,0.08) !important;
+}
+
+.clickable-row:hover ::ng-deep .mat-mdc-cell {
+  background-color: transparent !important;
+}
+
+/* Column widths */
 .mat-column-deck,
 .mat-column-ankiId {
   width: 10%;
@@ -16,4 +174,46 @@
 .mat-column-front,
 .mat-column-back {
   width: 15%;
+}
+
+/* Material form-field (outline) dark overrides */
+::ng-deep .filter-panel .mat-mdc-form-field {
+  --mdc-outlined-text-field-outline-color: var(--border-mid);
+  --mdc-outlined-text-field-hover-outline-color: var(--c-v);
+  --mdc-outlined-text-field-focus-outline-color: var(--c-v);
+  --mdc-outlined-text-field-label-text-color: var(--text-muted);
+  --mdc-outlined-text-field-focus-label-text-color: var(--c-v);
+  --mdc-outlined-text-field-input-text-color: var(--text);
+  --mdc-outlined-text-field-container-shape: 8px;
+}
+
+::ng-deep .filter-panel .mat-mdc-text-field-wrapper {
+  background: var(--raised) !important;
+}
+
+/* Mat checkbox */
+::ng-deep .filter-panel .mat-mdc-checkbox .mdc-label {
+  color: var(--text-muted);
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.85rem;
+}
+
+::ng-deep .filter-panel .mat-mdc-checkbox.mat-mdc-checkbox-checked .mdc-checkbox__background {
+  background-color: var(--c-v) !important;
+  border-color: var(--c-v) !important;
+}
+
+/* Mat select panel */
+::ng-deep .mat-mdc-select-value-text {
+  color: var(--text);
+}
+
+::ng-deep .mat-mdc-option {
+  background: var(--surface) !important;
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-option:hover,
+::ng-deep .mat-mdc-option.mat-mdc-option-active {
+  background: var(--raised) !important;
 }

--- a/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.html
+++ b/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.html
@@ -1,91 +1,88 @@
-<div class="h-100 d-flex flex-column p-2">
+<div class="vocab-list">
 
-  <div class="row m-0">
-    <div class="col-3 p-0 d-flex flex-column flex-shrink-1">
-      <mat-form-field>
-        <mat-label>Filter</mat-label>
-        <input matInput (keyup)="applyFilter($event)">
-      </mat-form-field>
-    </div>
-    <div class="col-5 d-flex justify-content-between flex-wrap">
-      <mat-checkbox
-          [(ngModel)]="withoutArticle"
-          (change)="filterWithoutArticle('withoutArticle')">
-        Without Article
-      </mat-checkbox>
-      <mat-checkbox
-          [(ngModel)]="markedAsupdated"
-          (change)="filterMarkedAsUpdated('markedAsUpdated')">
-        Updated
-      </mat-checkbox>
-      <mat-checkbox
-          [(ngModel)]="withoutDescription"
-          (change)="filterWithoutDescription('withoutDescription')">
-        Without Description
-      </mat-checkbox>
-      <mat-form-field>
-        <mat-label>Deck</mat-label>
-        <mat-select (selectionChange)="filterDeck($event)">
-          @for (deck of decks(); track deck.id) {
-            <mat-option value="{{deck.id}}">{{ deck.name }}</mat-option>
-          }
-        </mat-select>
-      </mat-form-field>
-    </div>
-    <div class="col-4">
-      @if (hasActiveFilters()) {
-        <div class="alert alert-info mb-0 py-2 px-3">
-          <small>
-            <strong>{{ filteredCount() }}</strong> of <strong>{{ totalCount() }}</strong> entries match current filters
-          </small>
-        </div>
-      } @else {
-        <div class="alert alert-info mb-0 py-2 px-3 text-center">
-          <small>
-            <strong>{{ totalCount() }}</strong> entries
-          </small>
-        </div>
-      }
-    </div>
+  <header class="table-header">
+    <span class="table-header__dot"></span>
+    <span class="table-header__label">VOCABULARY</span>
+  </header>
+
+  <div class="filter-panel">
+    <mat-form-field appearance="outline">
+      <mat-label>Filter</mat-label>
+      <input matInput (keyup)="applyFilter($event)">
+    </mat-form-field>
+
+    <mat-checkbox
+        [(ngModel)]="withoutArticle"
+        (change)="filterWithoutArticle('withoutArticle')">
+      Without Article
+    </mat-checkbox>
+    <mat-checkbox
+        [(ngModel)]="markedAsupdated"
+        (change)="filterMarkedAsUpdated('markedAsUpdated')">
+      Updated
+    </mat-checkbox>
+    <mat-checkbox
+        [(ngModel)]="withoutDescription"
+        (change)="filterWithoutDescription('withoutDescription')">
+      Without Description
+    </mat-checkbox>
+
+    <mat-form-field appearance="outline">
+      <mat-label>Deck</mat-label>
+      <mat-select (selectionChange)="filterDeck($event)">
+        @for (deck of decks(); track deck.id) {
+          <mat-option value="{{deck.id}}">{{ deck.name }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
+    @if (hasActiveFilters()) {
+      <span class="stats-badge">
+        <strong>{{ filteredCount() }}</strong> / <strong>{{ totalCount() }}</strong> entries
+      </span>
+    } @else {
+      <span class="stats-badge">
+        <strong>{{ totalCount() }}</strong> entries
+      </span>
+    }
   </div>
 
-  <div class="border border-black border-1 overflow-auto">
-    <div>
-      <table mat-table [dataSource]="flashcards" matSort>
+  <div class="table-container">
+    <table mat-table [dataSource]="flashcards" matSort>
 
-        <ng-container matColumnDef="deck">
-          <th mat-header-cell *matHeaderCellDef>deck</th>
-          <td mat-cell *matCellDef="let element">{{ getDeck(element) }}</td>
-        </ng-container>
+      <ng-container matColumnDef="deck">
+        <th mat-header-cell *matHeaderCellDef class="col-header">deck</th>
+        <td mat-cell *matCellDef="let element">{{ getDeck(element) }}</td>
+      </ng-container>
 
-        <ng-container matColumnDef="front">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header>front</th>
-          <td mat-cell *matCellDef="let element">{{ element.front }}</td>
-        </ng-container>
+      <ng-container matColumnDef="front">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="col-header">front</th>
+        <td mat-cell *matCellDef="let element">{{ element.front }}</td>
+      </ng-container>
 
-        <ng-container matColumnDef="back">
-          <th mat-header-cell *matHeaderCellDef>back</th>
-          <td mat-cell *matCellDef="let element">{{ element.back }}</td>
-        </ng-container>
+      <ng-container matColumnDef="back">
+        <th mat-header-cell *matHeaderCellDef class="col-header">back</th>
+        <td mat-cell *matCellDef="let element">{{ element.back }}</td>
+      </ng-container>
 
-        <ng-container matColumnDef="description">
-          <th mat-header-cell *matHeaderCellDef>description</th>
-          <td mat-cell *matCellDef="let element">{{ element.description }}</td>
-        </ng-container>
+      <ng-container matColumnDef="description">
+        <th mat-header-cell *matHeaderCellDef class="col-header">description</th>
+        <td mat-cell *matCellDef="let element">{{ element.description }}</td>
+      </ng-container>
 
-        <ng-container matColumnDef="ankiId">
-          <th mat-header-cell *matHeaderCellDef>ankiId</th>
-          <td mat-cell *matCellDef="let element">{{ element.ankiId }}</td>
-        </ng-container>
+      <ng-container matColumnDef="ankiId">
+        <th mat-header-cell *matHeaderCellDef class="col-header">ankiId</th>
+        <td mat-cell *matCellDef="let element">{{ element.ankiId }}</td>
+      </ng-container>
 
-        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-        <tr
-            mat-row
-            *matRowDef="let word; columns: displayedColumns;"
-            (click)="navigateToWord(word.id)"
-        ></tr>
-      </table>
-    </div>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr
+          mat-row
+          class="clickable-row"
+          *matRowDef="let word; columns: displayedColumns;"
+          (click)="navigateToWord(word.id)"
+      ></tr>
+    </table>
   </div>
 
 </div>


### PR DESCRIPTION
## Summary

- **Step 1 — `vocabulary-home`:** Replaced old flex-nav with the navcard grid pattern. Introduces vocabulary design tokens (`--c-v: #fbbf24`, `--cg-v`) and dark background recipe. Three navcards: Add Word, List, Manage Decks with staggered `fadeUp` animation.
- **Step 2 — `vocabulary-list`:** Ported dark table layout from `plant-table`. Yellow row hover (`rgba(251,191,36,0.08)`), dark filter panel, blinking dot header, custom scrollbar.
- **Step 3 — Dialogs (`article-dialog`, `deck-management-dialog`, `deck-change-name-dialog`):** Dark `mdc-dialog__surface`, JetBrains Mono titles, yellow accent buttons and hover states.
- **Step 4 — `add-word`:** Dark 3-panel layout (dictionary / translation / save word). Yellow definition selection glow, yellow primary button, dark Material form field and button-toggle overrides.

## Test plan

- [ ] `npm run build` passes
- [ ] `/vocabulary` — three yellow nav cards with hover glow + translateY animation
- [ ] `/vocabulary/list` — dark table, yellow row hover, dark filter panel
- [ ] `/vocabulary/add` — dark 3-panel layout, yellow definition selection, yellow button glow
- [ ] Dialogs (article select, deck management, deck rename) — dark surface, yellow accents
- [ ] Responsive at mobile (< 640px) and desktop (> 1024px)
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)