### PR TITLE
style(mental-arithmetic): apply dark theme from home component

### DIFF
--- a/src/app/mental-arithmetic/components/arithmetic-list/arithmetic-list.component.css
+++ b/src/app/mental-arithmetic/components/arithmetic-list/arithmetic-list.component.css
@@ -1,51 +1,60 @@
 .arithmetic-list-container {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 20px;
-  font-family: 'Roboto', sans-serif;
+  padding: 1.25rem;
+  font-family: 'Outfit', sans-serif;
 }
 
 .list-header {
   text-align: center;
-  margin-bottom: 30px;
+  margin-bottom: 1.5rem;
+  animation: fadeUp 0.5s ease both;
 }
 
 .list-header h2 {
-  color: #1976d2;
+  color: var(--text, #c8d4e8);
   margin-bottom: 8px;
-  font-size: 2.2rem;
-  font-weight: 300;
+  font-size: 1.75rem;
+  font-weight: 600;
 }
 
 .subtitle {
-  color: #666;
-  font-size: 1.1rem;
+  color: var(--text-muted, #7a93b0);
+  font-size: 0.9rem;
   margin: 0;
 }
 
 /* Statistics Cards */
 .stats-container {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 20px;
-  margin-bottom: 30px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
 }
 
 .stat-card {
-  padding: 25px;
+  padding: 1.25rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+  background: var(--surface, #0c1018);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.07));
   border-radius: 12px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  min-height: 120px;
+  transition: transform 0.2s ease, border-color 0.2s, box-shadow 0.2s;
+  min-height: 100px;
+  animation: fadeUp 0.5s ease both;
 }
+
+.stat-card:nth-child(1) { animation-delay: 0.05s; }
+.stat-card:nth-child(2) { animation-delay: 0.1s; }
+.stat-card:nth-child(3) { animation-delay: 0.15s; }
+.stat-card:nth-child(4) { animation-delay: 0.2s; }
+.stat-card:nth-child(5) { animation-delay: 0.25s; }
 
 .stat-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+  border-color: rgba(167, 139, 250, 0.3);
+  box-shadow: 0 6px 20px rgba(167, 139, 250, 0.1);
 }
 
 .stat-content {
@@ -53,86 +62,89 @@
 }
 
 .stat-number {
-  font-size: 2.5rem;
-  font-weight: bold;
-  color: #1976d2;
+  font-size: 2rem;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', monospace;
+  color: #a78bfa;
   line-height: 1;
   margin-bottom: 5px;
 }
 
 .stat-label {
-  font-size: 0.9rem;
-  color: #666;
+  font-size: 0.75rem;
+  color: var(--text-muted, #7a93b0);
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.08em;
 }
 
 .stat-icon {
-  font-size: 2.5rem;
-  color: #1976d2;
+  font-size: 2rem;
+  color: var(--text-dim, #3d5470);
   opacity: 0.8;
-  margin-left: 15px;
+  margin-left: 12px;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 50px;
-  height: 50px;
-  background: rgba(25, 118, 210, 0.1);
-  border-radius: 50%;
+  width: 44px;
+  height: 44px;
+  background: var(--raised, #111826);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.07));
+  border-radius: 10px;
 }
 
 /* Filters Card */
 .filters-card {
-  margin-bottom: 20px;
-  padding: 20px;
+  margin-bottom: 1rem;
+  padding: 1rem;
   border-radius: 12px;
+  background: var(--surface, #0c1018);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.07));
+  animation: fadeUp 0.5s ease both;
+  animation-delay: 0.3s;
 }
 
 .filters-row {
   display: flex;
-  gap: 20px;
+  gap: 1rem;
   align-items: center;
   flex-wrap: wrap;
 }
 
 .filter-field {
   flex: 1;
-  min-width: 200px;
+  min-width: 180px;
 }
 
 .action-buttons {
   display: flex;
-  gap: 10px;
+  gap: 0.5rem;
   margin-left: auto;
-}
-
-.action-buttons button {
-  margin-left: 5px;
 }
 
 /* Loading State */
 .loading-container {
   text-align: center;
-  padding: 40px;
-  background: white;
+  padding: 2.5rem;
+  background: var(--surface, #0c1018);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.07));
   border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  margin-bottom: 20px;
-}
-
-.loading-container mat-progress-bar {
-  margin-bottom: 20px;
+  margin-bottom: 1rem;
 }
 
 .loading-container p {
-  color: #666;
-  font-size: 1.1rem;
+  color: var(--text-muted, #7a93b0);
+  font-size: 1rem;
+  margin-top: 1rem;
 }
 
 /* Sessions Card */
 .sessions-card {
   border-radius: 12px;
   overflow: hidden;
+  background: var(--surface, #0c1018);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.07));
+  animation: fadeUp 0.5s ease both;
+  animation-delay: 0.35s;
 }
 
 .card-content {
@@ -143,20 +155,21 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 20px;
-  border-bottom: 1px solid #e0e0e0;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border, rgba(255, 255, 255, 0.07));
 }
 
 .table-header h3 {
   margin: 0;
-  color: #333;
-  font-size: 1.5rem;
-  font-weight: 400;
+  color: var(--text, #c8d4e8);
+  font-size: 1.1rem;
+  font-weight: 600;
 }
 
 .session-count {
-  color: #666;
-  font-size: 0.9rem;
+  color: var(--text-dim, #3d5470);
+  font-size: 0.8rem;
+  font-family: 'JetBrains Mono', monospace;
 }
 
 .table-container {
@@ -165,7 +178,7 @@
 
 table {
   width: 100%;
-  background: white;
+  background: transparent;
 }
 
 .sortable-header {
@@ -176,7 +189,7 @@ table {
 }
 
 .sortable-header:hover {
-  background-color: #f5f5f5;
+  background-color: var(--raised, #111826);
 }
 
 .sortable-header mat-icon {
@@ -190,54 +203,60 @@ table {
 .difficulty-badge {
   padding: 4px 12px;
   border-radius: 16px;
-  font-size: 0.85rem;
-  font-weight: 500;
+  font-size: 0.75rem;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.05em;
 }
 
 .difficulty-easy {
-  background-color: #c8e6c9;
-  color: #2e7d32;
+  background-color: rgba(34, 211, 94, 0.12);
+  color: #22d35e;
+  border: 1px solid rgba(34, 211, 94, 0.25);
 }
 
 .difficulty-medium {
-  background-color: #fff3cd;
-  color: #f57c00;
+  background-color: rgba(251, 191, 36, 0.12);
+  color: #fbbf24;
+  border: 1px solid rgba(251, 191, 36, 0.25);
 }
 
 .difficulty-hard {
-  background-color: #ffcdd2;
-  color: #c62828;
+  background-color: rgba(251, 113, 133, 0.12);
+  color: #fb7185;
+  border: 1px solid rgba(251, 113, 133, 0.25);
 }
 
 .operation-badge {
   display: inline-block;
   padding: 4px 8px;
   margin-right: 6px;
-  background-color: #1976d2;
-  color: white;
+  background-color: rgba(167, 139, 250, 0.15);
+  border: 1px solid rgba(167, 139, 250, 0.3);
+  color: #a78bfa;
   border-radius: 12px;
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   font-weight: bold;
+  font-family: 'JetBrains Mono', monospace;
 }
 
 /* Score colors */
 .score {
   font-weight: bold;
-  font-size: 1.1rem;
+  font-size: 1rem;
+  font-family: 'JetBrains Mono', monospace;
 }
 
 .score-high {
-  color: #2e7d32;
+  color: #22d35e;
 }
 
 .score-medium {
-  color: #f57c00;
+  color: #fbbf24;
 }
 
 .score-low {
-  color: #c62828;
+  color: #fb7185;
 }
 
 .operations-list {
@@ -252,45 +271,47 @@ table {
   justify-content: center;
   align-items: center;
   text-align: center;
-  padding: 60px 20px;
-  background: #f9f9f9;
+  padding: 3rem 1.5rem;
+  background: var(--raised, #111826);
   border-radius: 12px;
+  margin: 1rem;
 }
 
 .empty-icon {
   font-size: 2.5rem;
-  color: #ccc;
-  margin-bottom: 20px;
+  color: var(--text-dim, #3d5470);
+  margin-bottom: 1.25rem;
   width: 50px;
   height: 50px;
 }
 
 .empty-state h3 {
-  color: #666;
-  margin-bottom: 10px;
-  font-weight: 400;
+  color: var(--text-muted, #7a93b0);
+  margin-bottom: 0.5rem;
+  font-weight: 500;
 }
 
 .empty-state p {
-  color: #999;
-  margin-bottom: 30px;
+  color: var(--text-dim, #3d5470);
+  margin-bottom: 1.5rem;
   max-width: 400px;
-  margin-left: auto;
-  margin-right: auto;
 }
 
 /* Session Details Card */
 .session-details-card {
-  margin-top: 20px;
+  margin-top: 1rem;
   border-radius: 12px;
+  background: var(--surface, #0c1018);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.07));
+  animation: fadeUp 0.4s ease both;
 }
 
 .details-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 20px;
-  border-bottom: 1px solid #e0e0e0;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border, rgba(255, 255, 255, 0.07));
 }
 
 .details-header mat-icon {
@@ -299,136 +320,142 @@ table {
 
 .details-header h3 {
   margin: 0;
-  color: #333;
-  font-size: 1.5rem;
-  font-weight: 400;
+  color: var(--text, #c8d4e8);
+  font-size: 1.1rem;
+  font-weight: 600;
 }
 
 .details-content {
-  padding: 20px;
+  padding: 1.25rem;
 }
 
 .session-info {
-  margin-bottom: 30px;
+  margin-bottom: 1.5rem;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 15px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.75rem;
 }
 
 .info-row {
   display: flex;
-  padding: 10px;
-  background: #f8f9fa;
+  padding: 0.75rem;
+  background: var(--raised, #111826);
   border-radius: 8px;
-  border-left: 4px solid #1976d2;
+  border-left: 3px solid #a78bfa;
 }
 
 .info-row .label {
   font-weight: 500;
-  color: #666;
-  min-width: 120px;
-  margin-right: 15px;
+  color: var(--text-muted, #7a93b0);
+  min-width: 110px;
+  margin-right: 12px;
+  font-size: 0.85rem;
 }
 
 .info-row span:last-child {
-  color: #333;
+  color: var(--text, #c8d4e8);
   font-weight: 400;
+  font-size: 0.85rem;
 }
 
 .problems-list h4 {
-  color: #333;
-  margin-bottom: 20px;
-  font-size: 1.3rem;
-  font-weight: 400;
+  color: var(--text, #c8d4e8);
+  margin-bottom: 1rem;
+  font-size: 1rem;
+  font-weight: 600;
 }
 
 .problem-grid {
   display: grid;
-  gap: 10px;
+  gap: 0.5rem;
   max-height: 400px;
   overflow-y: auto;
-  padding: 10px;
-  background: #f8f9fa;
+  padding: 0.75rem;
+  background: var(--raised, #111826);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.07));
   border-radius: 8px;
 }
 
 .problem-item {
   display: flex;
   align-items: center;
-  gap: 15px;
-  padding: 12px;
-  background: white;
+  gap: 12px;
+  padding: 0.75rem;
+  background: var(--surface, #0c1018);
   border-radius: 6px;
-  border-left: 4px solid transparent;
+  border-left: 3px solid transparent;
   transition: all 0.2s ease;
 }
 
 .problem-item.correct {
-  border-left-color: #4caf50;
-  background-color: #f1f8e9;
+  border-left-color: #22d35e;
+  background: rgba(34, 211, 94, 0.05);
 }
 
 .problem-item.incorrect {
-  border-left-color: #f44336;
-  background-color: #ffebee;
+  border-left-color: #fb7185;
+  background: rgba(251, 113, 133, 0.05);
 }
 
 .problem-number {
   font-weight: bold;
-  color: #666;
-  min-width: 30px;
+  color: var(--text-dim, #3d5470);
+  min-width: 28px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
 }
 
 .problem-expression {
-  font-family: 'Courier New', monospace;
-  font-size: 1.1rem;
-  color: #333;
-  min-width: 120px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.95rem;
+  color: var(--text, #c8d4e8);
+  min-width: 110px;
 }
 
 .problem-answer {
   font-weight: bold;
-  color: #1976d2;
-  font-family: 'Courier New', monospace;
-  font-size: 1.1rem;
+  color: #a78bfa;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.95rem;
 }
 
 .user-answer {
-  color: #f44336;
-  font-size: 0.9rem;
+  color: #fb7185;
+  font-size: 0.8rem;
   font-style: italic;
 }
 
 .problem-time {
-  color: #666;
-  font-size: 0.9rem;
+  color: var(--text-dim, #3d5470);
+  font-size: 0.8rem;
+  font-family: 'JetBrains Mono', monospace;
   margin-left: auto;
 }
 
 /* Responsive Design */
 @media (max-width: 768px) {
   .arithmetic-list-container {
-    padding: 10px;
+    padding: 0.75rem;
   }
 
   .list-header h2 {
-    font-size: 1.8rem;
+    font-size: 1.4rem;
   }
 
   .stats-container {
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 15px;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.5rem;
   }
 
   .stat-number {
-    font-size: 2rem;
+    font-size: 1.5rem;
   }
 
   .stat-icon {
-    font-size: 2rem;
-    width: 40px;
-    height: 40px;
-    margin-left: 10px;
+    font-size: 1.5rem;
+    width: 36px;
+    height: 36px;
+    margin-left: 8px;
   }
 
   .filters-row {
@@ -442,12 +469,12 @@ table {
 
   .action-buttons {
     justify-content: center;
-    margin: 20px 0 0 0;
+    margin: 0.75rem 0 0 0;
   }
 
   .table-header {
     flex-direction: column;
-    gap: 10px;
+    gap: 0.5rem;
     text-align: center;
   }
 
@@ -457,7 +484,7 @@ table {
 
   .problem-item {
     flex-wrap: wrap;
-    gap: 10px;
+    gap: 8px;
   }
 
   .problem-expression {
@@ -480,60 +507,36 @@ table {
   }
 }
 
-/* Animations */
-.mat-card {
-  animation: fadeInUp 0.5s ease-out;
-}
-
-@keyframes fadeInUp {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+/* Entrance Animations */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 /* Scrollbar styling */
 .problem-grid::-webkit-scrollbar {
-  width: 6px;
+  width: 5px;
 }
 
 .problem-grid::-webkit-scrollbar-track {
-  background: #f1f1f1;
+  background: var(--raised, #111826);
   border-radius: 3px;
 }
 
 .problem-grid::-webkit-scrollbar-thumb {
-  background: #c1c1c1;
+  background: var(--text-dim, #3d5470);
   border-radius: 3px;
 }
 
 .problem-grid::-webkit-scrollbar-thumb:hover {
-  background: #a8a8a8;
+  background: var(--text-muted, #7a93b0);
 }
 
 /* Table hover effects */
 .mat-row:hover {
-  background-color: #f5f5f5;
+  background-color: var(--raised, #111826);
 }
 
 .mat-row {
   transition: background-color 0.2s ease;
-}
-
-/* Button hover effects */
-.mat-icon-button:hover {
-  background-color: rgba(0, 0, 0, 0.04);
-}
-
-.mat-raised-button {
-  transition: all 0.2s ease;
-}
-
-.mat-raised-button:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }

--- a/src/app/mental-arithmetic/components/arithmetic-main/mental-arithmetic-main.component.css
+++ b/src/app/mental-arithmetic/components/arithmetic-main/mental-arithmetic-main.component.css
@@ -1,33 +1,157 @@
-.mental-arithmetic-card-container {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 15px;
-  padding: 15px;
+/* ── Card Container ──────────────────────────────── */
+.card-container {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.75rem;
+  padding: 1rem;
+  max-width: 720px;
+  margin: 0 auto;
 }
 
-.mental-arithmetic-card {
-  width: 50%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: 15px;
-  flex: 1 0 0;
-  border: 1px solid #ccc;
-  border-radius: 10px;
-  text-align: center;
-  cursor: pointer;
-  transition: box-shadow 0.3s ease;
+@media (min-width: 640px) {
+  .card-container { gap: 1rem; padding: 1.5rem; }
 }
 
-.mental-arithmetic-card:hover {
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.15);
+/* Last odd card centered */
+.navcard:last-child:nth-child(odd) {
+  grid-column: 1 / -1;
+  justify-self: center;
+  width: calc(50% - 0.375rem);
 }
 
-@media (max-width: 480px) {
-  .mental-arithmetic-card {
-    width: 90%;
+@media (min-width: 640px) {
+  .navcard:last-child:nth-child(odd) {
+    width: calc(50% - 0.5rem);
   }
 }
+
+/* ── Nav Cards ──────────────────────────────────── */
+.navcard {
+  position: relative;
+  background: var(--surface, #0c1018);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.07));
+  border-radius: 12px;
+  padding: 1.1rem 1rem 1.75rem;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  min-height: 140px;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
+  animation: fadeUp 0.5s ease both;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Radial glow overlay on hover */
+.navcard::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 0% 0%, var(--cc-glow, transparent) 0%, transparent 65%);
+  opacity: 0;
+  transition: opacity 0.25s;
+  pointer-events: none;
+}
+
+/* Left accent stripe */
+.navcard::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 22%;
+  bottom: 22%;
+  width: 2px;
+  background: var(--cc, transparent);
+  border-radius: 0 2px 2px 0;
+  opacity: 0.35;
+  transition: opacity 0.2s, top 0.2s, bottom 0.2s;
+}
+
+.navcard:hover {
+  border-color: var(--cc);
+  box-shadow: 0 8px 28px var(--cc-glow);
+  transform: translateY(-3px);
+}
+
+.navcard:hover::before { opacity: 1; }
+
+.navcard:hover::after {
+  opacity: 0.9;
+  top: 12%;
+  bottom: 12%;
+}
+
+.navcard:active { transform: translateY(-1px); }
+
+/* ── Card Accent Variants ───────────────────────── */
+.navcard--start    { --cc: #22d35e; --cc-glow: rgba(34,  211,  94, 0.18); }
+.navcard--settings { --cc: #fbbf24; --cc-glow: rgba(251, 191,  36, 0.18); }
+.navcard--history  { --cc: #4da6ff; --cc-glow: rgba(77,  166, 255, 0.18); }
+
+/* ── Card Mark ──────────────────────────────────── */
+.navcard__mark {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--cc) 40%, transparent);
+  background: color-mix(in srgb, var(--cc) 10%, transparent);
+  display: grid;
+  place-items: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--cc);
+  flex-shrink: 0;
+  transition: background 0.2s;
+}
+
+.navcard:hover .navcard__mark {
+  background: color-mix(in srgb, var(--cc) 20%, transparent);
+}
+
+/* ── Card Text ──────────────────────────────────── */
+.navcard__title {
+  margin: 0;
+  font-size: clamp(0.95rem, 2.5vw, 1.1rem);
+  font-weight: 600;
+  color: var(--text, #c8d4e8);
+  line-height: 1.25;
+  letter-spacing: 0.01em;
+}
+
+.navcard__sub {
+  margin: 0;
+  font-size: 0.7rem;
+  color: var(--text-muted, #7a93b0);
+  line-height: 1.4;
+  font-weight: 400;
+}
+
+/* ── Card Arrow ─────────────────────────────────── */
+.navcard__arrow {
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.875rem;
+  font-size: 0.8rem;
+  color: var(--text-dim, #3d5470);
+  line-height: 1;
+  transition: color 0.2s, transform 0.2s;
+}
+
+.navcard:hover .navcard__arrow {
+  color: var(--cc);
+  transform: translate(2px, -2px);
+}
+
+/* ── Entrance Animations ────────────────────────── */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.navcard:nth-child(1) { animation-delay: 0.05s; }
+.navcard:nth-child(2) { animation-delay: 0.12s; }
+.navcard:nth-child(3) { animation-delay: 0.19s; }

--- a/src/app/mental-arithmetic/components/arithmetic-main/mental-arithmetic-main.component.html
+++ b/src/app/mental-arithmetic/components/arithmetic-main/mental-arithmetic-main.component.html
@@ -1,14 +1,20 @@
-<div class="mental-arithmetic-card-container">
-  <div class="mental-arithmetic-card" (click)="onStartTraining()">
-    <h2>Start Training</h2>
-    <span>Begin your mental arithmetic training!</span>
+<div class="card-container">
+  <div class="navcard navcard--start" (click)="onStartTraining()">
+    <div class="navcard__mark">▶</div>
+    <h2 class="navcard__title">Start Training</h2>
+    <p class="navcard__sub">Begin your mental arithmetic training!</p>
+    <span class="navcard__arrow">↗</span>
   </div>
-  <div class="mental-arithmetic-card" routerLink="/mental-arithmetic/settings">
-    <h2>Settings</h2>
-    <span>Configure difficulty and operations!</span>
+  <div class="navcard navcard--settings" routerLink="/mental-arithmetic/settings">
+    <div class="navcard__mark">⚙</div>
+    <h2 class="navcard__title">Settings</h2>
+    <p class="navcard__sub">Configure difficulty and operations!</p>
+    <span class="navcard__arrow">↗</span>
   </div>
-  <div class="mental-arithmetic-card" routerLink="/mental-arithmetic/arithmetic-list">
-    <h2>Statistics & History</h2>
-    <span>View your training progress and performance!</span>
+  <div class="navcard navcard--history" routerLink="/mental-arithmetic/arithmetic-list">
+    <div class="navcard__mark">📊</div>
+    <h2 class="navcard__title">Statistics & History</h2>
+    <p class="navcard__sub">View your training progress and performance!</p>
+    <span class="navcard__arrow">↗</span>
   </div>
 </div>

--- a/src/app/mental-arithmetic/components/arithmetic-root/mental-arithmetic-root.component.css
+++ b/src/app/mental-arithmetic/components/arithmetic-root/mental-arithmetic-root.component.css
@@ -1,45 +1,102 @@
-.container {
-  height: 100vh;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+/* ── Design Tokens ───────────────────────────────── */
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --accent:      #a78bfa;
+  --accent-glow: rgba(167, 139, 250, 0.18);
+
+  display: block;
+  min-height: 100dvh;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+  background-color: var(--bg);
+  background-image:
+    radial-gradient(ellipse 70% 35% at 0% 0%,    rgba(167, 139, 250, 0.05) 0%, transparent 100%),
+    radial-gradient(ellipse 50% 35% at 100% 100%, rgba(77, 166, 255, 0.04) 0%, transparent 100%),
+    radial-gradient(circle, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+  background-size: auto, auto, 28px 28px;
 }
 
-.header-button {
-  height: 35px;
-  width: 35px;
-}
-
-.mental-arithmetic-root-header-title {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-}
-
-.header-row {
-  height: auto;
-  flex-shrink: 0;
+/* ── Topbar ──────────────────────────────────────── */
+.topbar {
   position: sticky;
   top: 0;
-  z-index: 100;
-  background: white;
-  border-bottom: 1px solid #e0e0e0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: max(0.75rem, env(safe-area-inset-top)) max(1.25rem, env(safe-area-inset-right)) 0.75rem max(1.25rem, env(safe-area-inset-left));
+  background: rgba(6, 8, 14, 0.88);
+  border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  box-shadow: 0 1px 0 rgba(167, 139, 250, 0.06);
 }
 
-.data-row {
+.topbar__left {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.topbar__btn {
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--raised);
+  color: var(--text-muted);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s, background 0.2s;
+}
+
+.topbar__btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.topbar__title {
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.topbar__icon {
+  color: var(--accent);
+  font-size: 0.9rem;
+  filter: drop-shadow(0 0 6px rgba(167, 139, 250, 0.5));
+}
+
+/* ── Layout ──────────────────────────────────────── */
+.layout {
   flex: 1;
   overflow-y: auto;
-  height: calc(100vh - 80px);
 }
 
+/* ── Menu Overrides ─────────────────────────────── */
 .mat-mdc-menu-content {
   display: flex;
   flex-direction: column;
 }
 
 @media (min-width: 480px) {
-  .header-button {
-    height: 50px;
-    width: 50px;
+  .topbar__btn {
+    width: 40px;
+    height: 40px;
   }
 }

--- a/src/app/mental-arithmetic/components/arithmetic-root/mental-arithmetic-root.component.html
+++ b/src/app/mental-arithmetic/components/arithmetic-root/mental-arithmetic-root.component.html
@@ -1,34 +1,29 @@
-<div class="container h-100">
-  <header class="row header-row p-2">
-    <div class="col-4 col-sm-2 d-flex justify-content-between align-items-center">
-      <button mat-fab [routerLink]="homeLink" class="header-button">
-        <mat-icon>home</mat-icon>
+<div class="topbar">
+  <div class="topbar__left">
+    <button class="topbar__btn" [routerLink]="homeLink">
+      <mat-icon>home</mat-icon>
+    </button>
+    <button class="topbar__btn" [matMenuTriggerFor]="menu">
+      <mat-icon>more_vert</mat-icon>
+    </button>
+    <mat-menu #menu="matMenu">
+      <button mat-menu-item routerLink="/mental-arithmetic/session">
+        <span>Start Training</span>
       </button>
-      <button mat-fab [matMenuTriggerFor]="menu" class="header-button">
-        <mat-icon>more_vert</mat-icon>
+      <button mat-menu-item routerLink="/mental-arithmetic/settings">
+        <span>Settings</span>
       </button>
-      <mat-menu #menu="matMenu">
-        <button mat-menu-item routerLink="/mental-arithmetic/session">
-          <span>Start Training</span>
-        </button>
-        <button mat-menu-item routerLink="/mental-arithmetic/settings">
-          <span>Settings</span>
-        </button>
-        <button mat-menu-item routerLink="/mental-arithmetic/arithmetic-list">
-          <span>History</span>
-        </button>
-        <button mat-menu-item routerLink="/mental-arithmetic">
-          <span>Home</span>
-        </button>
-      </mat-menu>
-    </div>
-    <div class="col-8 col-sm-10 d-flex flex-column justify-content-center align-items-center">
-      <h1 class="mental-arithmetic-root-header-title">Mental Arithmetic</h1>
-    </div>
-  </header>
-  <main class="row data-row">
-    <div class="col h-100">
-      <router-outlet></router-outlet>
-    </div>
-  </main>
+      <button mat-menu-item routerLink="/mental-arithmetic/arithmetic-list">
+        <span>History</span>
+      </button>
+      <button mat-menu-item routerLink="/mental-arithmetic">
+        <span>Home</span>
+      </button>
+    </mat-menu>
+  </div>
+  <span class="topbar__icon">⬡</span>
+  <span class="topbar__title">Mental Arithmetic</span>
+</div>
+<div class="layout">
+  <router-outlet></router-outlet>
 </div>

--- a/src/app/mental-arithmetic/components/arithmetic-root/mental-arithmetic-root.component.ts
+++ b/src/app/mental-arithmetic/components/arithmetic-root/mental-arithmetic-root.component.ts
@@ -1,5 +1,4 @@
 import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
-import {MatFabButton} from "@angular/material/button";
 import {MatIcon} from "@angular/material/icon";
 import {ActivatedRoute, NavigationEnd, Router, RouterLink, RouterOutlet} from "@angular/router";
 import {filter} from 'rxjs';
@@ -8,7 +7,6 @@ import {MatMenu, MatMenuItem, MatMenuTrigger} from '@angular/material/menu';
 @Component({
   selector: 'app-mental-arithmetic-root',
   imports: [
-    MatFabButton,
     MatIcon,
     RouterLink,
     RouterOutlet,

--- a/src/app/mental-arithmetic/components/arithmetic-session/arithmetic-session.component.css
+++ b/src/app/mental-arithmetic/components/arithmetic-session/arithmetic-session.component.css
@@ -1,7 +1,6 @@
 .session-container {
   min-height: 100vh;
   padding: 1rem;
-  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
   max-width: 1200px;
   margin: 0 auto;
 }
@@ -18,7 +17,7 @@
 
 .loading-text {
   font-size: 1.2rem;
-  color: #666;
+  color: var(--text-muted, #7a93b0);
   margin: 0;
 }
 
@@ -48,10 +47,11 @@ mat-icon {
   align-items: center;
   flex-wrap: wrap;
   gap: 1rem;
-  background: white;
+  background: var(--surface, #0c1018);
   padding: 1rem;
   border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.07));
+  animation: fadeUp 0.5s ease both;
 }
 
 .progress-section {
@@ -64,16 +64,16 @@ mat-icon {
   justify-content: space-between;
   margin-bottom: 0.5rem;
   font-size: 0.9rem;
-  color: #666;
+  color: var(--text-muted, #7a93b0);
 }
 
 .problem-counter {
   font-weight: 600;
-  color: #333;
+  color: var(--text, #c8d4e8);
 }
 
 .remaining-problems {
-  color: #0078d4;
+  color: #4da6ff;
 }
 
 .timer-section {
@@ -81,24 +81,26 @@ mat-icon {
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem 1rem;
-  background: #f8f9fa;
+  background: var(--raised, #111826);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.07));
   border-radius: 8px;
   font-weight: 600;
-  color: #333;
+  color: var(--text, #c8d4e8);
 }
 
 .timer-section.time-warning {
-  background: #fee;
-  color: #d83b01;
+  background: rgba(251, 113, 133, 0.1);
+  border-color: rgba(251, 113, 133, 0.3);
+  color: #fb7185;
   animation: pulse 2s infinite;
 }
 
 .timer-icon {
-  color: #666;
+  color: var(--text-muted, #7a93b0);
 }
 
 .time-warning .timer-icon {
-  color: #d83b01;
+  color: #fb7185;
 }
 
 .score-section {
@@ -111,17 +113,19 @@ mat-icon {
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem 1rem;
-  background: #f8f9fa;
+  background: var(--raised, #111826);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.07));
   border-radius: 8px;
   font-weight: 600;
+  color: var(--text, #c8d4e8);
 }
 
 .score-icon {
-  color: #f4b400;
+  color: #fbbf24;
 }
 
 .accuracy-icon {
-  color: #4caf50;
+  color: #22d35e;
 }
 
 /* Training Area */
@@ -140,21 +144,23 @@ mat-icon {
 }
 
 .problem-card {
-  background: white;
+  background: var(--surface, #0c1018);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.07));
   border-radius: 16px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
   text-align: center;
-  transition: transform 0.2s ease;
+  transition: transform 0.2s ease, border-color 0.2s;
+  animation: fadeUp 0.5s ease both;
+  animation-delay: 0.1s;
 }
 
 .problem-card.correct-feedback {
-  border: 3px solid #4caf50;
-  background: linear-gradient(135deg, #4caf5008 0%, #4caf5015 100%);
+  border: 2px solid #22d35e;
+  background: rgba(34, 211, 94, 0.05);
 }
 
 .problem-card.incorrect-feedback {
-  border: 3px solid #f44336;
-  background: linear-gradient(135deg, #f4433608 0%, #f4433615 100%);
+  border: 2px solid #fb7185;
+  background: rgba(251, 113, 133, 0.05);
 }
 
 .problem-content {
@@ -164,7 +170,8 @@ mat-icon {
 .problem-expression {
   font-size: 3.5rem;
   font-weight: 700;
-  color: #333;
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--text, #c8d4e8);
   margin-bottom: 2rem;
   line-height: 1.2;
   letter-spacing: 0.05em;
@@ -183,21 +190,21 @@ mat-icon {
 }
 
 .feedback-icon.correct {
-  color: #4caf50;
+  color: #22d35e;
   font-size: 2rem;
 }
 
 .feedback-icon.incorrect {
-  color: #f44336;
+  color: #fb7185;
   font-size: 2rem;
 }
 
 .feedback-text.correct {
-  color: #4caf50;
+  color: #22d35e;
 }
 
 .feedback-text.incorrect {
-  color: #f44336;
+  color: #fb7185;
 }
 
 /* Answer Input Area */
@@ -208,9 +215,11 @@ mat-icon {
 }
 
 .answer-card {
-  background: white;
+  background: var(--surface, #0c1018);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.07));
   border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  animation: fadeUp 0.5s ease both;
+  animation-delay: 0.15s;
 }
 
 .answer-input-field {
@@ -263,14 +272,15 @@ mat-icon {
   font-size: 1.3rem;
   font-weight: 600;
   border-radius: 12px;
-  background: white;
-  border: 2px solid #e0e0e0;
+  background: var(--surface, #0c1018);
+  border: 1px solid var(--border-mid, rgba(255, 255, 255, 0.13));
+  color: var(--text, #c8d4e8);
   transition: all 0.2s ease;
 }
 
 .pad-btn:hover {
-  background: #f5f5f5;
-  border-color: #0078d4;
+  background: var(--raised, #111826);
+  border-color: #a78bfa;
   transform: translateY(-1px);
 }
 
@@ -280,8 +290,8 @@ mat-icon {
 
 .pad-btn.negative {
   font-size: 1rem;
-  background: #f8f9fa;
-  color: #666;
+  background: var(--raised, #111826);
+  color: var(--text-muted, #7a93b0);
 }
 
 /* Session Controls */
@@ -308,10 +318,11 @@ mat-icon {
 }
 
 .completion-card {
-  background: white;
+  background: var(--surface, #0c1018);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.07));
   border-radius: 16px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
   text-align: center;
+  animation: fadeUp 0.5s ease both;
 }
 
 .completion-content {
@@ -320,14 +331,15 @@ mat-icon {
 
 .completion-icon {
   font-size: 4rem;
-  color: #4caf50;
+  color: #fbbf24;
   margin-bottom: 1rem;
+  filter: drop-shadow(0 0 12px rgba(251, 191, 36, 0.4));
 }
 
 .completion-title {
   font-size: 2rem;
   font-weight: 700;
-  color: #333;
+  color: var(--text, #c8d4e8);
   margin-bottom: 2rem;
 }
 
@@ -343,20 +355,22 @@ mat-icon {
   flex-direction: column;
   align-items: center;
   padding: 1rem;
-  background: #f8f9fa;
+  background: var(--raised, #111826);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.07));
   border-radius: 8px;
 }
 
 .stat-label {
   font-size: 0.9rem;
-  color: #666;
+  color: var(--text-muted, #7a93b0);
   margin-bottom: 0.5rem;
 }
 
 .stat-value {
   font-size: 1.5rem;
   font-weight: 700;
-  color: #0078d4;
+  font-family: 'JetBrains Mono', monospace;
+  color: #a78bfa;
 }
 
 .completion-actions {
@@ -384,7 +398,9 @@ mat-icon {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.7);
+  background: rgba(6, 8, 14, 0.85);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -392,9 +408,10 @@ mat-icon {
 }
 
 .paused-card {
-  background: white;
+  background: var(--surface, #0c1018);
+  border: 1px solid var(--border-mid, rgba(255, 255, 255, 0.13));
   border-radius: 16px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
   text-align: center;
   max-width: 400px;
   width: 90%;
@@ -406,20 +423,20 @@ mat-icon {
 
 .paused-icon {
   font-size: 3rem;
-  color: #ff9800;
+  color: #fbbf24;
   margin-bottom: 1rem;
 }
 
 .paused-title {
   font-size: 1.5rem;
   font-weight: 700;
-  color: #333;
+  color: var(--text, #c8d4e8);
   margin-bottom: 1rem;
 }
 
 .paused-text {
   font-size: 1rem;
-  color: #666;
+  color: var(--text-muted, #7a93b0);
   margin-bottom: 2rem;
   line-height: 1.5;
 }
@@ -431,16 +448,15 @@ mat-icon {
 }
 
 /* Animations */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
 @keyframes pulse {
-  0% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.05);
-  }
-  100% {
-    transform: scale(1);
-  }
+  0%   { transform: scale(1); }
+  50%  { transform: scale(1.05); }
+  100% { transform: scale(1); }
 }
 
 /* Responsive Design */

--- a/src/app/mental-arithmetic/components/arithmetic-session/arithmetic-session.component.ts
+++ b/src/app/mental-arithmetic/components/arithmetic-session/arithmetic-session.component.ts
@@ -551,15 +551,18 @@ export class ArithmeticSessionComponent implements OnInit, OnDestroy {
       padding: 20px;
       text-align: center;
       min-width: 300px;
+      background: #0c1018;
+      color: #c8d4e8;
     }
 
     h2 {
-      color: #1976d2;
+      color: #a78bfa;
       margin-bottom: 20px;
     }
 
     .session-stats {
-      background-color: #f5f5f5;
+      background-color: #111826;
+      border: 1px solid rgba(255, 255, 255, 0.07);
       padding: 15px;
       border-radius: 8px;
       margin: 15px 0;
@@ -568,11 +571,11 @@ export class ArithmeticSessionComponent implements OnInit, OnDestroy {
 
     .session-stats p {
       margin: 8px 0;
-      color: #333;
+      color: #c8d4e8;
     }
 
     .warning-text {
-      color: #666;
+      color: #7a93b0;
       font-style: italic;
       margin: 15px 0;
     }
@@ -585,8 +588,9 @@ export class ArithmeticSessionComponent implements OnInit, OnDestroy {
     }
 
     .confirm-button {
-      background-color: #f44336;
-      color: white;
+      background-color: rgba(251, 113, 133, 0.15);
+      border: 1px solid rgba(251, 113, 133, 0.3);
+      color: #fb7185;
       border-radius: 20px;
       padding: 8px 16px;
       display: flex;
@@ -595,12 +599,13 @@ export class ArithmeticSessionComponent implements OnInit, OnDestroy {
     }
 
     .confirm-button:hover {
-      background-color: #d32f2f;
+      background-color: rgba(251, 113, 133, 0.25);
     }
 
     .cancel-button {
-      background-color: #4caf50;
-      color: white;
+      background-color: rgba(34, 211, 94, 0.15);
+      border: 1px solid rgba(34, 211, 94, 0.3);
+      color: #22d35e;
       border-radius: 20px;
       padding: 8px 16px;
       display: flex;
@@ -609,7 +614,7 @@ export class ArithmeticSessionComponent implements OnInit, OnDestroy {
     }
 
     .cancel-button:hover {
-      background-color: #388e3c;
+      background-color: rgba(34, 211, 94, 0.25);
     }
 
     mat-icon {

--- a/src/app/mental-arithmetic/components/arithmetic-settings/arithmetic-settings.component.css
+++ b/src/app/mental-arithmetic/components/arithmetic-settings/arithmetic-settings.component.css
@@ -1,28 +1,31 @@
 .container-fluid {
-  padding: 20px;
+  padding: 1.5rem;
   min-height: calc(100vh - 64px);
-  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
 }
 
 .settings-card {
   max-width: 600px;
-  margin: 20px auto;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+  margin: 0 auto;
+  background: var(--surface, #0c1018);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.07));
   border-radius: 16px;
-  background: white;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  animation: fadeUp 0.5s ease both;
 }
 
 .mat-mdc-card-header {
-  background: linear-gradient(135deg, #2196f3 0%, #1976d2 100%);
-  color: white;
+  background: var(--raised, #111826);
+  border-bottom: 1px solid var(--border, rgba(255, 255, 255, 0.07));
   border-radius: 16px 16px 0 0;
   padding: 20px;
 }
 
 .mat-mdc-card-title h2 {
   margin: 0;
-  font-weight: 500;
-  font-size: 24px;
+  font-weight: 600;
+  font-size: 1.25rem;
+  color: var(--text, #c8d4e8);
+  letter-spacing: 0.02em;
 }
 
 .settings-form {
@@ -31,12 +34,18 @@
 
 .section {
   margin-bottom: 32px;
+  animation: fadeUp 0.5s ease both;
 }
 
+.section:nth-child(1) { animation-delay: 0.05s; }
+.section:nth-child(2) { animation-delay: 0.1s; }
+.section:nth-child(3) { animation-delay: 0.15s; }
+.section:nth-child(4) { animation-delay: 0.2s; }
+
 .section-title {
-  font-size: 18px;
-  font-weight: 500;
-  color: #333;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text, #c8d4e8);
   margin-bottom: 16px;
   display: flex;
   align-items: center;
@@ -45,9 +54,9 @@
 .section-title::before {
   content: '';
   display: inline-block;
-  width: 4px;
-  height: 20px;
-  background-color: #2196f3;
+  width: 3px;
+  height: 18px;
+  background-color: #a78bfa;
   margin-right: 8px;
   border-radius: 2px;
 }
@@ -63,31 +72,33 @@
   display: flex !important;
   align-items: center;
   padding: 12px;
-  border: 2px solid #e0e0e0;
+  border: 1px solid var(--border-mid, rgba(255, 255, 255, 0.13));
   border-radius: 8px;
-  transition: all 0.3s ease;
+  background: var(--raised, #111826);
+  transition: all 0.2s ease;
   margin-bottom: 8px;
 }
 
 .operation-checkbox:hover {
-  border-color: #2196f3;
-  background-color: #f8f9fa;
+  border-color: #a78bfa;
+  background: rgba(167, 139, 250, 0.05);
 }
 
 .operation-checkbox.mat-mdc-checkbox-checked {
-  border-color: #2196f3;
-  background-color: #e3f2fd;
+  border-color: #a78bfa;
+  background: rgba(167, 139, 250, 0.1);
 }
 
 .operation-checkbox mat-icon {
   margin-right: 12px;
   font-size: 24px;
-  color: #2196f3;
+  color: #a78bfa;
 }
 
 .operation-checkbox span {
   font-size: 16px;
   font-weight: 500;
+  color: var(--text, #c8d4e8);
 }
 
 /* Difficulty Selection */
@@ -101,20 +112,21 @@
   display: flex !important;
   align-items: center;
   padding: 16px;
-  border: 2px solid #e0e0e0;
+  border: 1px solid var(--border-mid, rgba(255, 255, 255, 0.13));
   border-radius: 8px;
-  transition: all 0.3s ease;
+  background: var(--raised, #111826);
+  transition: all 0.2s ease;
   margin-bottom: 8px;
 }
 
 .difficulty-option:hover {
-  border-color: #2196f3;
-  background-color: #f8f9fa;
+  border-color: #a78bfa;
+  background: rgba(167, 139, 250, 0.05);
 }
 
 .difficulty-option.mat-mdc-radio-checked {
-  border-color: #2196f3;
-  background-color: #e3f2fd;
+  border-color: #a78bfa;
+  background: rgba(167, 139, 250, 0.1);
 }
 
 .difficulty-content {
@@ -126,12 +138,12 @@
 .difficulty-label {
   font-size: 16px;
   font-weight: 500;
-  color: #333;
+  color: var(--text, #c8d4e8);
 }
 
 .difficulty-desc {
   font-size: 14px;
-  color: #666;
+  color: var(--text-muted, #7a93b0);
   margin-top: 4px;
 }
 
@@ -144,41 +156,14 @@
   margin-bottom: 16px;
 }
 
-/* Time Limit Input */
 input[type="number"] {
   font-size: 16px;
   text-align: center;
 }
 
-/* Problem Count Slider */
-.slider-container {
-  margin-top: 16px;
-  padding: 0 8px;
-}
-
-.slider-labels {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: 8px;
-  font-size: 14px;
-  color: #666;
-}
-
-.slider-labels span:nth-child(2) {
-  font-weight: 500;
-  color: #2196f3;
-  font-size: 16px;
-}
-
-.mat-mdc-slider {
-  width: 100%;
-  margin: 16px 0;
-}
-
 /* Validation */
 .error-message {
-  color: #f44336;
+  color: #fb7185;
   font-size: 14px;
   margin-top: 8px;
   display: block;
@@ -188,20 +173,20 @@ input[type="number"] {
   display: flex;
   align-items: center;
   padding: 12px;
-  background-color: #ffebee;
-  border: 1px solid #f44336;
-  border-radius: 4px;
+  background-color: rgba(251, 113, 133, 0.08);
+  border: 1px solid rgba(251, 113, 133, 0.3);
+  border-radius: 8px;
   margin-top: 16px;
 }
 
 .error-icon {
-  color: #f44336;
+  color: #fb7185;
   margin-right: 8px;
   font-size: 20px;
 }
 
 .error-text {
-  color: #f44336;
+  color: #fb7185;
   font-size: 14px;
 }
 
@@ -220,39 +205,42 @@ input[type="number"] {
   font-size: 16px;
   font-weight: 500;
   border-radius: 8px;
-  transition: all 0.3s ease;
+  transition: all 0.2s ease;
 }
 
 .save-button {
-  background-color: #f8f9fa;
-  border: 1px solid #dee2e6;
-  color: #495057;
+  background-color: var(--raised, #111826);
+  border: 1px solid var(--border-mid, rgba(255, 255, 255, 0.13));
+  color: var(--text-muted, #7a93b0);
 }
 
 .save-button:hover:not(:disabled) {
-  background-color: #e9ecef;
-  border-color: #adb5bd;
+  border-color: var(--text-muted, #7a93b0);
+  color: var(--text, #c8d4e8);
 }
 
 .save-button:disabled {
-  opacity: 0.6;
+  opacity: 0.4;
   cursor: not-allowed;
 }
 
 .start-button {
-  background: linear-gradient(135deg, #2196f3 0%, #1976d2 100%);
-  color: white;
-  box-shadow: 0 4px 12px rgba(33, 150, 243, 0.3);
+  background: rgba(167, 139, 250, 0.15);
+  border: 1px solid rgba(167, 139, 250, 0.4);
+  color: #a78bfa;
+  box-shadow: 0 4px 12px rgba(167, 139, 250, 0.15);
 }
 
 .start-button:hover:not(:disabled) {
-  background: linear-gradient(135deg, #1976d2 0%, #1565c0 100%);
-  box-shadow: 0 6px 20px rgba(33, 150, 243, 0.4);
+  background: rgba(167, 139, 250, 0.25);
+  box-shadow: 0 6px 20px rgba(167, 139, 250, 0.25);
   transform: translateY(-2px);
 }
 
 .start-button:disabled {
-  background: #ccc;
+  background: var(--raised, #111826);
+  border-color: var(--border, rgba(255, 255, 255, 0.07));
+  color: var(--text-dim, #3d5470);
   box-shadow: none;
   cursor: not-allowed;
   transform: none;
@@ -267,11 +255,10 @@ input[type="number"] {
 /* Responsive Design */
 @media (max-width: 768px) {
   .container-fluid {
-    padding: 10px;
+    padding: 0.75rem;
   }
 
   .settings-card {
-    margin: 10px auto;
     border-radius: 12px;
   }
 
@@ -290,7 +277,7 @@ input[type="number"] {
   }
 
   .section-title {
-    font-size: 16px;
+    font-size: 0.95rem;
   }
 
   .operation-checkbox,
@@ -309,7 +296,7 @@ input[type="number"] {
 
 @media (max-width: 480px) {
   .container-fluid {
-    padding: 5px;
+    padding: 0.5rem;
   }
 
   .settings-form {
@@ -321,7 +308,7 @@ input[type="number"] {
   }
 
   .mat-mdc-card-title h2 {
-    font-size: 20px;
+    font-size: 1.1rem;
   }
 
   .section {
@@ -329,16 +316,7 @@ input[type="number"] {
   }
 
   .section-title {
-    font-size: 15px;
-  }
-
-  .operation-checkbox mat-icon,
-  .difficulty-label {
-    font-size: 14px;
-  }
-
-  .difficulty-desc {
-    font-size: 12px;
+    font-size: 0.9rem;
   }
 
   .action-buttons {
@@ -346,70 +324,8 @@ input[type="number"] {
   }
 }
 
-/* Material Theme Overrides */
-.mat-mdc-checkbox-checked .mdc-checkbox__checkmark {
-  color: white !important;
-}
-
-.mat-mdc-checkbox-checked .mdc-checkbox__background {
-  background-color: #2196f3 !important;
-  border-color: #2196f3 !important;
-}
-
-.mat-mdc-radio-checked .mdc-radio__outer-circle {
-  border-color: #2196f3 !important;
-}
-
-.mat-mdc-radio-checked .mdc-radio__inner-circle {
-  background-color: #2196f3 !important;
-}
-
-.mat-mdc-slider-thumb {
-  background-color: #2196f3 !important;
-}
-
-.mat-mdc-slider-track-fill {
-  background-color: #2196f3 !important;
-}
-
-.mat-mdc-form-field-focus .mat-mdc-form-field-focus-overlay {
-  background-color: rgba(33, 150, 243, 0.1) !important;
-}
-
-.mat-mdc-form-field-focus .mat-mdc-form-field-label {
-  color: #2196f3 !important;
-}
-
-/* Animation Effects */
-.settings-card {
-  animation: fadeInUp 0.6s ease-out;
-}
-
-@keyframes fadeInUp {
-  from {
-    opacity: 0;
-    transform: translateY(30px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.section {
-  animation: fadeIn 0.8s ease-out;
-}
-
-.section:nth-child(1) { animation-delay: 0.1s; }
-.section:nth-child(2) { animation-delay: 0.2s; }
-.section:nth-child(3) { animation-delay: 0.3s; }
-.section:nth-child(4) { animation-delay: 0.4s; }
-
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
+/* Entrance Animations */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
 }


### PR DESCRIPTION
## Summary
- Restyle all 5 mental-arithmetic components (root, main, session, settings, list) to use the dark theme design system from `home.component.css`
- Apply shared design tokens: `--bg`, `--surface`, `--raised`, `--border`, `--text` hierarchy, accent colors with glow variants
- Use Outfit + JetBrains Mono fonts, fadeUp entrance animations, glow-on-hover card patterns, and left accent stripes consistent with the home landing page
- Replace light backgrounds (white, `#f5f7fa`) with dark surfaces (`#0c1018`, `#111826`), and update all text/badge/score colors for dark theme contrast

## Test plan
- [ ] Verify `/mental-arithmetic` main landing page renders with dark cards and hover glow effects
- [ ] Verify `/mental-arithmetic/settings` form elements are readable and interactive on dark background
- [ ] Verify `/mental-arithmetic/session` training UI (progress bar, timer, problem display, number pad, completion screen) renders correctly
- [ ] Verify `/mental-arithmetic/arithmetic-list` stats cards, filters, table, and session details all use dark theme
- [ ] Check mobile responsiveness on all views
- [ ] Verify navigation (home button, menu) works correctly with restyled topbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)