### PR TITLE
feat: add IT News frontend with article list

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -19,6 +19,8 @@ import {ArithmeticListComponent} from './mental-arithmetic/components/arithmetic
 import {ExportsComponent} from './exports/exports.component';
 import {ExportsFilesComponent} from './exports/exports-files.component';
 import {ExportsBackupsComponent} from './exports/exports-backups.component';
+import {ItNewsLayoutComponent} from './it-news/components/it-news-layout/it-news-layout.component';
+import {ArticleListComponent} from './it-news/components/article-list/article-list.component';
 
 export const routes: Routes = [
   {path: '', component: HomeComponent},
@@ -61,6 +63,13 @@ export const routes: Routes = [
       {path: 'settings', component: ArithmeticSettingsComponent, data: {home: '/mental-arithmetic'}},
       {path: 'session', component: ArithmeticSessionComponent, data: {home: '/mental-arithmetic'}},
       {path: 'arithmetic-list', component: ArithmeticListComponent, data: {home: '/mental-arithmetic'}}
+    ]
+  },
+  {
+    path: 'it-news',
+    component: ItNewsLayoutComponent,
+    children: [
+      {path: '', component: ArticleListComponent, data: {home: '/'}},
     ]
   }
 ];

--- a/src/app/home/home.component.css
+++ b/src/app/home/home.component.css
@@ -18,6 +18,7 @@
   --c-v:  #fbbf24;  --cg-v: rgba(251, 191,  36, 0.18);
   --c-m:  #a78bfa;  --cg-m: rgba(167, 139, 250, 0.18);
   --c-e:  #fb7185;  --cg-e: rgba(251, 113, 133, 0.18);
+  --c-n:  #2dd4bf;  --cg-n: rgba(45,  212, 191, 0.18);
 
   display: block;
   min-height: 100dvh;
@@ -194,6 +195,7 @@
 .navcard--v { --cc: var(--c-v); --cc-glow: var(--cg-v); }
 .navcard--m { --cc: var(--c-m); --cc-glow: var(--cg-m); }
 .navcard--e { --cc: var(--c-e); --cc-glow: var(--cg-e); }
