### PR TITLE
feat(it-news): add mark-as-read UI with toggle

### DIFF
--- a/src/app/it-news/components/article-list/article-list.component.css
+++ b/src/app/it-news/components/article-list/article-list.component.css
@@ -161,6 +161,48 @@
   font-family: 'JetBrains Mono', monospace;
 }
 
+.mark-read-btn {
+  width: 28px !important;
+  height: 28px !important;
+  padding: 0 !important;
+  line-height: 28px !important;
+  color: var(--text-dim);
+  flex-shrink: 0;
+}
+
+.mark-read-btn:hover {
+  color: var(--c-n);
+}
+
+.mark-read-btn .mat-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+}
+
+.read-indicator {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+  color: var(--c-n);
+  flex-shrink: 0;
+}
+
+.show-read-checkbox {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  margin-left: 0.25rem;
+}
+
+::ng-deep .show-read-checkbox .mdc-checkbox__background {
+  border-color: var(--text-dim) !important;
+}
+
+::ng-deep .show-read-checkbox .mdc-checkbox--selected .mdc-checkbox__background {
+  background-color: var(--c-n) !important;
+  border-color: var(--c-n) !important;
+}
+
 .article-title {
   margin: 0 0 0.35rem 0;
   font-size: 1rem;

--- a/src/app/it-news/components/article-list/article-list.component.html
+++ b/src/app/it-news/components/article-list/article-list.component.html
@@ -24,6 +24,10 @@
       <mat-icon>refresh</mat-icon>
       {{ fetching ? 'Fetching...' : 'Refresh' }}
     </button>
+
+    <mat-checkbox [(ngModel)]="showRead" (change)="onShowReadChange()" class="show-read-checkbox">
+      Show read
+    </mat-checkbox>
   </div>
 
   @if (loading) {
@@ -46,6 +50,16 @@
           <span class="badge category">{{ article.category }}</span>
           <span class="badge source">{{ article.source }}</span>
           <span class="date">{{ formatDate(article.publishedAt) }}</span>
+          @if (!article.isRead) {
+            <button mat-icon-button
+                    class="mark-read-btn"
+                    matTooltip="Mark as read"
+                    (click)="markAsRead($event, article)">
+              <mat-icon>done</mat-icon>
+            </button>
+          } @else {
+            <mat-icon class="read-indicator" matTooltip="Already read">done_all</mat-icon>
+          }
         </div>
         <h2 class="article-title">{{ article.title }}</h2>
         @if (article.description) {

--- a/src/app/it-news/components/article-list/article-list.component.ts
+++ b/src/app/it-news/components/article-list/article-list.component.ts
@@ -6,6 +6,8 @@ import {MatSelectModule} from '@angular/material/select';
 import {MatButtonModule} from '@angular/material/button';
 import {MatIconModule} from '@angular/material/icon';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
+import {MatCheckboxModule} from '@angular/material/checkbox';
+import {MatTooltipModule} from '@angular/material/tooltip';
 import {Article, ArticlePage, FeedSource} from '../../models/article.model';
 import {ArticleService} from '../../services/article.service';
 
@@ -18,7 +20,9 @@ import {ArticleService} from '../../services/article.service';
     MatSelectModule,
     MatButtonModule,
     MatIconModule,
-    MatProgressSpinnerModule
+    MatProgressSpinnerModule,
+    MatCheckboxModule,
+    MatTooltipModule
   ],
   templateUrl: './article-list.component.html',
   styleUrl: './article-list.component.css',
@@ -36,6 +40,7 @@ export class ArticleListComponent implements OnInit {
   currentPage = 0;
   totalPages = 0;
   totalElements = 0;
+  showRead = false;
   loading = false;
   fetching = false;
 
@@ -67,7 +72,8 @@ export class ArticleListComponent implements OnInit {
         this.currentPage,
         20,
         this.selectedCategory || undefined,
-        this.selectedSource || undefined
+        this.selectedSource || undefined,
+        this.showRead
       )
       .subscribe({
         next: (page: ArticlePage) => {
@@ -103,6 +109,24 @@ export class ArticleListComponent implements OnInit {
   onSourceChange(): void {
     this.currentPage = 0;
     this.loadArticles();
+  }
+
+  onShowReadChange(): void {
+    this.currentPage = 0;
+    this.loadArticles();
+  }
+
+  markAsRead(event: Event, article: Article): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.articleService.markAsRead(article.id).subscribe(() => {
+      article.isRead = true;
+      if (!this.showRead) {
+        this.articles = this.articles.filter(a => a.id !== article.id);
+        this.totalElements--;
+      }
+      this.cdr.markForCheck();
+    });
   }
 
   nextPage(): void {

--- a/src/app/it-news/models/article.model.ts
+++ b/src/app/it-news/models/article.model.ts
@@ -7,6 +7,7 @@ export interface Article {
   category: string;
   publishedAt: string;
   fetchedAt: string;
+  isRead: boolean;
 }
 
 export interface ArticlePage {

--- a/src/app/it-news/services/article.service.ts
+++ b/src/app/it-news/services/article.service.ts
@@ -12,10 +12,11 @@ export class ArticleService {
   constructor(private http: HttpClient) {
   }
 
-  getArticles(page = 0, size = 20, category?: string, source?: string): Observable<ArticlePage> {
+  getArticles(page = 0, size = 20, category?: string, source?: string, includeRead = false): Observable<ArticlePage> {
     let params = new HttpParams()
       .set('page', page.toString())
-      .set('size', size.toString());
+      .set('size', size.toString())
+      .set('includeRead', includeRead.toString());
     if (category) {
       params = params.set('category', category);
     }
@@ -23,6 +24,10 @@ export class ArticleService {
       params = params.set('source', source);
     }
     return this.http.get<ArticlePage>(`${this.baseUrl}/articles`, {params});
+  }
+
+  markAsRead(id: number): Observable<void> {
+    return this.http.patch<void>(`${this.baseUrl}/articles/${id}/read`, null);
   }
 
   getSources(): Observable<FeedSource[]> {


### PR DESCRIPTION
## Summary
- Add "Mark as read" icon button on each article card
- Add "Show read" checkbox to toggle visibility of read articles
- Add `markAsRead()` service method calling backend `PATCH` endpoint
- Add `isRead` field to `Article` model

## Test plan
- [ ] Click the check icon on an article — it should disappear from the list
- [ ] Check "Show read" — read articles should reappear with a double-check indicator
- [ ] Uncheck "Show read" — read articles should be hidden again
- [ ] Verify pagination updates correctly after marking articles as read

🤖 Generated with [Claude Code](https://claude.com/claude-code)