### PR TITLE
feature: add Backups card to exports with backup run history table

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -18,6 +18,7 @@ import {ArithmeticSessionComponent} from './mental-arithmetic/components/arithme
 import {ArithmeticListComponent} from './mental-arithmetic/components/arithmetic-list/arithmetic-list.component';
 import {ExportsComponent} from './exports/exports.component';
 import {ExportsFilesComponent} from './exports/exports-files.component';
+import {ExportsBackupsComponent} from './exports/exports-backups.component';
 
 export const routes: Routes = [
   {path: '', component: HomeComponent},
@@ -26,7 +27,8 @@ export const routes: Routes = [
     path: 'exports',
     children: [
       {path: '', component: ExportsComponent},
-      {path: 'files', component: ExportsFilesComponent}
+      {path: 'files', component: ExportsFilesComponent},
+      {path: 'backups', component: ExportsBackupsComponent}
     ]
   },
   {

--- a/src/app/exports/exports-backups.component.css
+++ b/src/app/exports/exports-backups.component.css
@@ -1,0 +1,207 @@
+:host {
+  /* Exports: dark fluid theme tokens (component-scoped) */
+  --ex-bg: #0b0f17;
+  --ex-bg-2: #0a1221;
+  --ex-surface: rgba(255, 255, 255, 0.06);
+  --ex-surface-2: rgba(255, 255, 255, 0.08);
+  --ex-surface-3: rgba(255, 255, 255, 0.10);
+
+  --ex-border: rgba(255, 255, 255, 0.10);
+  --ex-border-strong: rgba(255, 255, 255, 0.16);
+  --ex-shadow: 0 14px 40px rgba(0, 0, 0, 0.45);
+  --ex-shadow-soft: 0 8px 24px rgba(0, 0, 0, 0.35);
+
+  --ex-text: rgba(255, 255, 255, 0.92);
+  --ex-text-muted: rgba(255, 255, 255, 0.68);
+  --ex-text-faint: rgba(255, 255, 255, 0.52);
+
+  --ex-accent: #7c5cff; /* violet */
+  --ex-accent-2: #22d3ee; /* cyan */
+  --ex-focus: rgba(124, 92, 255, 0.55);
+
+  --ex-danger: #ff4d4d;
+  --ex-success: #4caf7d;
+
+  --ex-radius-lg: 16px;
+  --ex-radius-md: 12px;
+  --ex-radius-sm: 10px;
+  --ex-gap: 16px;
+}
+
+/* Shell */
+.exports-shell {
+  color: var(--ex-text);
+}
+
+.exports-shell.container {
+  max-width: 1200px;
+  padding: clamp(16px, 2.4vw, 28px);
+  border-radius: var(--ex-radius-lg);
+  background:
+    radial-gradient(1200px 600px at 10% -10%, rgba(124, 92, 255, 0.26), transparent 55%),
+    radial-gradient(900px 500px at 90% 10%, rgba(34, 211, 238, 0.14), transparent 55%),
+    linear-gradient(180deg, var(--ex-bg-2), var(--ex-bg));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: var(--ex-shadow);
+}
+
+.exports-shell h2 {
+  font-size: 1.75rem;
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+
+.exports-shell h3 {
+  font-size: 1.125rem;
+  letter-spacing: -0.01em;
+  color: rgba(255, 255, 255, 0.90);
+}
+
+.exports-shell button[mat-icon-button] {
+  border-radius: 12px;
+}
+
+.exports-shell button[mat-icon-button]:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.exports-shell button[mat-icon-button]:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--ex-focus);
+}
+
+/* Backups panel (Bootstrap card) */
+.exports-backups .card {
+  border-radius: var(--ex-radius-lg);
+  border: 1px solid var(--ex-border);
+  background: linear-gradient(180deg, var(--ex-surface-2), var(--ex-surface));
+  box-shadow: var(--ex-shadow-soft);
+  overflow: hidden;
+}
+
+.exports-backups .card-header {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.exports-backups .card-header h5 {
+  color: rgba(255, 255, 255, 0.90);
+}
+
+.exports-backups .card-body {
+  color: var(--ex-text);
+  padding: 0;
+}
+
+.w-100 {
+  width: 100%;
+}
+
+/* Angular Material table (MDC) */
+table[mat-table] {
+  background: transparent;
+}
+
+table[mat-table] .mat-mdc-header-row {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+table[mat-table] .mat-mdc-header-cell {
+  color: rgba(255, 255, 255, 0.78);
+  font-weight: 600;
+  border-bottom-color: rgba(255, 255, 255, 0.10);
+}
+
+table[mat-table] .mat-mdc-row {
+  transition: background 160ms ease;
+}
+
+table[mat-table] .mat-mdc-row:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+table[mat-table] .mat-mdc-cell {
+  color: rgba(255, 255, 255, 0.86);
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+table[mat-table] button[mat-icon-button] {
+  border-radius: 10px;
+}
+
+table[mat-table] button[mat-icon-button]:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+/* Status badges */
+.status-badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 20px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.status-success {
+  background: rgba(76, 175, 125, 0.18);
+  color: #4caf7d;
+  border: 1px solid rgba(76, 175, 125, 0.30);
+}
+
+.status-failed {
+  background: rgba(255, 77, 77, 0.15);
+  color: var(--ex-danger);
+  border: 1px solid rgba(255, 77, 77, 0.28);
+}
+
+.status-in-progress {
+  background: rgba(34, 211, 238, 0.12);
+  color: var(--ex-accent-2);
+  border: 1px solid rgba(34, 211, 238, 0.25);
+}
+
+/* Upload success/failure icons */
+.icon-success {
+  color: var(--ex-success);
+  vertical-align: middle;
+}
+
+.icon-danger {
+  color: var(--ex-danger);
+  vertical-align: middle;
+}
+
+/* Paginator */
+mat-paginator {
+  background: transparent;
+  color: var(--ex-text-muted);
+  border-top: 1px solid var(--ex-border);
+}
+
+/* Bootstrap alerts (dark equivalents) */
+.alert {
+  border-radius: var(--ex-radius-lg);
+  border: 1px solid var(--ex-border);
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.86);
+}
+
+.alert-info {
+  border-color: rgba(34, 211, 238, 0.25);
+}
+
+.alert-danger {
+  border-color: rgba(255, 77, 77, 0.28);
+}
+
+/* Spinner label */
+.exports-shell p {
+  color: var(--ex-text-muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    transition: none !important;
+  }
+}

--- a/src/app/exports/exports-backups.component.html
+++ b/src/app/exports/exports-backups.component.html
@@ -1,0 +1,112 @@
+<div class="container mt-4 exports-shell">
+  <div class="d-flex justify-content-between align-items-center">
+    <h2>Backups</h2>
+    <div class="d-flex align-items-center" style="gap: 8px;">
+      <button mat-icon-button routerLink="/exports" matTooltip="Back to Exports">
+        <mat-icon>arrow_back</mat-icon>
+      </button>
+      <button mat-icon-button routerLink="/" matTooltip="Back to Home">
+        <mat-icon>home</mat-icon>
+      </button>
+    </div>
+  </div>
+
+  <div class="mt-5 exports-backups">
+    <h3>Backup Run History</h3>
+
+    @if (isLoading) {
+      <div class="text-center mt-4">
+        <mat-spinner></mat-spinner>
+        <p class="mt-2">Loading backup runs...</p>
+      </div>
+    }
+
+    @if (error) {
+      <div class="alert alert-danger mt-4">
+        <strong>Error:</strong> {{ error }}
+      </div>
+    }
+
+    @if (!isLoading && !error && backupRuns.length === 0) {
+      <div class="alert alert-info mt-4">
+        No backup runs found.
+      </div>
+    }
+
+    @if (!isLoading && !error && backupRuns.length > 0) {
+      <div class="mt-4">
+        <div class="card">
+          <div class="card-header d-flex justify-content-between align-items-center">
+            <h5 class="mb-0">Backup Runs ({{ totalElements }})</h5>
+            <button mat-icon-button (click)="loadBackupRuns()" [disabled]="isLoading" matTooltip="Refresh">
+              <mat-icon>refresh</mat-icon>
+            </button>
+          </div>
+          <div class="card-body">
+            <table mat-table [dataSource]="backupRuns" class="w-100">
+
+              <!-- File Name Column -->
+              <ng-container matColumnDef="fileName">
+                <th mat-header-cell *matHeaderCellDef>File Name</th>
+                <td mat-cell *matCellDef="let run">{{ run.fileName }}</td>
+              </ng-container>
+
+              <!-- Status Column -->
+              <ng-container matColumnDef="status">
+                <th mat-header-cell *matHeaderCellDef>Status</th>
+                <td mat-cell *matCellDef="let run">
+                  <span class="status-badge" [class]="'status-' + run.status.toLowerCase().replace('_', '-')">
+                    {{ run.status }}
+                  </span>
+                </td>
+              </ng-container>
+
+              <!-- Started At Column -->
+              <ng-container matColumnDef="startedAt">
+                <th mat-header-cell *matHeaderCellDef>Started</th>
+                <td mat-cell *matCellDef="let run">{{ formatDateTime(run.startedAt) }}</td>
+              </ng-container>
+
+              <!-- Finished At Column -->
+              <ng-container matColumnDef="finishedAt">
+                <th mat-header-cell *matHeaderCellDef>Finished</th>
+                <td mat-cell *matCellDef="let run">{{ formatDateTime(run.finishedAt) }}</td>
+              </ng-container>
+
+              <!-- Duration Column -->
+              <ng-container matColumnDef="durationMs">
+                <th mat-header-cell *matHeaderCellDef>Duration</th>
+                <td mat-cell *matCellDef="let run">{{ formatDuration(run.durationMs) }}</td>
+              </ng-container>
+
+              <!-- Upload Success Column -->
+              <ng-container matColumnDef="uploadSuccess">
+                <th mat-header-cell *matHeaderCellDef>Upload</th>
+                <td mat-cell *matCellDef="let run">
+                  @if (run.uploadSuccess === true) {
+                    <mat-icon class="icon-success" matTooltip="Upload successful">check_circle</mat-icon>
+                  } @else if (run.uploadSuccess === false) {
+                    <mat-icon class="icon-danger" [matTooltip]="run.errorMessage || 'Upload failed'">cancel</mat-icon>
+                  } @else {
+                    <span>-</span>
+                  }
+                </td>
+              </ng-container>
+
+              <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+              <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+            </table>
+
+            <mat-paginator
+              [length]="totalElements"
+              [pageSize]="pageSize"
+              [pageIndex]="pageIndex"
+              [pageSizeOptions]="[10, 20, 50]"
+              (page)="onPageChange($event)"
+            ></mat-paginator>
+          </div>
+        </div>
+      </div>
+    }
+  </div>
+</div>

--- a/src/app/exports/exports-backups.component.ts
+++ b/src/app/exports/exports-backups.component.ts
@@ -1,0 +1,88 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+import { BackupRunService } from './services/backup/backup-run.service';
+import { BackupRun } from './services/backup/backup-run.model';
+
+@Component({
+  selector: 'app-exports-backups',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    CommonModule,
+    RouterModule,
+    MatTableModule,
+    MatIconModule,
+    MatButtonModule,
+    MatProgressSpinnerModule,
+    MatTooltipModule,
+    MatPaginatorModule
+  ],
+  templateUrl: './exports-backups.component.html',
+  styleUrl: './exports-backups.component.css'
+})
+export class ExportsBackupsComponent implements OnInit {
+  backupRuns: BackupRun[] = [];
+  isLoading = true;
+  error: string | null = null;
+  displayedColumns: string[] = ['fileName', 'status', 'startedAt', 'finishedAt', 'durationMs', 'uploadSuccess'];
+  totalElements = 0;
+  pageSize = 20;
+  pageIndex = 0;
+
+  constructor(
+    private backupRunService: BackupRunService,
+    private cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit(): void {
+    this.loadBackupRuns();
+  }
+
+  loadBackupRuns(): void {
+    this.isLoading = true;
+    this.error = null;
+
+    this.backupRunService.getBackupRuns(this.pageSize, this.pageIndex * this.pageSize).subscribe({
+      next: (page) => {
+        this.backupRuns = page.content;
+        this.totalElements = page.totalElements;
+        this.isLoading = false;
+        this.cdr.markForCheck();
+      },
+      error: (err) => {
+        this.error = 'Failed to load backup runs: ' + err.message;
+        this.isLoading = false;
+        this.cdr.markForCheck();
+      }
+    });
+  }
+
+  onPageChange(event: PageEvent): void {
+    this.pageIndex = event.pageIndex;
+    this.pageSize = event.pageSize;
+    this.loadBackupRuns();
+  }
+
+  formatDuration(ms: number | null): string {
+    if (ms === null) return '-';
+    if (ms < 1000) return `${ms}ms`;
+    const seconds = ms / 1000;
+    if (seconds < 60) return `${seconds.toFixed(1)}s`;
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = Math.floor(seconds % 60);
+    return `${minutes}m ${remainingSeconds}s`;
+  }
+
+  formatDateTime(dt: string | null): string {
+    if (!dt) return '-';
+    return new Date(dt).toLocaleString('de-DE');
+  }
+}

--- a/src/app/exports/exports.component.html
+++ b/src/app/exports/exports.component.html
@@ -23,6 +23,21 @@
       </mat-card-actions>
     </mat-card>
 
+    <mat-card class="export-card" routerLink="backups">
+      <mat-card-header>
+        <mat-card-title>Backups</mat-card-title>
+        <mat-card-subtitle>Uploaded backup run history</mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content>
+        <div class="card-icon">
+          <mat-icon>backup</mat-icon>
+        </div>
+      </mat-card-content>
+      <mat-card-actions>
+        <button mat-button color="primary">OPEN</button>
+      </mat-card-actions>
+    </mat-card>
+
     <mat-card class="export-card">
       <mat-card-header>
         <mat-card-title>Anki Sync</mat-card-title>

--- a/src/app/exports/services/backup/backup-run.model.ts
+++ b/src/app/exports/services/backup/backup-run.model.ts
@@ -1,0 +1,18 @@
+export interface BackupRun {
+  id: number;
+  fileName: string;
+  status: string;
+  startedAt: string;
+  finishedAt: string | null;
+  durationMs: number | null;
+  uploadSuccess: boolean | null;
+  errorMessage: string | null;
+}
+
+export interface BackupRunPage {
+  content: BackupRun[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+}

--- a/src/app/exports/services/backup/backup-run.service.ts
+++ b/src/app/exports/services/backup/backup-run.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { BackupRunPage } from './backup-run.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BackupRunService {
+  host: string = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getBackupRuns(limit = 20, offset = 0): Observable<BackupRunPage> {
+    return this.http.get<BackupRunPage>(`${this.host}/backups`, {
+      params: { limit: limit.toString(), offset: offset.toString() }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new "Backups" card to `/exports` that navigates to `/exports/backups`
- New `ExportsBackupsComponent` displays backup runs in a mat-table with pagination
- `BackupRunService` calls `GET /backups?limit=&offset=` from the backend
- Status column shows color-coded badges (SUCCESS/FAILED/IN_PROGRESS); upload success shown with icons

## Test plan
- [ ] Navigate to `/exports` → three cards visible: Files, Backups, Anki Sync
- [ ] Click Backups card → navigates to `/exports/backups`
- [ ] Table loads; network tab shows `GET /backups?limit=20&offset=0`
- [ ] Pagination controls update offset and reload data
- [ ] Status badges render with correct colors
- [ ] Upload success column shows check/cancel icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)