### PR TITLE
Sort backup runs by started date descending

### DIFF
--- a/src/app/exports/exports-backups.component.ts
+++ b/src/app/exports/exports-backups.component.ts
@@ -52,7 +52,9 @@ export class ExportsBackupsComponent implements OnInit {
 
     this.backupRunService.getBackupRuns(this.pageSize, this.pageIndex * this.pageSize).subscribe({
       next: (page) => {
-        this.backupRuns = page.content;
+        this.backupRuns = page.content.slice().sort((a, b) =>
+          new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()
+        );
         this.totalElements = page.totalElements;
         this.isLoading = false;
         this.cdr.markForCheck();


### PR DESCRIPTION
## Summary
- Sorts the backup run table by `startedAt` descending (latest first) after each page load
- Sorting is done client-side since the API does not support server-side ordering

## Test plan
- [ ] Navigate to Exports → Backups
- [ ] Verify the table shows the most recently started backup run at the top
- [ ] Change pages and verify each page is sorted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)