### PR TITLE
feat(it-news): add RSS feed configuration GUI

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -21,6 +21,7 @@ import {ExportsFilesComponent} from './exports/exports-files.component';
 import {ExportsBackupsComponent} from './exports/exports-backups.component';
 import {ItNewsLayoutComponent} from './it-news/components/it-news-layout/it-news-layout.component';
 import {ArticleListComponent} from './it-news/components/article-list/article-list.component';
+import {FeedConfigComponent} from './it-news/components/feed-config/feed-config.component';
 
 export const routes: Routes = [
   {path: '', component: HomeComponent},
@@ -70,6 +71,7 @@ export const routes: Routes = [
     component: ItNewsLayoutComponent,
     children: [
       {path: '', component: ArticleListComponent, data: {home: '/'}},
+      {path: 'feeds', component: FeedConfigComponent, data: {home: '/it-news'}}
     ]
   }
 ];

--- a/src/app/it-news/components/feed-config/feed-config.component.css
+++ b/src/app/it-news/components/feed-config/feed-config.component.css
@@ -1,0 +1,173 @@
+/* ── Design Tokens ───────────────────────────────── */
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-n:  #2dd4bf;  --cg-n: rgba(45, 212, 191, 0.18);
+  --c-e:  #fb7185;
+
+  display: block;
+  height: 100%;
+  overflow-y: auto;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1.25rem 1rem;
+}
+
+/* ── Controls ────────────────────────────────────── */
+.controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+}
+
+.section-title {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  color: var(--text);
+}
+
+.add-btn {
+  background: var(--c-n) !important;
+  color: #06080e !important;
+  font-weight: 600 !important;
+}
+
+/* ── Loading / Empty ─────────────────────────────── */
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 3rem;
+  color: var(--text-muted);
+}
+
+::ng-deep .loading .mat-mdc-progress-spinner circle {
+  stroke: var(--c-n) !important;
+}
+
+.empty {
+  text-align: center;
+  padding: 3rem;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+/* ── Table ───────────────────────────────────────── */
+.table-wrapper {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+table {
+  width: 100%;
+}
+
+::ng-deep .mat-mdc-header-row {
+  background: var(--raised) !important;
+}
+
+::ng-deep .mat-mdc-header-cell {
+  color: var(--text-muted) !important;
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.75rem !important;
+  font-weight: 600 !important;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-bottom-color: var(--border-mid) !important;
+}
+
+::ng-deep .mat-mdc-row {
+  background: var(--surface) !important;
+  transition: background 0.15s;
+}
+
+::ng-deep .mat-mdc-row:hover {
+  background: var(--raised) !important;
+}
+
+::ng-deep .mat-mdc-cell {
+  color: var(--text) !important;
+  font-size: 0.88rem !important;
+  border-bottom-color: var(--border) !important;
+}
+
+.url-cell {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.78rem !important;
+  color: var(--text-muted) !important;
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Badge ───────────────────────────────────────── */
+.badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.badge.category {
+  background: rgba(45, 212, 191, 0.12);
+  color: var(--c-n);
+}
+
+/* ── Active Toggle ──────────────────────────────── */
+.active-toggle {
+  transform: scale(0.85);
+}
+
+::ng-deep .active-toggle .mdc-switch--selected .mdc-switch__track::after {
+  background: rgba(45, 212, 191, 0.4) !important;
+}
+
+::ng-deep .active-toggle .mdc-switch--selected .mdc-switch__handle::after {
+  background: var(--c-n) !important;
+}
+
+/* ── Action Buttons ─────────────────────────────── */
+.actions-cell {
+  white-space: nowrap;
+}
+
+.action-btn {
+  color: var(--text-dim) !important;
+  transition: color 0.2s;
+}
+
+.action-btn:hover {
+  color: var(--c-n) !important;
+}
+
+.delete-btn:hover {
+  color: var(--c-e) !important;
+}
+
+.action-btn .mat-icon {
+  font-size: 20px;
+  width: 20px;
+  height: 20px;
+}

--- a/src/app/it-news/components/feed-config/feed-config.component.html
+++ b/src/app/it-news/components/feed-config/feed-config.component.html
@@ -1,0 +1,69 @@
+<div class="container">
+  <div class="controls">
+    <span class="section-title">Feed Configuration</span>
+    <button mat-flat-button (click)="openAddDialog()" class="add-btn">
+      <mat-icon>add</mat-icon> Add Feed
+    </button>
+  </div>
+
+  @if (loading()) {
+    <div class="loading">
+      <mat-progress-spinner mode="indeterminate" diameter="28"></mat-progress-spinner>
+      <span>Loading feeds...</span>
+    </div>
+  }
+
+  @if (!loading() && feeds().length > 0) {
+    <div class="table-wrapper">
+      <table mat-table [dataSource]="feeds()">
+
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef>Name</th>
+          <td mat-cell *matCellDef="let feed">{{ feed.name }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="url">
+          <th mat-header-cell *matHeaderCellDef>URL</th>
+          <td mat-cell *matCellDef="let feed" class="url-cell">{{ feed.url }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="category">
+          <th mat-header-cell *matHeaderCellDef>Category</th>
+          <td mat-cell *matCellDef="let feed">
+            <span class="badge category">{{ feed.category }}</span>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="active">
+          <th mat-header-cell *matHeaderCellDef>Active</th>
+          <td mat-cell *matCellDef="let feed">
+            <mat-slide-toggle
+              [checked]="feed.active"
+              (change)="toggleActive(feed)"
+              class="active-toggle">
+            </mat-slide-toggle>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef></th>
+          <td mat-cell *matCellDef="let feed" class="actions-cell">
+            <button mat-icon-button (click)="openEditDialog(feed)" class="action-btn" aria-label="Edit feed">
+              <mat-icon>edit</mat-icon>
+            </button>
+            <button mat-icon-button (click)="openDeleteDialog(feed)" class="action-btn delete-btn" aria-label="Delete feed">
+              <mat-icon>delete</mat-icon>
+            </button>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+      </table>
+    </div>
+  }
+
+  @if (!loading() && feeds().length === 0) {
+    <div class="empty">No feed sources configured yet.</div>
+  }
+</div>

--- a/src/app/it-news/components/feed-config/feed-config.component.ts
+++ b/src/app/it-news/components/feed-config/feed-config.component.ts
@@ -1,0 +1,126 @@
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, signal} from '@angular/core';
+import {MatTableModule} from '@angular/material/table';
+import {MatIconButton, MatButton} from '@angular/material/button';
+import {MatIcon} from '@angular/material/icon';
+import {MatSlideToggle} from '@angular/material/slide-toggle';
+import {MatDialog} from '@angular/material/dialog';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {MatProgressSpinner} from '@angular/material/progress-spinner';
+import {FeedSource} from '../../models/article.model';
+import {FeedConfigService} from '../../services/feed-config.service';
+import {FeedFormDialogComponent} from '../../dialogs/feed-form-dialog/feed-form-dialog.component';
+import {FeedDeleteDialogComponent} from '../../dialogs/feed-delete-dialog/feed-delete-dialog.component';
+
+@Component({
+  selector: 'app-feed-config',
+  imports: [
+    MatTableModule,
+    MatIconButton,
+    MatButton,
+    MatIcon,
+    MatSlideToggle,
+    MatProgressSpinner
+  ],
+  templateUrl: './feed-config.component.html',
+  styleUrl: './feed-config.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class FeedConfigComponent implements OnInit {
+
+  feeds = signal<FeedSource[]>([]);
+  loading = signal(false);
+  displayedColumns = ['name', 'url', 'category', 'active', 'actions'];
+
+  constructor(
+    private feedConfigService: FeedConfigService,
+    private dialog: MatDialog,
+    private snackBar: MatSnackBar,
+    private cdr: ChangeDetectorRef
+  ) {
+  }
+
+  ngOnInit() {
+    this.loadFeeds();
+  }
+
+  loadFeeds() {
+    this.loading.set(true);
+    this.feedConfigService.getFeeds().subscribe({
+      next: (feeds) => {
+        this.feeds.set(feeds);
+        this.loading.set(false);
+        this.cdr.markForCheck();
+      },
+      error: () => {
+        this.loading.set(false);
+        this.snackBar.open('Failed to load feeds', 'Dismiss', {duration: 5000});
+        this.cdr.markForCheck();
+      }
+    });
+  }
+
+  openAddDialog() {
+    const ref = this.dialog.open(FeedFormDialogComponent, {
+      data: {},
+      width: '440px'
+    });
+    ref.afterClosed().subscribe((result: FeedSource | undefined) => {
+      if (result) {
+        this.feedConfigService.createFeed(result).subscribe({
+          next: () => {
+            this.snackBar.open('Feed created', 'Dismiss', {duration: 3000});
+            this.loadFeeds();
+          },
+          error: () => this.snackBar.open('Failed to create feed', 'Dismiss', {duration: 5000})
+        });
+      }
+    });
+  }
+
+  openEditDialog(feed: FeedSource) {
+    const ref = this.dialog.open(FeedFormDialogComponent, {
+      data: {feed},
+      width: '440px'
+    });
+    ref.afterClosed().subscribe((result: FeedSource | undefined) => {
+      if (result) {
+        this.feedConfigService.updateFeed(result).subscribe({
+          next: () => {
+            this.snackBar.open('Feed updated', 'Dismiss', {duration: 3000});
+            this.loadFeeds();
+          },
+          error: () => this.snackBar.open('Failed to update feed', 'Dismiss', {duration: 5000})
+        });
+      }
+    });
+  }
+
+  openDeleteDialog(feed: FeedSource) {
+    const ref = this.dialog.open(FeedDeleteDialogComponent, {
+      data: {feed}
+    });
+    ref.afterClosed().subscribe((result) => {
+      if (result === 'confirmed') {
+        this.feedConfigService.deleteFeed(feed.id!).subscribe({
+          next: () => {
+            this.snackBar.open(`Feed "${feed.name}" deleted`, 'Dismiss', {duration: 3000});
+            this.loadFeeds();
+          },
+          error: () => this.snackBar.open('Failed to delete feed', 'Dismiss', {duration: 5000})
+        });
+      }
+    });
+  }
+
+  toggleActive(feed: FeedSource) {
+    const updated = {...feed, active: !feed.active};
+    this.feedConfigService.updateFeed(updated).subscribe({
+      next: () => this.loadFeeds(),
+      error: () => {
+        this.snackBar.open('Failed to update feed', 'Dismiss', {duration: 5000});
+        this.loadFeeds();
+      }
+    });
+  }
+
+}

--- a/src/app/it-news/components/it-news-layout/it-news-layout.component.html
+++ b/src/app/it-news/components/it-news-layout/it-news-layout.component.html
@@ -11,6 +11,9 @@
         <button mat-menu-item routerLink="/it-news">
           <span>Articles</span>
         </button>
+        <button mat-menu-item routerLink="/it-news/feeds">
+          <span>Feed Config</span>
+        </button>
         <button mat-menu-item routerLink="/">
           <span>Home</span>
         </button>

--- a/src/app/it-news/dialogs/feed-delete-dialog/feed-delete-dialog.component.css
+++ b/src/app/it-news/dialogs/feed-delete-dialog/feed-delete-dialog.component.css
@@ -1,0 +1,69 @@
+:host {
+  --surface:     #0c1018;
+  --border-mid:  rgba(255, 255, 255, 0.13);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --c-n:         #2dd4bf;
+  --c-e:         #fb7185;
+}
+
+::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-dialog-title {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
+  color: var(--text) !important;
+  letter-spacing: 0.03em;
+}
+
+::ng-deep .mat-mdc-dialog-content {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.9rem !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions {
+  gap: 10px;
+  padding-bottom: 16px !important;
+  justify-content: center !important;
+}
+
+.btn-confirm {
+  background: rgba(45, 212, 191, 0.10) !important;
+  border: 1px solid rgba(45, 212, 191, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-n) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-confirm:hover {
+  background: rgba(45, 212, 191, 0.18) !important;
+  box-shadow: 0 0 12px rgba(45, 212, 191, 0.25) !important;
+}
+
+.btn-confirm mat-icon {
+  color: var(--c-n) !important;
+}
+
+.btn-cancel {
+  background: rgba(251, 113, 133, 0.10) !important;
+  border: 1px solid rgba(251, 113, 133, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-e) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-cancel:hover {
+  background: rgba(251, 113, 133, 0.18) !important;
+  box-shadow: 0 0 12px rgba(251, 113, 133, 0.25) !important;
+}
+
+.btn-cancel mat-icon {
+  color: var(--c-e) !important;
+}

--- a/src/app/it-news/dialogs/feed-delete-dialog/feed-delete-dialog.component.html
+++ b/src/app/it-news/dialogs/feed-delete-dialog/feed-delete-dialog.component.html
@@ -1,0 +1,14 @@
+<h2 mat-dialog-title>Delete Feed</h2>
+
+<mat-dialog-content>
+  <span>Do you really want to delete the feed <strong>{{ data.feed.name }}</strong>?</span>
+</mat-dialog-content>
+
+<mat-dialog-actions align="center">
+  <button mat-mini-fab class="btn-confirm" (click)="confirm()">
+    <mat-icon>check_circle</mat-icon>
+  </button>
+  <button mat-mini-fab mat-dialog-close class="btn-cancel">
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-dialog-actions>

--- a/src/app/it-news/dialogs/feed-delete-dialog/feed-delete-dialog.component.ts
+++ b/src/app/it-news/dialogs/feed-delete-dialog/feed-delete-dialog.component.ts
@@ -1,0 +1,32 @@
+import {Component, Inject} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MatIcon} from '@angular/material/icon';
+import {MatMiniFabButton} from '@angular/material/button';
+import {FeedSource} from '../../models/article.model';
+
+@Component({
+  selector: 'app-feed-delete-dialog',
+  imports: [
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatIcon,
+    MatMiniFabButton
+  ],
+  templateUrl: './feed-delete-dialog.component.html',
+  styleUrl: './feed-delete-dialog.component.css'
+})
+export class FeedDeleteDialogComponent {
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: { feed: FeedSource },
+    private dialogRef: MatDialogRef<FeedDeleteDialogComponent>
+  ) {
+  }
+
+  confirm() {
+    this.dialogRef.close('confirmed');
+  }
+
+}

--- a/src/app/it-news/dialogs/feed-form-dialog/feed-form-dialog.component.css
+++ b/src/app/it-news/dialogs/feed-form-dialog/feed-form-dialog.component.css
@@ -1,0 +1,108 @@
+/* ── Design Tokens ───────────────────────────────── */
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --c-n:         #2dd4bf;
+  --c-e:         #fb7185;
+}
+
+/* ── Dialog Surface ─────────────────────────────── */
+::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-dialog-title {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
+  color: var(--text) !important;
+  letter-spacing: 0.03em;
+}
+
+::ng-deep .mat-mdc-dialog-content {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions {
+  padding: 12px 24px 16px !important;
+}
+
+/* ── Form ───────────────────────────────────────── */
+.feed-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 320px;
+  padding-top: 0.5rem;
+}
+
+.form-field {
+  width: 100%;
+}
+
+::ng-deep .form-field .mat-mdc-text-field-wrapper {
+  background: var(--raised) !important;
+}
+
+::ng-deep .form-field .mdc-notched-outline__leading,
+::ng-deep .form-field .mdc-notched-outline__notch,
+::ng-deep .form-field .mdc-notched-outline__trailing {
+  border-color: var(--border-mid) !important;
+}
+
+::ng-deep .form-field .mat-mdc-floating-label {
+  color: var(--text-muted) !important;
+}
+
+::ng-deep .form-field .mat-mdc-input-element {
+  color: var(--text) !important;
+}
+
+::ng-deep .form-field.mat-focused .mdc-notched-outline__leading,
+::ng-deep .form-field.mat-focused .mdc-notched-outline__notch,
+::ng-deep .form-field.mat-focused .mdc-notched-outline__trailing {
+  border-color: var(--c-n) !important;
+}
+
+::ng-deep .form-field.mat-focused .mat-mdc-floating-label {
+  color: var(--c-n) !important;
+}
+
+/* ── Active Toggle ──────────────────────────────── */
+.active-toggle {
+  margin: 0.5rem 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+::ng-deep .active-toggle .mdc-switch--selected .mdc-switch__track::after {
+  background: rgba(45, 212, 191, 0.4) !important;
+}
+
+::ng-deep .active-toggle .mdc-switch--selected .mdc-switch__handle::after {
+  background: var(--c-n) !important;
+}
+
+/* ── Buttons ────────────────────────────────────── */
+.btn-save {
+  background: var(--c-n) !important;
+  color: #06080e !important;
+  font-weight: 600 !important;
+}
+
+.btn-save:disabled {
+  opacity: 0.4 !important;
+}
+
+.btn-cancel {
+  color: var(--text-muted) !important;
+}

--- a/src/app/it-news/dialogs/feed-form-dialog/feed-form-dialog.component.html
+++ b/src/app/it-news/dialogs/feed-form-dialog/feed-form-dialog.component.html
@@ -1,0 +1,29 @@
+<h2 mat-dialog-title>{{ isEdit ? 'Edit Feed' : 'Add Feed' }}</h2>
+
+<mat-dialog-content>
+  <form [formGroup]="feedForm" class="feed-form">
+    <mat-form-field class="form-field">
+      <mat-label>Name</mat-label>
+      <input matInput formControlName="name" placeholder="e.g. Baeldung">
+    </mat-form-field>
+
+    <mat-form-field class="form-field">
+      <mat-label>URL</mat-label>
+      <input matInput formControlName="url" placeholder="https://example.com/feed.xml">
+    </mat-form-field>
+
+    <mat-form-field class="form-field">
+      <mat-label>Category</mat-label>
+      <input matInput formControlName="category" placeholder="e.g. Java">
+    </mat-form-field>
+
+    <mat-slide-toggle formControlName="active" class="active-toggle">Active</mat-slide-toggle>
+  </form>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button mat-dialog-close class="btn-cancel">Cancel</button>
+  <button mat-flat-button (click)="save()" [disabled]="feedForm.invalid" class="btn-save">
+    {{ isEdit ? 'Update' : 'Create' }}
+  </button>
+</mat-dialog-actions>

--- a/src/app/it-news/dialogs/feed-form-dialog/feed-form-dialog.component.ts
+++ b/src/app/it-news/dialogs/feed-form-dialog/feed-form-dialog.component.ts
@@ -1,0 +1,57 @@
+import {ChangeDetectionStrategy, Component, Inject} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
+import {MatFormField, MatLabel} from '@angular/material/form-field';
+import {MatInput} from '@angular/material/input';
+import {MatSlideToggle} from '@angular/material/slide-toggle';
+import {MatButton} from '@angular/material/button';
+import {FeedSource} from '../../models/article.model';
+
+@Component({
+  selector: 'app-feed-form-dialog',
+  imports: [
+    ReactiveFormsModule,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatFormField,
+    MatLabel,
+    MatInput,
+    MatSlideToggle,
+    MatButton
+  ],
+  templateUrl: './feed-form-dialog.component.html',
+  styleUrl: './feed-form-dialog.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class FeedFormDialogComponent {
+
+  feedForm: FormGroup;
+  isEdit: boolean;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: { feed?: FeedSource },
+    private dialogRef: MatDialogRef<FeedFormDialogComponent>,
+    private fb: FormBuilder
+  ) {
+    this.isEdit = !!data?.feed;
+    this.feedForm = this.fb.group({
+      name: [data?.feed?.name || '', Validators.required],
+      url: [data?.feed?.url || '', Validators.required],
+      category: [data?.feed?.category || '', Validators.required],
+      active: [data?.feed?.active ?? true]
+    });
+  }
+
+  save() {
+    if (this.feedForm.valid) {
+      const result: FeedSource = {
+        ...this.feedForm.value,
+        ...(this.isEdit ? {id: this.data.feed!.id} : {})
+      };
+      this.dialogRef.close(result);
+    }
+  }
+
+}

--- a/src/app/it-news/models/article.model.ts
+++ b/src/app/it-news/models/article.model.ts
@@ -20,7 +20,9 @@ export interface ArticlePage {
 }
 
 export interface FeedSource {
+  id?: number;
   name: string;
   url: string;
   category: string;
+  active?: boolean;
 }

--- a/src/app/it-news/services/feed-config.service.ts
+++ b/src/app/it-news/services/feed-config.service.ts
@@ -1,0 +1,32 @@
+import {Injectable} from '@angular/core';
+import {HttpClient, HttpParams} from '@angular/common/http';
+import {Observable} from 'rxjs';
+import {FeedSource} from '../models/article.model';
+import {environment} from '../../../environments/environment';
+
+@Injectable({providedIn: 'root'})
+export class FeedConfigService {
+
+  private readonly baseUrl = environment.apiUrl + '/it-news/feeds';
+
+  constructor(private http: HttpClient) {
+  }
+
+  getFeeds(activeOnly = false): Observable<FeedSource[]> {
+    const params = new HttpParams().set('activeOnly', activeOnly.toString());
+    return this.http.get<FeedSource[]>(`${this.baseUrl}/`, {params});
+  }
+
+  createFeed(feed: FeedSource): Observable<FeedSource> {
+    return this.http.post<FeedSource>(`${this.baseUrl}/`, feed);
+  }
+
+  updateFeed(feed: FeedSource): Observable<FeedSource> {
+    return this.http.put<FeedSource>(`${this.baseUrl}/${feed.id}`, feed);
+  }
+
+  deleteFeed(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${id}`);
+  }
+
+}


### PR DESCRIPTION
## Summary
- Add feed configuration management view at `/it-news/feeds` with full CRUD operations
- New `FeedConfigService` for the `/it-news/feeds/` API endpoints (GET, POST, PUT, DELETE)
- Material table with inline active toggle, edit/delete dialogs, and dark theme styling matching existing IT News design
- Navigation menu entry added to IT News layout

## Test plan
- [ ] Navigate to `/it-news/feeds` — table loads existing feed sources
- [ ] Click "Add Feed" — dialog opens, create a new feed with name/url/category
- [ ] Click edit icon — dialog pre-fills with feed data, update and verify changes persist
- [ ] Toggle active switch — feed active state updates via API
- [ ] Click delete icon — confirmation dialog appears, confirm and verify removal
- [ ] Navigate to `/it-news` — article list still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)