### PR TITLE
Fix: add-word three-column layout (translation section visibility)

### DIFF
--- a/src/app/vocabulary/components/add-word/add-word.component.css
+++ b/src/app/vocabulary/components/add-word/add-word.component.css
@@ -114,7 +114,7 @@
 .dictionary-section {
   display: flex;
   flex-direction: column;
-  flex: 1.5;
+  flex: 1.4;
   min-height: 0;
 }
 
@@ -221,8 +221,10 @@
 
 /* Translation section */
 .translation-section {
-  margin-top: 1rem;
-  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  flex: 0.8;
+  min-height: 0;
 }
 
 .translation-section form {
@@ -350,6 +352,7 @@
   }
 
   .dictionary-section,
+  .translation-section,
   .save-word-section {
     flex: none;
     min-height: auto;

--- a/src/app/vocabulary/components/add-word/add-word.component.css
+++ b/src/app/vocabulary/components/add-word/add-word.component.css
@@ -106,6 +106,7 @@
   display: flex;
   flex: 1;
   min-height: 0;
+  overflow: hidden;
   padding: 1rem;
   gap: 1rem;
 }

--- a/src/app/vocabulary/components/add-word/add-word.component.css
+++ b/src/app/vocabulary/components/add-word/add-word.component.css
@@ -299,7 +299,8 @@
 ::ng-deep .search-bar input.mat-mdc-input-element,
 ::ng-deep .dictionary-section input.mat-mdc-input-element,
 ::ng-deep .translation-section input.mat-mdc-input-element,
-::ng-deep .save-word-section input.mat-mdc-input-element {
+::ng-deep .save-word-section input.mat-mdc-input-element,
+::ng-deep .save-word-section textarea.mat-mdc-input-element {
   color: var(--text) !important;
 }
 

--- a/src/app/vocabulary/components/add-word/add-word.component.html
+++ b/src/app/vocabulary/components/add-word/add-word.component.html
@@ -93,44 +93,45 @@
         </div>
       </div>
 
-      <!-- Translation Section -->
-      @if (wordToShow) {
-        <div class="translation-section">
-          <header class="panel-header">
-            <span class="panel-dot"></span>
-            <span class="panel-label">TRANSLATION</span>
-          </header>
-
-          <form
-              [formGroup]="wordFormTranslation"
-              (ngSubmit)="onSubmitTranslation()"
-          >
-            <mat-form-field appearance="outline">
-              <mat-label>Word</mat-label>
-              <input matInput formControlName="word">
-            </mat-form-field>
-
-            <mat-form-field appearance="outline">
-              <mat-label>Context</mat-label>
-              <input matInput formControlName="context">
-            </mat-form-field>
-
-            <button
-                mat-flat-button
-                color="primary"
-                [disabled]="!wordFormTranslation.valid"
-                type="submit"
-            >
-              Translate
-            </button>
-          </form>
-
-          @if (translation()) {
-            <div class="translation-result">{{ translation() }}</div>
-          }
-        </div>
-      }
     </div>
+
+    <!-- Translation Section -->
+    @if (wordToShow) {
+      <div class="translation-section">
+        <header class="panel-header">
+          <span class="panel-dot"></span>
+          <span class="panel-label">TRANSLATION</span>
+        </header>
+
+        <form
+            [formGroup]="wordFormTranslation"
+            (ngSubmit)="onSubmitTranslation()"
+        >
+          <mat-form-field appearance="outline">
+            <mat-label>Word</mat-label>
+            <input matInput formControlName="word">
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
+            <mat-label>Context</mat-label>
+            <input matInput formControlName="context">
+          </mat-form-field>
+
+          <button
+              mat-flat-button
+              color="primary"
+              [disabled]="!wordFormTranslation.valid"
+              type="submit"
+          >
+            Translate
+          </button>
+        </form>
+
+        @if (translation()) {
+          <div class="translation-result">{{ translation() }}</div>
+        }
+      </div>
+    }
 
     <!-- Save Word Section -->
     <div class="save-word-section">

--- a/src/app/vocabulary/components/add-word/add-word.component.html
+++ b/src/app/vocabulary/components/add-word/add-word.component.html
@@ -39,6 +39,7 @@
         </header>
       }
 
+      @if (wordToShow) {
       <div class="entries-container">
         <div class="word-entries-list">
           @for (wordEntry of wordEntries(); track entryIndex; let entryIndex = $index) {
@@ -92,6 +93,7 @@
           }
         </div>
       </div>
+      }
 
     </div>
 

--- a/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.css
+++ b/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.css
@@ -15,8 +15,10 @@
   --c-v:  #fbbf24;
   --cg-v: rgba(251, 191, 36, 0.18);
 
-  display: block;
-  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
   font-family: 'Outfit', sans-serif;
   color: var(--text);
   background-color: var(--bg);
@@ -33,6 +35,7 @@
   align-items: center;
   gap: 1rem;
   padding: 0.75rem 1rem;
+  flex-shrink: 0;
 }
 
 ::ng-deep .home-fab.mat-mdc-fab {
@@ -207,5 +210,8 @@
 
 /* ── Content Area ────────────────────────────────── */
 .content-area {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
   padding: 0 1rem;
 }


### PR DESCRIPTION
## Summary

- Moves `.translation-section` out of `.dictionary-section` so it becomes a direct peer child of `.add-word-main`
- All three panels (Dictionary / Translation / Save Word) are now independent flex columns with ratios `1.4 / 0.8 / 1`
- Removes the `margin-top` hack from `.translation-section` (no longer needed)
- Adds `.translation-section` to the mobile stacking breakpoint (`max-width: 820px`)

**Before:** `.translation-section` was nested inside `.dictionary-section`, which caused `.entries-container` (`flex: 1`) to consume all available height and push the translation form out of view.

**After:** Three independent, side-by-side panels — each self-contained and independently scrollable.

## Test plan

- [ ] `npm run build` passes (no errors)
- [ ] Desktop (≥ 820px): three columns visible side by side; entries list scrolls independently; translation form fully visible; save-word form fully visible
- [ ] Mobile (< 820px): sections stack vertically in order — dictionary → translation → save word