+.navcard--n { --cc: var(--c-n); --cc-glow: var(--cg-n); }
 
 /* ── Card Mark ───────────────────────────────────── */
 .navcard__mark {
@@ -359,3 +361,4 @@
 .navcard:nth-child(3)  { animation-delay: 0.19s; }
 .navcard:nth-child(4)  { animation-delay: 0.26s; }
 .navcard:nth-child(5)  { animation-delay: 0.33s; }
+.navcard:nth-child(6)  { animation-delay: 0.40s; }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -85,6 +85,14 @@
           <span class="navcard__arrow" aria-hidden="true">↗</span>
         </a>
 
+
+        <a class="navcard navcard--n" routerLink="/it-news">
+          <div class="navcard__mark">N</div>
+          <h2 class="navcard__title">IT News</h2>
+          <p class="navcard__sub">Aggregated tech news</p>
+          <span class="navcard__arrow" aria-hidden="true">↗</span>
+        </a>
+
       </div>
     </main>
 

--- a/src/app/it-news/components/article-list/article-list.component.css
+++ b/src/app/it-news/components/article-list/article-list.component.css
@@ -1,0 +1,211 @@
+/* ── Design Tokens ───────────────────────────────── */
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-n:  #2dd4bf;  --cg-n: rgba(45, 212, 191, 0.18);
+
+  display: block;
+  height: 100%;
+  overflow-y: auto;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1.25rem 1rem;
+}
+
+/* ── Controls ────────────────────────────────────── */
+.controls {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.filter-field {
+  flex: 1;
+  min-width: 140px;
+}
+
+/* Material form field dark theme overrides */
+::ng-deep .filter-field .mat-mdc-text-field-wrapper {
+  background: var(--surface) !important;
+}
+
+::ng-deep .filter-field .mdc-notched-outline__leading,
+::ng-deep .filter-field .mdc-notched-outline__notch,
+::ng-deep .filter-field .mdc-notched-outline__trailing {
+  border-color: var(--border-mid) !important;
+}
+
+::ng-deep .filter-field .mat-mdc-select-value-text {
+  color: var(--text) !important;
+}
+
+::ng-deep .filter-field .mat-mdc-floating-label {
+  color: var(--text-muted) !important;
+}
+
+::ng-deep .filter-field .mat-mdc-select-arrow {
+  color: var(--text-muted) !important;
+}
+
+::ng-deep .mat-mdc-option {
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-select-panel {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+}
+
+.refresh-btn {
+  background: var(--c-n) !important;
+  color: #06080e !important;
+  font-weight: 600 !important;
+  height: 48px;
+}
+
+.refresh-btn:disabled {
+  opacity: 0.5 !important;
+}
+
+/* ── Loading / Empty ─────────────────────────────── */
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 3rem;
+  color: var(--text-muted);
+}
+
+::ng-deep .loading .mat-mdc-progress-spinner circle {
+  stroke: var(--c-n) !important;
+}
+
+.empty {
+  text-align: center;
+  padding: 3rem;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+/* ── Article List ────────────────────────────────── */
+.article-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.article-card {
+  display: block;
+  padding: 1rem 1.25rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
+}
+
+.article-card:hover {
+  border-color: var(--c-n);
+  box-shadow: 0 4px 20px var(--cg-n);
+  transform: translateY(-2px);
+}
+
+.article-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.badge.category {
+  background: rgba(45, 212, 191, 0.12);
+  color: var(--c-n);
+}
+
+.badge.source {
+  background: var(--raised);
+  color: var(--text-muted);
+}
+
+.date {
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  margin-left: auto;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.article-title {
+  margin: 0 0 0.35rem 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1.35;
+}
+
+.article-desc {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* ── Pagination ──────────────────────────────────── */
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1.5rem;
+  padding: 1rem 0;
+}
+
+.pagination button {
+  color: var(--text-muted) !important;
+  border-color: var(--border-mid) !important;
+}
+
+.pagination button:hover:not(:disabled) {
+  color: var(--c-n) !important;
+  border-color: var(--c-n) !important;
+}
+
+.pagination button:disabled {
+  opacity: 0.3 !important;
+}
+
+.page-info {
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  font-family: 'JetBrains Mono', monospace;
+}

--- a/src/app/it-news/components/article-list/article-list.component.html
+++ b/src/app/it-news/components/article-list/article-list.component.html
@@ -1,0 +1,69 @@
+<div class="container">
+  <div class="controls">
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>Category</mat-label>
+      <mat-select [(ngModel)]="selectedCategory" (selectionChange)="onFilterChange()">
+        <mat-option value="">All Categories</mat-option>
+        @for (cat of categories; track cat) {
+          <mat-option [value]="cat">{{ cat }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="filter-field">
+      <mat-label>Source</mat-label>
+      <mat-select [(ngModel)]="selectedSource" (selectionChange)="onFilterChange()">
+        <mat-option value="">All Sources</mat-option>
+        @for (src of sources; track src.name) {
+          <mat-option [value]="src.name">{{ src.name }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
+    <button mat-flat-button (click)="refreshFeeds()" [disabled]="fetching" class="refresh-btn">
+      <mat-icon>refresh</mat-icon>
+      {{ fetching ? 'Fetching...' : 'Refresh' }}
+    </button>
+  </div>
+
+  @if (loading) {
+    <div class="loading">
+      <mat-spinner diameter="36"></mat-spinner>
+      <span>Loading articles...</span>
+    </div>
+  }
+
+  @if (!loading && articles.length === 0) {
+    <div class="empty">
+      No articles found. Try refreshing the feeds or adjusting your filters.
+    </div>
+  }
+
+  <div class="article-list">
+    @for (article of articles; track article.id) {
+      <a [href]="article.link" target="_blank" rel="noopener noreferrer" class="article-card">
+        <div class="article-meta">
+          <span class="badge category">{{ article.category }}</span>
+          <span class="badge source">{{ article.source }}</span>
+          <span class="date">{{ formatDate(article.publishedAt) }}</span>
+        </div>
+        <h2 class="article-title">{{ article.title }}</h2>
+        @if (article.description) {
+          <p class="article-desc">{{ article.description }}</p>
+        }
+      </a>
+    }
+  </div>
+
+  @if (totalPages > 1) {
+    <div class="pagination">
+      <button mat-stroked-button (click)="prevPage()" [disabled]="currentPage === 0">
+        <mat-icon>chevron_left</mat-icon> Previous
+      </button>
+      <span class="page-info">Page {{ currentPage + 1 }} of {{ totalPages }} ({{ totalElements }} articles)</span>
+      <button mat-stroked-button (click)="nextPage()" [disabled]="currentPage >= totalPages - 1">
+        Next <mat-icon>chevron_right</mat-icon>
+      </button>
+    </div>
+  }
+</div>

--- a/src/app/it-news/components/article-list/article-list.component.html
+++ b/src/app/it-news/components/article-list/article-list.component.html
@@ -2,7 +2,7 @@
   <div class="controls">
     <mat-form-field appearance="outline" class="filter-field">
       <mat-label>Category</mat-label>
-      <mat-select [(ngModel)]="selectedCategory" (selectionChange)="onFilterChange()">
+      <mat-select [(ngModel)]="selectedCategory" (selectionChange)="onCategoryChange()">
         <mat-option value="">All Categories</mat-option>
         @for (cat of categories; track cat) {
           <mat-option [value]="cat">{{ cat }}</mat-option>
@@ -12,9 +12,9 @@
 
     <mat-form-field appearance="outline" class="filter-field">
       <mat-label>Source</mat-label>
-      <mat-select [(ngModel)]="selectedSource" (selectionChange)="onFilterChange()">
+      <mat-select [(ngModel)]="selectedSource" (selectionChange)="onSourceChange()">
         <mat-option value="">All Sources</mat-option>
-        @for (src of sources; track src.name) {
+        @for (src of filteredSources; track src.name) {
           <mat-option [value]="src.name">{{ src.name }}</mat-option>
         }
       </mat-select>

--- a/src/app/it-news/components/article-list/article-list.component.ts
+++ b/src/app/it-news/components/article-list/article-list.component.ts
@@ -1,0 +1,133 @@
+import {Component, OnInit, ChangeDetectionStrategy, ChangeDetectorRef} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {FormsModule} from '@angular/forms';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatSelectModule} from '@angular/material/select';
+import {MatButtonModule} from '@angular/material/button';
+import {MatIconModule} from '@angular/material/icon';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
+import {Article, ArticlePage, FeedSource} from '../../models/article.model';
+import {ArticleService} from '../../services/article.service';
+
+@Component({
+  selector: 'app-article-list',
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    MatButtonModule,
+    MatIconModule,
+    MatProgressSpinnerModule
+  ],
+  templateUrl: './article-list.component.html',
+  styleUrl: './article-list.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ArticleListComponent implements OnInit {
+
+  articles: Article[] = [];
+  sources: FeedSource[] = [];
+  categories: string[] = [];
+
+  selectedCategory = '';
+  selectedSource = '';
+  currentPage = 0;
+  totalPages = 0;
+  totalElements = 0;
+  loading = false;
+  fetching = false;
+
+  constructor(
+    private articleService: ArticleService,
+    private cdr: ChangeDetectorRef
+  ) {
+  }
+
+  ngOnInit(): void {
+    this.loadSources();
+    this.loadArticles();
+  }
+
+  loadSources(): void {
+    this.articleService.getSources().subscribe(sources => {
+      this.sources = sources;
+      this.categories = [...new Set(sources.map(s => s.category))];
+      this.cdr.markForCheck();
+    });
+  }
+
+  loadArticles(): void {
+    this.loading = true;
+    this.cdr.markForCheck();
+    this.articleService
+      .getArticles(
+        this.currentPage,
+        20,
+        this.selectedCategory || undefined,
+        this.selectedSource || undefined
+      )
+      .subscribe({
+        next: (page: ArticlePage) => {
+          this.articles = page.content;
+          this.totalPages = page.totalPages;
+          this.totalElements = page.totalElements;
+          this.loading = false;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.loading = false;
+          this.cdr.markForCheck();
+        }
+      });
+  }
+
+  onFilterChange(): void {
+    this.currentPage = 0;
+    this.loadArticles();
+  }
+
+  nextPage(): void {
+    if (this.currentPage < this.totalPages - 1) {
+      this.currentPage++;
+      this.loadArticles();
+    }
+  }
+
+  prevPage(): void {
+    if (this.currentPage > 0) {
+      this.currentPage--;
+      this.loadArticles();
+    }
+  }
+
+  refreshFeeds(): void {
+    this.fetching = true;
+    this.cdr.markForCheck();
+    this.articleService.triggerFetch().subscribe({
+      next: () => {
+        this.fetching = false;
+        this.currentPage = 0;
+        this.loadArticles();
+      },
+      error: () => {
+        this.fetching = false;
+        this.cdr.markForCheck();
+      }
+    });
+  }
+
+  formatDate(dateStr: string): string {
+    if (!dateStr) {
+      return '';
+    }
+    return new Date(dateStr).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  }
+
+}

--- a/src/app/it-news/components/article-list/article-list.component.ts
+++ b/src/app/it-news/components/article-list/article-list.component.ts
@@ -28,6 +28,7 @@ export class ArticleListComponent implements OnInit {
 
   articles: Article[] = [];
   sources: FeedSource[] = [];
+  filteredSources: FeedSource[] = [];
   categories: string[] = [];
 
   selectedCategory = '';
@@ -53,6 +54,7 @@ export class ArticleListComponent implements OnInit {
     this.articleService.getSources().subscribe(sources => {
       this.sources = sources;
       this.categories = [...new Set(sources.map(s => s.category))];
+      this.updateFilteredSources();
       this.cdr.markForCheck();
     });
   }
@@ -82,7 +84,23 @@ export class ArticleListComponent implements OnInit {
       });
   }
 
-  onFilterChange(): void {
+  updateFilteredSources(): void {
+    this.filteredSources = this.selectedCategory
+      ? this.sources.filter(s => s.category === this.selectedCategory)
+      : [...this.sources];
+  }
+
+  onCategoryChange(): void {
+    this.updateFilteredSources();
+    if (this.selectedSource &&
+        !this.filteredSources.some(s => s.name === this.selectedSource)) {
+      this.selectedSource = '';
+    }
+    this.currentPage = 0;
+    this.loadArticles();
+  }
+
+  onSourceChange(): void {
     this.currentPage = 0;
     this.loadArticles();
   }

--- a/src/app/it-news/components/it-news-layout/it-news-layout.component.css
+++ b/src/app/it-news/components/it-news-layout/it-news-layout.component.css
@@ -1,0 +1,127 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+/* ── Design Tokens ───────────────────────────────── */
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-n:  #2dd4bf;  --cg-n: rgba(45, 212, 191, 0.18);
+
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+  overflow: hidden;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+  background-color: var(--bg);
+  background-image:
+    radial-gradient(ellipse 70% 35% at 0% 0%,    rgba(45, 212, 191, 0.04) 0%, transparent 100%),
+    radial-gradient(ellipse 50% 35% at 100% 100%, rgba(77,  166, 255, 0.04) 0%, transparent 100%),
+    radial-gradient(circle, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+  background-size: auto, auto, 28px 28px;
+}
+
+/* ── Layout ──────────────────────────────────────── */
+.it-news-layout {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+/* ── Topbar ──────────────────────────────────────── */
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: max(0.5rem, env(safe-area-inset-top)) max(1rem, env(safe-area-inset-right)) 0.5rem max(1rem, env(safe-area-inset-left));
+  background: rgba(6, 8, 14, 0.88);
+  border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  box-shadow: 0 1px 0 rgba(45, 212, 191, 0.06);
+}
+
+.topbar__left {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.topbar__right {
+  width: 80px;
+}
+
+.topbar__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  color: var(--text-muted);
+}
+
+.topbar__hex {
+  color: var(--c-n);
+  font-size: 0.9rem;
+  filter: drop-shadow(0 0 6px rgba(45, 212, 191, 0.5));
+}
+
+/* ── Nav Buttons ─────────────────────────────────── */
+.nav-btn {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  padding: 0 !important;
+  color: var(--text-muted) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: 8px !important;
+  width: 36px !important;
+  height: 36px !important;
+  transition: color 0.2s, border-color 0.2s, box-shadow 0.2s !important;
+}
+
+.nav-btn:hover {
+  color: var(--c-n) !important;
+  border-color: var(--c-n) !important;
+  box-shadow: 0 0 10px rgba(45, 212, 191, 0.2) !important;
+}
+
+/* ── Content ─────────────────────────────────────── */
+.content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* ── Menu Panel ──────────────────────────────────── */
+::ng-deep .mat-mdc-menu-panel {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 8px !important;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5) !important;
+}
+
+::ng-deep .mat-mdc-menu-item {
+  color: var(--text) !important;
+  font-family: 'Outfit', sans-serif !important;
+}
+
+::ng-deep .mat-mdc-menu-item:hover .mdc-list-item__primary-text {
+  color: var(--c-n) !important;
+}
+
+::ng-deep .mat-mdc-menu-item:hover {
+  background: var(--raised) !important;
+}

--- a/src/app/it-news/components/it-news-layout/it-news-layout.component.html
+++ b/src/app/it-news/components/it-news-layout/it-news-layout.component.html
@@ -1,0 +1,31 @@
+<div class="it-news-layout">
+  <header class="topbar">
+    <div class="topbar__left">
+      <button mat-icon-button [routerLink]="homeLink" class="nav-btn" aria-label="Go home">
+        <mat-icon>home</mat-icon>
+      </button>
+      <button mat-icon-button [matMenuTriggerFor]="menu" class="nav-btn" aria-label="Open menu">
+        <mat-icon>more_vert</mat-icon>
+      </button>
+      <mat-menu #menu="matMenu">
+        <button mat-menu-item routerLink="/it-news">
+          <span>Articles</span>
+        </button>
+        <button mat-menu-item routerLink="/">
+          <span>Home</span>
+        </button>
+      </mat-menu>
+    </div>
+
+    <div class="topbar__brand">
+      <span class="topbar__hex">⬡</span>
+      <span class="topbar__name">IT NEWS</span>
+    </div>
+
+    <div class="topbar__right"></div>
+  </header>
+
+  <main class="content">
+    <router-outlet></router-outlet>
+  </main>
+</div>

--- a/src/app/it-news/components/it-news-layout/it-news-layout.component.ts
+++ b/src/app/it-news/components/it-news-layout/it-news-layout.component.ts
@@ -1,0 +1,42 @@
+import {Component} from '@angular/core';
+import {MatIconButton} from '@angular/material/button';
+import {MatIcon} from '@angular/material/icon';
+import {ActivatedRoute, NavigationEnd, Router, RouterLink, RouterOutlet} from '@angular/router';
+import {filter} from 'rxjs';
+import {MatMenu, MatMenuItem, MatMenuTrigger} from '@angular/material/menu';
+
+@Component({
+  selector: 'app-it-news-layout',
+  imports: [
+    MatIconButton,
+    MatIcon,
+    RouterLink,
+    RouterOutlet,
+    MatMenuTrigger,
+    MatMenu,
+    MatMenuItem
+  ],
+  templateUrl: './it-news-layout.component.html',
+  styleUrl: './it-news-layout.component.css'
+})
+export class ItNewsLayoutComponent {
+
+  homeLink: string = '/';
+
+  constructor(private router: Router, private route: ActivatedRoute) {
+    this.router.events
+      .pipe(filter(event => event instanceof NavigationEnd))
+      .subscribe(() => {
+        const home = this.getDeepestChild(this.route).snapshot.data['home'];
+        this.homeLink = home || '/';
+      });
+  }
+
+  private getDeepestChild(route: ActivatedRoute): ActivatedRoute {
+    while (route.firstChild) {
+      route = route.firstChild;
+    }
+    return route;
+  }
+
+}

--- a/src/app/it-news/models/article.model.ts
+++ b/src/app/it-news/models/article.model.ts
@@ -1,0 +1,25 @@
+export interface Article {
+  id: number;
+  title: string;
+  description: string;
+  link: string;
+  source: string;
+  category: string;
+  publishedAt: string;
+  fetchedAt: string;
+}
+
+export interface ArticlePage {
+  content: Article[];
+  totalElements: number;
+  totalPages: number;
+  number: number;
+  size: number;
+  last: boolean;
+}
+
+export interface FeedSource {
+  name: string;
+  url: string;
+  category: string;
+}

--- a/src/app/it-news/services/article.service.ts
+++ b/src/app/it-news/services/article.service.ts
@@ -1,0 +1,36 @@
+import {Injectable} from '@angular/core';
+import {HttpClient, HttpParams} from '@angular/common/http';
+import {Observable} from 'rxjs';
+import {Article, ArticlePage, FeedSource} from '../models/article.model';
+import {environment} from '../../../environments/environment';
+
+@Injectable({providedIn: 'root'})
+export class ArticleService {
+
+  private readonly baseUrl = environment.apiUrl + '/it-news';
+
+  constructor(private http: HttpClient) {
+  }
+
+  getArticles(page = 0, size = 20, category?: string, source?: string): Observable<ArticlePage> {
+    let params = new HttpParams()
+      .set('page', page.toString())
+      .set('size', size.toString());
+    if (category) {
+      params = params.set('category', category);
+    }
+    if (source) {
+      params = params.set('source', source);
+    }
+    return this.http.get<ArticlePage>(`${this.baseUrl}/articles`, {params});
+  }
+
+  getSources(): Observable<FeedSource[]> {
+    return this.http.get<FeedSource[]>(`${this.baseUrl}/sources`);
+  }
+
+  triggerFetch(): Observable<string> {
+    return this.http.post(`${this.baseUrl}/fetch`, null, {responseType: 'text'});
+  }
+
+}


### PR DESCRIPTION
## Summary
- New `it-news` feature module with article list component, layout component, service, and models
- Dark theme with teal accent (`#2dd4bf`), matching the existing design system
- Material selects for category/source filtering, pagination, and manual feed refresh
- Routing at `/it-news` with layout wrapper; navigation card added to home page

## Test plan
- [ ] `npm run build` passes
- [ ] Navigate to `/it-news` — layout renders with topbar and teal accent
- [ ] Articles load and display with category/source badges
- [ ] Category and source filters work correctly
- [ ] Pagination controls appear when results exceed 20
- [ ] "Refresh" button triggers feed fetch
- [ ] Home page shows IT News card with teal accent

🤖 Generated with [Claude Code](https://claude.com/claude-code)