### PR TITLE
style(exports): apply dark theme matching home design system

### DIFF
--- a/src/app/exports/exports-backups.component.css
+++ b/src/app/exports/exports-backups.component.css
@@ -1,115 +1,188 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+/* ── Design Tokens ───────────────────────────────── */
 :host {
-  /* Exports: dark fluid theme tokens (component-scoped) */
-  --ex-bg: #0b0f17;
-  --ex-bg-2: #0a1221;
-  --ex-surface: rgba(255, 255, 255, 0.06);
-  --ex-surface-2: rgba(255, 255, 255, 0.08);
-  --ex-surface-3: rgba(255, 255, 255, 0.10);
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
 
-  --ex-border: rgba(255, 255, 255, 0.10);
-  --ex-border-strong: rgba(255, 255, 255, 0.16);
-  --ex-shadow: 0 14px 40px rgba(0, 0, 0, 0.45);
-  --ex-shadow-soft: 0 8px 24px rgba(0, 0, 0, 0.35);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
 
-  --ex-text: rgba(255, 255, 255, 0.92);
-  --ex-text-muted: rgba(255, 255, 255, 0.68);
-  --ex-text-faint: rgba(255, 255, 255, 0.52);
+  --accent:      #22d35e;
+  --accent-glow: rgba(34, 211, 94, 0.18);
 
-  --ex-accent: #7c5cff; /* violet */
-  --ex-accent-2: #22d3ee; /* cyan */
-  --ex-focus: rgba(124, 92, 255, 0.55);
+  --danger:      #fb7185;
+  --success:     #22d35e;
+  --info:        #4da6ff;
 
-  --ex-danger: #ff4d4d;
-  --ex-success: #4caf7d;
-
-  --ex-radius-lg: 16px;
-  --ex-radius-md: 12px;
-  --ex-radius-sm: 10px;
-  --ex-gap: 16px;
+  display: block;
+  min-height: 100dvh;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+  background-color: var(--bg);
+  background-image:
+    radial-gradient(ellipse 70% 35% at 0% 0%,    rgba(34, 211, 94, 0.05) 0%, transparent 100%),
+    radial-gradient(ellipse 50% 35% at 100% 100%, rgba(251, 113, 133, 0.04) 0%, transparent 100%),
+    radial-gradient(circle, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+  background-size: auto, auto, 28px 28px;
 }
 
-/* Shell */
-.exports-shell {
-  color: var(--ex-text);
+/* ── Topbar ──────────────────────────────────────── */
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: max(0.75rem, env(safe-area-inset-top)) max(1.25rem, env(safe-area-inset-right)) 0.75rem max(1.25rem, env(safe-area-inset-left));
+  background: rgba(6, 8, 14, 0.88);
+  border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  box-shadow: 0 1px 0 rgba(34, 211, 94, 0.06);
 }
 
-.exports-shell.container {
-  max-width: 1200px;
-  padding: clamp(16px, 2.4vw, 28px);
-  border-radius: var(--ex-radius-lg);
-  background:
-    radial-gradient(1200px 600px at 10% -10%, rgba(124, 92, 255, 0.26), transparent 55%),
-    radial-gradient(900px 500px at 90% 10%, rgba(34, 211, 238, 0.14), transparent 55%),
-    linear-gradient(180deg, var(--ex-bg-2), var(--ex-bg));
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  box-shadow: var(--ex-shadow);
+.topbar__left {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
-.exports-shell h2 {
-  font-size: 1.75rem;
-  letter-spacing: -0.02em;
-  margin: 0;
+.topbar__btn {
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--raised);
+  color: var(--text-muted);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s, background 0.2s;
 }
 
-.exports-shell h3 {
-  font-size: 1.125rem;
-  letter-spacing: -0.01em;
-  color: rgba(255, 255, 255, 0.90);
+.topbar__btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
 }
 
-.exports-shell button[mat-icon-button] {
-  border-radius: 12px;
+.topbar__icon {
+  color: var(--accent);
+  font-size: 0.9rem;
+  filter: drop-shadow(0 0 6px rgba(34, 211, 94, 0.5));
 }
 
-.exports-shell button[mat-icon-button]:hover {
-  background: rgba(255, 255, 255, 0.06);
+.topbar__title {
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  color: var(--text-muted);
+  text-transform: uppercase;
 }
 
-.exports-shell button[mat-icon-button]:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px var(--ex-focus);
-}
-
-/* Backups panel (Bootstrap card) */
-.exports-backups .card {
-  border-radius: var(--ex-radius-lg);
-  border: 1px solid var(--ex-border);
-  background: linear-gradient(180deg, var(--ex-surface-2), var(--ex-surface));
-  box-shadow: var(--ex-shadow-soft);
-  overflow: hidden;
-}
-
-.exports-backups .card-header {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.05);
-}
-
-.exports-backups .card-header h5 {
-  color: rgba(255, 255, 255, 0.90);
-}
-
-.exports-backups .card-body {
-  color: var(--ex-text);
-  padding: 0;
-}
-
-.w-100 {
+/* ── Layout ──────────────────────────────────────── */
+.layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem
+    max(1rem, env(safe-area-inset-right))
+    max(1rem, env(safe-area-inset-bottom))
+    max(1rem, env(safe-area-inset-left));
+  max-width: 1280px;
+  margin: 0 auto;
   width: 100%;
+  box-sizing: border-box;
 }
 
-/* Angular Material table (MDC) */
+@media (min-width: 1024px) {
+  .layout {
+    gap: 1.5rem;
+    padding: 1.5rem;
+  }
+}
+
+/* ── Panel ───────────────────────────────────────── */
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  animation: fadeUp 0.5s ease both;
+}
+
+.panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.65rem 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.panel__label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+}
+
+.panel__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex-shrink: 0;
+  animation: blink 2s ease-in-out infinite;
+  box-shadow: 0 0 5px var(--accent);
+}
+
+.panel__action {
+  width: 30px;
+  height: 30px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--raised);
+  color: var(--text-muted);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.panel__action:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* ── Table ───────────────────────────────────────── */
 table[mat-table] {
+  width: 100%;
   background: transparent;
 }
 
 table[mat-table] .mat-mdc-header-row {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--raised);
 }
 
 table[mat-table] .mat-mdc-header-cell {
-  color: rgba(255, 255, 255, 0.78);
-  font-weight: 600;
-  border-bottom-color: rgba(255, 255, 255, 0.10);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  border-bottom-color: var(--border);
 }
 
 table[mat-table] .mat-mdc-row {
@@ -117,91 +190,123 @@ table[mat-table] .mat-mdc-row {
 }
 
 table[mat-table] .mat-mdc-row:hover {
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(34, 211, 94, 0.04);
 }
 
 table[mat-table] .mat-mdc-cell {
-  color: rgba(255, 255, 255, 0.86);
-  border-bottom-color: rgba(255, 255, 255, 0.08);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  color: var(--text);
+  border-bottom-color: var(--border);
 }
 
-table[mat-table] button[mat-icon-button] {
-  border-radius: 10px;
-}
-
-table[mat-table] button[mat-icon-button]:hover {
-  background: rgba(255, 255, 255, 0.06);
-}
-
-/* Status badges */
-.status-badge {
+/* ── Status Badges ───────────────────────────────── */
+.badge {
   display: inline-block;
   padding: 2px 10px;
   border-radius: 20px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
-.status-success {
-  background: rgba(76, 175, 125, 0.18);
-  color: #4caf7d;
-  border: 1px solid rgba(76, 175, 125, 0.30);
+.badge--success {
+  background: rgba(34, 211, 94, 0.12);
+  color: var(--success);
+  border: 1px solid rgba(34, 211, 94, 0.30);
 }
 
-.status-failed {
-  background: rgba(255, 77, 77, 0.15);
-  color: var(--ex-danger);
-  border: 1px solid rgba(255, 77, 77, 0.28);
+.badge--failed {
+  background: rgba(251, 113, 133, 0.12);
+  color: var(--danger);
+  border: 1px solid rgba(251, 113, 133, 0.28);
 }
 
-.status-in-progress {
-  background: rgba(34, 211, 238, 0.12);
-  color: var(--ex-accent-2);
-  border: 1px solid rgba(34, 211, 238, 0.25);
+.badge--in-progress {
+  background: rgba(77, 166, 255, 0.12);
+  color: var(--info);
+  border: 1px solid rgba(77, 166, 255, 0.25);
 }
 
-/* Upload success/failure icons */
+/* ── Upload Status Icons ─────────────────────────── */
 .icon-success {
-  color: var(--ex-success);
+  color: var(--success);
   vertical-align: middle;
+  font-size: 20px;
 }
 
 .icon-danger {
-  color: var(--ex-danger);
+  color: var(--danger);
   vertical-align: middle;
+  font-size: 20px;
 }
 
-/* Paginator */
+/* ── Paginator ───────────────────────────────────── */
 mat-paginator {
-  background: transparent;
-  color: var(--ex-text-muted);
-  border-top: 1px solid var(--ex-border);
+  background: var(--raised);
+  color: var(--text-muted);
+  border-top: 1px solid var(--border);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.68rem;
 }
 
-/* Bootstrap alerts (dark equivalents) */
-.alert {
-  border-radius: var(--ex-radius-lg);
-  border: 1px solid var(--ex-border);
-  background: rgba(255, 255, 255, 0.05);
-  color: rgba(255, 255, 255, 0.86);
+/* ── Loading / Empty / Error States ──────────────── */
+.state-box {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 2.5rem 1rem;
+  text-align: center;
 }
 
-.alert-info {
-  border-color: rgba(34, 211, 238, 0.25);
+.state-box__text {
+  font-size: 0.78rem;
+  color: var(--text-muted);
 }
 
-.alert-danger {
-  border-color: rgba(255, 77, 77, 0.28);
+.state-box--error .state-box__text {
+  color: var(--danger);
 }
 
-/* Spinner label */
-.exports-shell p {
-  color: var(--ex-text-muted);
+mat-spinner {
+  --mdc-circular-progress-active-indicator-color: var(--accent);
 }
 
-@media (prefers-reduced-motion: reduce) {
-  * {
-    transition: none !important;
+.alert-box {
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--raised);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.alert-box--info {
+  border-color: rgba(77, 166, 255, 0.25);
+}
+
+.alert-box--danger {
+  border-color: rgba(251, 113, 133, 0.28);
+  color: var(--danger);
+}
+
+/* ── Animations ──────────────────────────────────── */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.2; }
+}
+
+@media (min-width: 480px) {
+  .topbar__btn {
+    width: 40px;
+    height: 40px;
   }
 }

--- a/src/app/exports/exports-backups.component.html
+++ b/src/app/exports/exports-backups.component.html
@@ -1,112 +1,107 @@
-<div class="container mt-4 exports-shell">
-  <div class="d-flex justify-content-between align-items-center">
-    <h2>Backups</h2>
-    <div class="d-flex align-items-center" style="gap: 8px;">
-      <button mat-icon-button routerLink="/exports" matTooltip="Back to Exports">
-        <mat-icon>arrow_back</mat-icon>
-      </button>
-      <button mat-icon-button routerLink="/" matTooltip="Back to Home">
-        <mat-icon>home</mat-icon>
-      </button>
+<div class="topbar">
+  <div class="topbar__left">
+    <button class="topbar__btn" routerLink="/">
+      <mat-icon>home</mat-icon>
+    </button>
+    <button class="topbar__btn" routerLink="/exports">
+      <mat-icon>arrow_back</mat-icon>
+    </button>
+  </div>
+  <span class="topbar__icon">&#x2B21;</span>
+  <span class="topbar__title">Backups</span>
+</div>
+
+<div class="layout">
+
+  @if (isLoading) {
+    <div class="state-box">
+      <mat-spinner [diameter]="36"></mat-spinner>
+      <span class="state-box__text">Loading backup runs&#x2026;</span>
     </div>
-  </div>
+  }
 
-  <div class="mt-5 exports-backups">
-    <h3>Backup Run History</h3>
+  @if (error) {
+    <div class="alert-box alert-box--danger">
+      <strong>Error:</strong> {{ error }}
+    </div>
+  }
 
-    @if (isLoading) {
-      <div class="text-center mt-4">
-        <mat-spinner></mat-spinner>
-        <p class="mt-2">Loading backup runs...</p>
-      </div>
-    }
+  @if (!isLoading && !error && backupRuns.length === 0) {
+    <div class="alert-box alert-box--info">
+      No backup runs found.
+    </div>
+  }
 
-    @if (error) {
-      <div class="alert alert-danger mt-4">
-        <strong>Error:</strong> {{ error }}
-      </div>
-    }
-
-    @if (!isLoading && !error && backupRuns.length === 0) {
-      <div class="alert alert-info mt-4">
-        No backup runs found.
-      </div>
-    }
-
-    @if (!isLoading && !error && backupRuns.length > 0) {
-      <div class="mt-4">
-        <div class="card">
-          <div class="card-header d-flex justify-content-between align-items-center">
-            <h5 class="mb-0">Backup Runs ({{ totalElements }})</h5>
-            <button mat-icon-button (click)="loadBackupRuns()" [disabled]="isLoading" matTooltip="Refresh">
-              <mat-icon>refresh</mat-icon>
-            </button>
-          </div>
-          <div class="card-body">
-            <table mat-table [dataSource]="backupRuns" class="w-100">
-
-              <!-- File Name Column -->
-              <ng-container matColumnDef="fileName">
-                <th mat-header-cell *matHeaderCellDef>File Name</th>
-                <td mat-cell *matCellDef="let run">{{ run.fileName }}</td>
-              </ng-container>
-
-              <!-- Status Column -->
-              <ng-container matColumnDef="status">
-                <th mat-header-cell *matHeaderCellDef>Status</th>
-                <td mat-cell *matCellDef="let run">
-                  <span class="status-badge" [class]="'status-' + run.status.toLowerCase().replace('_', '-')">
-                    {{ run.status }}
-                  </span>
-                </td>
-              </ng-container>
-
-              <!-- Started At Column -->
-              <ng-container matColumnDef="startedAt">
-                <th mat-header-cell *matHeaderCellDef>Started</th>
-                <td mat-cell *matCellDef="let run">{{ formatDateTime(run.startedAt) }}</td>
-              </ng-container>
-
-              <!-- Finished At Column -->
-              <ng-container matColumnDef="finishedAt">
-                <th mat-header-cell *matHeaderCellDef>Finished</th>
-                <td mat-cell *matCellDef="let run">{{ formatDateTime(run.finishedAt) }}</td>
-              </ng-container>
-
-              <!-- Duration Column -->
-              <ng-container matColumnDef="durationMs">
-                <th mat-header-cell *matHeaderCellDef>Duration</th>
-                <td mat-cell *matCellDef="let run">{{ formatDuration(run.durationMs) }}</td>
-              </ng-container>
-
-              <!-- Upload Success Column -->
-              <ng-container matColumnDef="uploadSuccess">
-                <th mat-header-cell *matHeaderCellDef>Upload</th>
-                <td mat-cell *matCellDef="let run">
-                  @if (run.uploadSuccess === true) {
-                    <mat-icon class="icon-success" matTooltip="Upload successful">check_circle</mat-icon>
-                  } @else if (run.uploadSuccess === false) {
-                    <mat-icon class="icon-danger" [matTooltip]="run.errorMessage || 'Upload failed'">cancel</mat-icon>
-                  } @else {
-                    <span>-</span>
-                  }
-                </td>
-              </ng-container>
-
-              <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-              <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-            </table>
-
-            <mat-paginator
-              [length]="totalElements"
-              [pageSize]="pageSize"
-              [pageIndex]="pageIndex"
-              [pageSizeOptions]="[10, 20, 50]"
-              (page)="onPageChange($event)"
-            ></mat-paginator>
-          </div>
+  @if (!isLoading && !error && backupRuns.length > 0) {
+    <section class="panel">
+      <div class="panel__header">
+        <div class="panel__label">
+          <span class="panel__dot"></span>
+          <span>Backup Runs ({{ totalElements }})</span>
         </div>
+        <button class="panel__action" (click)="loadBackupRuns()" [disabled]="isLoading">
+          <mat-icon>refresh</mat-icon>
+        </button>
       </div>
-    }
-  </div>
+
+      <table mat-table [dataSource]="backupRuns">
+        <ng-container matColumnDef="fileName">
+          <th mat-header-cell *matHeaderCellDef>File Name</th>
+          <td mat-cell *matCellDef="let run">{{ run.fileName }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="status">
+          <th mat-header-cell *matHeaderCellDef>Status</th>
+          <td mat-cell *matCellDef="let run">
+            <span class="badge"
+              [class.badge--success]="run.status === 'SUCCESS'"
+              [class.badge--failed]="run.status === 'FAILED'"
+              [class.badge--in-progress]="run.status === 'IN_PROGRESS'">
+              {{ run.status }}
+            </span>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="startedAt">
+          <th mat-header-cell *matHeaderCellDef>Started</th>
+          <td mat-cell *matCellDef="let run">{{ formatDateTime(run.startedAt) }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="finishedAt">
+          <th mat-header-cell *matHeaderCellDef>Finished</th>
+          <td mat-cell *matCellDef="let run">{{ formatDateTime(run.finishedAt) }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="durationMs">
+          <th mat-header-cell *matHeaderCellDef>Duration</th>
+          <td mat-cell *matCellDef="let run">{{ formatDuration(run.durationMs) }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="uploadSuccess">
+          <th mat-header-cell *matHeaderCellDef>Upload</th>
+          <td mat-cell *matCellDef="let run">
+            @if (run.uploadSuccess === true) {
+              <mat-icon class="icon-success" matTooltip="Upload successful">check_circle</mat-icon>
+            } @else if (run.uploadSuccess === false) {
+              <mat-icon class="icon-danger" [matTooltip]="run.errorMessage || 'Upload failed'">cancel</mat-icon>
+            } @else {
+              <span>-</span>
+            }
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      </table>
+
+      <mat-paginator
+        [length]="totalElements"
+        [pageSize]="pageSize"
+        [pageIndex]="pageIndex"
+        [pageSizeOptions]="[10, 20, 50]"
+        (page)="onPageChange($event)">
+      </mat-paginator>
+    </section>
+  }
+
 </div>

--- a/src/app/exports/exports-backups.component.ts
+++ b/src/app/exports/exports-backups.component.ts
@@ -1,34 +1,30 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
-import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatTableModule } from '@angular/material/table';
-import { MatTooltipModule } from '@angular/material/tooltip';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit} from '@angular/core';
+import {RouterModule} from '@angular/router';
+import {MatIconModule} from '@angular/material/icon';
+import {MatPaginatorModule, PageEvent} from '@angular/material/paginator';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
+import {MatTableModule} from '@angular/material/table';
+import {MatTooltipModule} from '@angular/material/tooltip';
 
-import { BackupRunService } from './services/backup/backup-run.service';
-import { BackupRun } from './services/backup/backup-run.model';
+import {BackupRunService} from './services/backup/backup-run.service';
+import {BackupRun} from './services/backup/backup-run.model';
 
 @Component({
   selector: 'app-exports-backups',
-  standalone: true,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    CommonModule,
     RouterModule,
     MatTableModule,
     MatIconModule,
-    MatButtonModule,
     MatProgressSpinnerModule,
     MatTooltipModule,
-    MatPaginatorModule
+    MatPaginatorModule,
   ],
   templateUrl: './exports-backups.component.html',
-  styleUrl: './exports-backups.component.css'
+  styleUrl: './exports-backups.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ExportsBackupsComponent implements OnInit {
+
   backupRuns: BackupRun[] = [];
   isLoading = true;
   error: string | null = null;
@@ -37,10 +33,8 @@ export class ExportsBackupsComponent implements OnInit {
   pageSize = 20;
   pageIndex = 0;
 
-  constructor(
-    private backupRunService: BackupRunService,
-    private cdr: ChangeDetectorRef
-  ) {}
+  private backupRunService = inject(BackupRunService);
+  private cdr = inject(ChangeDetectorRef);
 
   ngOnInit(): void {
     this.loadBackupRuns();

--- a/src/app/exports/exports-files.component.css
+++ b/src/app/exports/exports-files.component.css
@@ -1,139 +1,186 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+/* ── Design Tokens ───────────────────────────────── */
 :host {
-  /* Exports: dark fluid theme tokens (component-scoped) */
-  --ex-bg: #0b0f17;
-  --ex-bg-2: #0a1221;
-  --ex-surface: rgba(255, 255, 255, 0.06);
-  --ex-surface-2: rgba(255, 255, 255, 0.08);
-  --ex-surface-3: rgba(255, 255, 255, 0.10);
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
 
-  --ex-border: rgba(255, 255, 255, 0.10);
-  --ex-border-strong: rgba(255, 255, 255, 0.16);
-  --ex-shadow: 0 14px 40px rgba(0, 0, 0, 0.45);
-  --ex-shadow-soft: 0 8px 24px rgba(0, 0, 0, 0.35);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
 
-  --ex-text: rgba(255, 255, 255, 0.92);
-  --ex-text-muted: rgba(255, 255, 255, 0.68);
-  --ex-text-faint: rgba(255, 255, 255, 0.52);
+  --accent:      #4da6ff;
+  --accent-glow: rgba(77, 166, 255, 0.18);
 
-  --ex-accent: #7c5cff; /* violet */
-  --ex-accent-2: #22d3ee; /* cyan */
-  --ex-focus: rgba(124, 92, 255, 0.55);
+  --danger:      #fb7185;
 
-  --ex-danger: #ff4d4d;
-
-  --ex-radius-lg: 16px;
-  --ex-radius-md: 12px;
-  --ex-radius-sm: 10px;
-  --ex-gap: 16px;
+  display: block;
+  min-height: 100dvh;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+  background-color: var(--bg);
+  background-image:
+    radial-gradient(ellipse 70% 35% at 0% 0%,    rgba(77, 166, 255, 0.05) 0%, transparent 100%),
+    radial-gradient(ellipse 50% 35% at 100% 100%, rgba(251, 113, 133, 0.04) 0%, transparent 100%),
+    radial-gradient(circle, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+  background-size: auto, auto, 28px 28px;
 }
 
-/* Shell */
-.exports-shell {
-  color: var(--ex-text);
-}
-
-.exports-shell.container {
-  max-width: 1200px;
-  padding: clamp(16px, 2.4vw, 28px);
-  border-radius: var(--ex-radius-lg);
-  background:
-    radial-gradient(1200px 600px at 10% -10%, rgba(124, 92, 255, 0.26), transparent 55%),
-    radial-gradient(900px 500px at 90% 10%, rgba(34, 211, 238, 0.14), transparent 55%),
-    linear-gradient(180deg, var(--ex-bg-2), var(--ex-bg));
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  box-shadow: var(--ex-shadow);
-}
-
-.exports-shell h2 {
-  font-size: 1.75rem;
-  letter-spacing: -0.02em;
-  margin: 0;
-}
-
-.exports-shell h3 {
-  font-size: 1.125rem;
-  letter-spacing: -0.01em;
-  color: rgba(255, 255, 255, 0.90);
-}
-
-/* Top-right icon button */
-.exports-shell button[mat-icon-button] {
-  border-radius: 12px;
-}
-
-.exports-shell button[mat-icon-button]:hover {
-  background: rgba(255, 255, 255, 0.06);
-}
-
-.exports-shell button[mat-icon-button]:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px var(--ex-focus);
-}
-
-/* Quick actions */
-.quick-actions-container {
+/* ── Topbar ──────────────────────────────────────── */
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
   display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
   align-items: center;
-  padding: 16px;
-  border-radius: var(--ex-radius-lg);
-  border: 1px solid var(--ex-border);
-  background: linear-gradient(180deg, var(--ex-surface-2), var(--ex-surface));
+  justify-content: space-between;
+  padding: max(0.75rem, env(safe-area-inset-top)) max(1.25rem, env(safe-area-inset-right)) 0.75rem max(1.25rem, env(safe-area-inset-left));
+  background: rgba(6, 8, 14, 0.88);
+  border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  box-shadow: 0 1px 0 rgba(77, 166, 255, 0.06);
 }
 
-/* Keep bootstrap spacing helpers working but harmonize */
-.ms-3 {
-  margin-left: 0.75rem;
+.topbar__left {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
-.d-inline-block {
-  display: inline-block;
+.topbar__btn {
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--raised);
+  color: var(--text-muted);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s, background 0.2s;
 }
 
-.align-middle {
-  vertical-align: middle;
+.topbar__btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
 }
 
-/* Files panel (Bootstrap card) */
-.exports-files .card {
-  border-radius: var(--ex-radius-lg);
-  border: 1px solid var(--ex-border);
-  background: linear-gradient(180deg, var(--ex-surface-2), var(--ex-surface));
-  box-shadow: var(--ex-shadow-soft);
-  overflow: hidden;
+.topbar__icon {
+  color: var(--accent);
+  font-size: 0.9rem;
+  filter: drop-shadow(0 0 6px rgba(77, 166, 255, 0.5));
 }
 
-.exports-files .card-header {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.05);
+.topbar__title {
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  color: var(--text-muted);
+  text-transform: uppercase;
 }
 
-.exports-files .card-header h5 {
-  color: rgba(255, 255, 255, 0.90);
-}
-
-.exports-files .card-body {
-  color: var(--ex-text);
-}
-
-.w-100 {
+/* ── Layout ──────────────────────────────────────── */
+.layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem
+    max(1rem, env(safe-area-inset-right))
+    max(1rem, env(safe-area-inset-bottom))
+    max(1rem, env(safe-area-inset-left));
+  max-width: 1280px;
+  margin: 0 auto;
   width: 100%;
+  box-sizing: border-box;
 }
 
-/* Angular Material table (MDC) */
+@media (min-width: 1024px) {
+  .layout {
+    gap: 1.5rem;
+    padding: 1.5rem;
+  }
+}
+
+/* ── Panel ───────────────────────────────────────── */
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  animation: fadeUp 0.5s ease both;
+}
+
+.panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.65rem 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.panel__label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+}
+
+.panel__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex-shrink: 0;
+  animation: blink 2s ease-in-out infinite;
+  box-shadow: 0 0 5px var(--accent);
+}
+
+.panel__action {
+  width: 30px;
+  height: 30px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--raised);
+  color: var(--text-muted);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.panel__action:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* ── Table ───────────────────────────────────────── */
 table[mat-table] {
+  width: 100%;
   background: transparent;
 }
 
 table[mat-table] .mat-mdc-header-row {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--raised);
 }
 
 table[mat-table] .mat-mdc-header-cell {
-  color: rgba(255, 255, 255, 0.78);
-  font-weight: 600;
-  border-bottom-color: rgba(255, 255, 255, 0.10);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  border-bottom-color: var(--border);
 }
 
 table[mat-table] .mat-mdc-row {
@@ -141,56 +188,105 @@ table[mat-table] .mat-mdc-row {
 }
 
 table[mat-table] .mat-mdc-row:hover {
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(77, 166, 255, 0.04);
 }
 
 table[mat-table] .mat-mdc-cell {
-  color: rgba(255, 255, 255, 0.86);
-  border-bottom-color: rgba(255, 255, 255, 0.08);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  color: var(--text);
+  border-bottom-color: var(--border);
 }
 
-/* Action buttons inside table */
-table[mat-table] button[mat-icon-button] {
-  border-radius: 10px;
+/* Action buttons in table */
+.tbl-btn {
+  width: 30px;
+  height: 30px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  display: inline-grid;
+  place-items: center;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s, background 0.2s;
+  margin-right: 0.25rem;
 }
 
-table[mat-table] button[mat-icon-button]:hover {
-  background: rgba(255, 255, 255, 0.06);
+.tbl-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
-table[mat-table] button[mat-icon-button]:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px var(--ex-focus);
+.tbl-btn--danger:hover {
+  border-color: var(--danger);
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 8%, transparent);
 }
 
-.text-danger {
-  color: var(--ex-danger) !important;
+.tbl-btn mat-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
 }
 
-/* Bootstrap alerts (dark equivalents) */
-.alert {
-  border-radius: var(--ex-radius-lg);
-  border: 1px solid var(--ex-border);
-  background: rgba(255, 255, 255, 0.05);
-  color: rgba(255, 255, 255, 0.86);
+/* ── Loading / Empty / Error States ──────────────── */
+.state-box {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 2.5rem 1rem;
+  text-align: center;
 }
 
-.alert-info {
-  border-color: rgba(34, 211, 238, 0.25);
+.state-box__text {
+  font-size: 0.78rem;
+  color: var(--text-muted);
 }
 
-.alert-danger {
-  border-color: rgba(255, 77, 77, 0.28);
+.state-box--error .state-box__text {
+  color: var(--danger);
 }
 
-/* Spinner label */
-.exports-shell p {
-  color: var(--ex-text-muted);
+mat-spinner {
+  --mdc-circular-progress-active-indicator-color: var(--accent);
 }
 
-@media (prefers-reduced-motion: reduce) {
-  * {
-    transition: none !important;
+/* ── Alert (fallback) ────────────────────────────── */
+.alert-box {
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--raised);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.alert-box--info {
+  border-color: rgba(77, 166, 255, 0.25);
+}
+
+.alert-box--danger {
+  border-color: rgba(251, 113, 133, 0.28);
+  color: var(--danger);
+}
+
+/* ── Animations ──────────────────────────────────── */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.2; }
+}
+
+@media (min-width: 480px) {
+  .topbar__btn {
+    width: 40px;
+    height: 40px;
   }
 }
-

--- a/src/app/exports/exports-files.component.html
+++ b/src/app/exports/exports-files.component.html
@@ -1,110 +1,90 @@
-<div class="container mt-4 exports-shell">
-  <div class="d-flex justify-content-between align-items-center">
-    <h2>Files</h2>
-    <div class="d-flex align-items-center" style="gap: 8px;">
-      <button mat-icon-button routerLink="/exports" matTooltip="Back to Exports">
-        <mat-icon>arrow_back</mat-icon>
-      </button>
-      <button mat-icon-button routerLink="/" matTooltip="Back to Home">
-        <mat-icon>home</mat-icon>
-      </button>
-    </div>
+<div class="topbar">
+  <div class="topbar__left">
+    <button class="topbar__btn" routerLink="/">
+      <mat-icon>home</mat-icon>
+    </button>
+    <button class="topbar__btn" routerLink="/exports">
+      <mat-icon>arrow_back</mat-icon>
+    </button>
   </div>
-
-  <!-- Files Section -->
-  <div class="mt-5 exports-files">
-    <h3>Exported Files</h3>
-
-    @if (isLoadingFiles) {
-      <div class="text-center mt-4">
-        <mat-spinner></mat-spinner>
-        <p class="mt-2">Loading files...</p>
-      </div>
-    }
-
-    @if (filesError) {
-      <div class="alert alert-danger mt-4">
-        <strong>Error:</strong> {{ filesError }}
-      </div>
-    }
-
-    @if (!isLoadingFiles && !filesError && files.length === 0) {
-      <div class="alert alert-info mt-4">
-        No files found.
-      </div>
-    }
-
-    @if (!isLoadingFiles && !filesError && files.length > 0) {
-      <div class="mt-4">
-        <div class="card">
-          <div class="card-header d-flex justify-content-between align-items-center">
-            <h5 class="mb-0">Available Files ({{ files.length }})</h5>
-            <button mat-icon-button (click)="loadFiles()" [disabled]="isLoadingFiles">
-              <mat-icon>refresh</mat-icon>
-            </button>
-          </div>
-          <div class="card-body">
-            <table mat-table [dataSource]="files" class="w-100">
-              <!-- Name Column -->
-              <ng-container matColumnDef="name">
-                <th mat-header-cell *matHeaderCellDef>Name</th>
-                <td mat-cell *matCellDef="let file">{{ file.name }}</td>
-              </ng-container>
-
-              <!-- Size Column -->
-              <ng-container matColumnDef="size">
-                <th mat-header-cell *matHeaderCellDef>Size</th>
-                <td mat-cell *matCellDef="let file">
-                  @if (file.size) {
-                    <span>{{ formatFileSize(file.size) }}</span>
-                  } @else {
-                    <span>-</span>
-                  }
-                </td>
-              </ng-container>
-
-              <!-- Modified Time Column -->
-              <ng-container matColumnDef="modifiedTime">
-                <th mat-header-cell *matHeaderCellDef>Modified</th>
-                <td mat-cell *matCellDef="let file">
-                  @if (file.modifiedTime) {
-                    <span>{{ formatDate(file.modifiedTime) }}</span>
-                  } @else {
-                    <span>-</span>
-                  }
-                </td>
-              </ng-container>
-
-              <!-- Actions Column -->
-              <ng-container matColumnDef="actions">
-                <th mat-header-cell *matHeaderCellDef>Actions</th>
-                <td mat-cell *matCellDef="let file">
-                  <button
-                    mat-icon-button
-                    [disabled]="!file.webViewLink"
-                    (click)="openFile(file.webViewLink)"
-                    matTooltip="Open file"
-                  >
-                    <mat-icon>open_in_new</mat-icon>
-                  </button>
-                  <button
-                    mat-icon-button
-                    (click)="deleteFile(file.id, file.name)"
-                    matTooltip="Delete file"
-                    class="text-danger"
-                  >
-                    <mat-icon>delete</mat-icon>
-                  </button>
-                </td>
-              </ng-container>
-
-              <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-              <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-            </table>
-          </div>
-        </div>
-      </div>
-    }
-  </div>
+  <span class="topbar__icon">&#x2B21;</span>
+  <span class="topbar__title">Files</span>
 </div>
 
+<div class="layout">
+
+  @if (isLoadingFiles) {
+    <div class="state-box">
+      <mat-spinner [diameter]="36"></mat-spinner>
+      <span class="state-box__text">Loading files&#x2026;</span>
+    </div>
+  }
+
+  @if (filesError) {
+    <div class="alert-box alert-box--danger">
+      <strong>Error:</strong> {{ filesError }}
+    </div>
+  }
+
+  @if (!isLoadingFiles && !filesError && files.length === 0) {
+    <div class="alert-box alert-box--info">
+      No files found.
+    </div>
+  }
+
+  @if (!isLoadingFiles && !filesError && files.length > 0) {
+    <section class="panel">
+      <div class="panel__header">
+        <div class="panel__label">
+          <span class="panel__dot"></span>
+          <span>Available Files ({{ files.length }})</span>
+        </div>
+        <button class="panel__action" (click)="loadFiles()" [disabled]="isLoadingFiles">
+          <mat-icon>refresh</mat-icon>
+        </button>
+      </div>
+
+      <table mat-table [dataSource]="files">
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef>Name</th>
+          <td mat-cell *matCellDef="let file">{{ file.name }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="size">
+          <th mat-header-cell *matHeaderCellDef>Size</th>
+          <td mat-cell *matCellDef="let file">
+            {{ file.size ? formatFileSize(file.size) : '-' }}
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="modifiedTime">
+          <th mat-header-cell *matHeaderCellDef>Modified</th>
+          <td mat-cell *matCellDef="let file">
+            {{ file.modifiedTime ? formatDate(file.modifiedTime) : '-' }}
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef>Actions</th>
+          <td mat-cell *matCellDef="let file">
+            <button
+              class="tbl-btn"
+              [disabled]="!file.webViewLink"
+              (click)="openFile(file.webViewLink)">
+              <mat-icon>open_in_new</mat-icon>
+            </button>
+            <button
+              class="tbl-btn tbl-btn--danger"
+              (click)="deleteFile(file.id, file.name)">
+              <mat-icon>delete</mat-icon>
+            </button>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      </table>
+    </section>
+  }
+
+</div>

--- a/src/app/exports/exports-files.component.ts
+++ b/src/app/exports/exports-files.component.ts
@@ -1,40 +1,33 @@
-import { CommonModule } from '@angular/common';
-import { Component, OnInit } from '@angular/core';
-import { RouterModule } from '@angular/router';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatTableModule } from '@angular/material/table';
-import { MatTooltipModule } from '@angular/material/tooltip';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit} from '@angular/core';
+import {RouterModule} from '@angular/router';
+import {MatIconModule} from '@angular/material/icon';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
+import {MatTableModule} from '@angular/material/table';
 
-import { FileService } from './services/file/file.service';
-import { FileDeleteResponse, FileItem, FileItemTime, FileListResponse } from './services/file/file.model';
+import {FileService} from './services/file/file.service';
+import {FileDeleteResponse, FileItem, FileItemTime, FileListResponse} from './services/file/file.model';
 
 @Component({
   selector: 'app-exports-files',
-  standalone: true,
   imports: [
-    CommonModule,
     RouterModule,
     MatTableModule,
     MatIconModule,
-    MatButtonModule,
     MatProgressSpinnerModule,
-    MatTooltipModule
   ],
   templateUrl: './exports-files.component.html',
-  styleUrl: './exports-files.component.css'
+  styleUrl: './exports-files.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ExportsFilesComponent implements OnInit {
-  // Files table properties
+
   files: FileItem[] = [];
   isLoadingFiles = false;
   filesError: string | null = null;
   displayedColumns: string[] = ['name', 'size', 'modifiedTime', 'actions'];
 
-  constructor(
-    private fileService: FileService
-  ) {}
+  private fileService = inject(FileService);
+  private cdr = inject(ChangeDetectorRef);
 
   ngOnInit() {
     this.loadFiles();
@@ -52,16 +45,16 @@ export class ExportsFilesComponent implements OnInit {
         } else {
           this.filesError = 'Failed to load files: Invalid response format';
         }
+        this.cdr.markForCheck();
       },
       error: (error) => {
         this.isLoadingFiles = false;
         this.filesError = 'Failed to load files: ' + error.message;
-        console.error('Error loading files:', error);
+        this.cdr.markForCheck();
       }
     });
   }
 
-  // File utility methods
   formatFileSize(bytes?: number): string {
     if (!bytes) return '-';
     const sizes = ['Bytes', 'KB', 'MB', 'GB'];
@@ -89,18 +82,17 @@ export class ExportsFilesComponent implements OnInit {
       this.fileService.deleteFile(fileId).subscribe({
         next: (response: FileDeleteResponse) => {
           if (response.success) {
-            // Reload the files list after successful deletion
             this.loadFiles();
           } else {
             this.filesError = response.error || 'Failed to delete file';
+            this.cdr.markForCheck();
           }
         },
         error: (error) => {
           this.filesError = 'Failed to delete file: ' + error.message;
-          console.error('Error deleting file:', error);
+          this.cdr.markForCheck();
         }
       });
     }
   }
 }
-

--- a/src/app/exports/exports.component.css
+++ b/src/app/exports/exports.component.css
@@ -1,139 +1,293 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+/* ── Design Tokens ───────────────────────────────── */
 :host {
-  /* Exports: dark fluid theme tokens (component-scoped) */
-  --ex-bg: #0b0f17;
-  --ex-bg-2: #0a1221;
-  --ex-surface: rgba(255, 255, 255, 0.06);
-  --ex-surface-2: rgba(255, 255, 255, 0.08);
-  --ex-surface-3: rgba(255, 255, 255, 0.10);
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
 
-  --ex-border: rgba(255, 255, 255, 0.10);
-  --ex-border-strong: rgba(255, 255, 255, 0.16);
-  --ex-shadow: 0 14px 40px rgba(0, 0, 0, 0.45);
-  --ex-shadow-soft: 0 8px 24px rgba(0, 0, 0, 0.35);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
 
-  --ex-text: rgba(255, 255, 255, 0.92);
-  --ex-text-muted: rgba(255, 255, 255, 0.68);
-  --ex-text-faint: rgba(255, 255, 255, 0.52);
+  --accent:      #fb7185;
+  --accent-glow: rgba(251, 113, 133, 0.18);
 
-  --ex-accent: #7c5cff; /* violet */
-  --ex-accent-2: #22d3ee; /* cyan */
-  --ex-focus: rgba(124, 92, 255, 0.55);
+  /* Per-card accent colors */
+  --c-files:    #4da6ff;  --cg-files:   rgba(77,  166, 255, 0.18);
+  --c-backups:  #22d35e;  --cg-backups: rgba(34,  211,  94, 0.18);
+  --c-anki:     #a78bfa;  --cg-anki:    rgba(167, 139, 250, 0.18);
 
-  --ex-danger: #ff4d4d;
-
-  --ex-radius-lg: 16px;
-  --ex-radius-md: 12px;
-  --ex-radius-sm: 10px;
-  --ex-gap: 16px;
+  display: block;
+  min-height: 100dvh;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+  background-color: var(--bg);
+  background-image:
+    radial-gradient(ellipse 70% 35% at 0% 0%,    rgba(251, 113, 133, 0.05) 0%, transparent 100%),
+    radial-gradient(ellipse 50% 35% at 100% 100%, rgba(77, 166, 255, 0.04) 0%, transparent 100%),
+    radial-gradient(circle, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+  background-size: auto, auto, 28px 28px;
 }
 
-/* Shell */
-.exports-shell {
-  color: var(--ex-text);
-}
-
-.exports-shell.container {
-  max-width: 1200px;
-  padding: clamp(16px, 2.4vw, 28px);
-  border-radius: var(--ex-radius-lg);
-  background:
-    radial-gradient(1200px 600px at 10% -10%, rgba(124, 92, 255, 0.26), transparent 55%),
-    radial-gradient(900px 500px at 90% 10%, rgba(34, 211, 238, 0.14), transparent 55%),
-    linear-gradient(180deg, var(--ex-bg-2), var(--ex-bg));
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  box-shadow: var(--ex-shadow);
-}
-
-.exports-shell h2 {
-  font-size: 1.75rem;
-  letter-spacing: -0.02em;
-  margin: 0;
-}
-
-.exports-shell h3 {
-  font-size: 1.125rem;
-  letter-spacing: -0.01em;
-  color: rgba(255, 255, 255, 0.90);
-}
-
-/* Top-right icon button */
-.exports-shell button[mat-icon-button] {
-  border-radius: 12px;
-}
-
-.exports-shell button[mat-icon-button]:hover {
-  background: rgba(255, 255, 255, 0.06);
-}
-
-.exports-shell button[mat-icon-button]:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px var(--ex-focus);
-}
-
-/* Export option cards */
-.export-cards-container {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: var(--ex-gap);
-}
-
-.export-card {
-  width: auto;
-  cursor: pointer;
-  border-radius: var(--ex-radius-lg);
-  border: 1px solid var(--ex-border);
-  background: linear-gradient(180deg, var(--ex-surface-2), var(--ex-surface));
-  box-shadow: var(--ex-shadow-soft);
-  overflow: hidden;
-  transition:
-    transform 180ms ease,
-    box-shadow 180ms ease,
-    border-color 180ms ease,
-    background 180ms ease;
-}
-
-.export-card:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--ex-shadow);
-  border-color: var(--ex-border-strong);
-  background: linear-gradient(180deg, var(--ex-surface-3), var(--ex-surface));
-}
-
-.export-card:focus-within {
-  box-shadow: var(--ex-shadow), 0 0 0 3px var(--ex-focus);
-}
-
-/* Material card header typography */
-.export-card mat-card-title {
-  color: rgba(255, 255, 255, 0.92);
-  letter-spacing: -0.01em;
-}
-
-.export-card mat-card-subtitle {
-  color: var(--ex-text-muted);
-}
-
-.card-icon {
+/* ── Topbar ──────────────────────────────────────── */
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
   display: flex;
-  justify-content: center;
   align-items: center;
-  padding: 26px 0;
+  justify-content: space-between;
+  padding: max(0.75rem, env(safe-area-inset-top)) max(1.25rem, env(safe-area-inset-right)) 0.75rem max(1.25rem, env(safe-area-inset-left));
+  background: rgba(6, 8, 14, 0.88);
+  border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  box-shadow: 0 1px 0 rgba(251, 113, 133, 0.06);
 }
 
-.card-icon mat-icon {
-  font-size: 52px;
-  width: 52px;
-  height: 52px;
-  color: var(--ex-accent);
-  filter: drop-shadow(0 10px 18px rgba(124, 92, 255, 0.18));
+.topbar__left {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
-.export-card mat-card-actions {
-  padding: 12px 16px 16px;
+.topbar__btn {
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--raised);
+  color: var(--text-muted);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s, background 0.2s;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  * {
-    transition: none !important;
+.topbar__btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.topbar__icon {
+  color: var(--accent);
+  font-size: 0.9rem;
+  filter: drop-shadow(0 0 6px rgba(251, 113, 133, 0.5));
+}
+
+.topbar__title {
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+/* ── Layout ──────────────────────────────────────── */
+.layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem
+    max(1rem, env(safe-area-inset-right))
+    max(1rem, env(safe-area-inset-bottom))
+    max(1rem, env(safe-area-inset-left));
+  max-width: 1280px;
+  margin: 0 auto;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+@media (min-width: 1024px) {
+  .layout {
+    gap: 1.5rem;
+    padding: 1.5rem;
+  }
+}
+
+/* ── Nav Grid ────────────────────────────────────── */
+.navgrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .navgrid { gap: 1rem; }
+}
+
+.navcard:last-child:nth-child(odd) {
+  grid-column: 1 / -1;
+  justify-self: center;
+  width: calc(50% - 0.375rem);
+}
+
+@media (min-width: 640px) {
+  .navcard:last-child:nth-child(odd) {
+    width: calc(50% - 0.5rem);
+  }
+}
+
+/* ── Nav Cards ───────────────────────────────────── */
+.navcard {
+  position: relative;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.1rem 1rem 1.75rem;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  min-height: 140px;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
+  animation: fadeUp 0.5s ease both;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.navcard::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 0% 0%, var(--cc-glow, transparent) 0%, transparent 65%);
+  opacity: 0;
+  transition: opacity 0.25s;
+  pointer-events: none;
+}
+
+.navcard::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 22%;
+  bottom: 22%;
+  width: 2px;
+  background: var(--cc, transparent);
+  border-radius: 0 2px 2px 0;
+  opacity: 0.35;
+  transition: opacity 0.2s, top 0.2s, bottom 0.2s;
+}
+
+.navcard:hover {
+  border-color: var(--cc);
+  box-shadow: 0 8px 28px var(--cc-glow);
+  transform: translateY(-3px);
+}
+
+.navcard:hover::before { opacity: 1; }
+
+.navcard:hover::after {
+  opacity: 0.9;
+  top: 12%;
+  bottom: 12%;
+}
+
+.navcard:active { transform: translateY(-1px); }
+
+/* ── Card Accent Variants ────────────────────────── */
+.navcard--files   { --cc: var(--c-files);   --cc-glow: var(--cg-files); }
+.navcard--backups { --cc: var(--c-backups);  --cc-glow: var(--cg-backups); }
+.navcard--anki    { --cc: var(--c-anki);     --cc-glow: var(--cg-anki); }
+
+/* ── Card Mark ───────────────────────────────────── */
+.navcard__mark {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--cc) 40%, transparent);
+  background: color-mix(in srgb, var(--cc) 10%, transparent);
+  display: grid;
+  place-items: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--cc);
+  flex-shrink: 0;
+  transition: background 0.2s;
+}
+
+.navcard:hover .navcard__mark {
+  background: color-mix(in srgb, var(--cc) 20%, transparent);
+}
+
+/* ── Card Text ───────────────────────────────────── */
+.navcard__title {
+  margin: 0;
+  font-size: clamp(0.95rem, 2.5vw, 1.1rem);
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1.25;
+  letter-spacing: 0.01em;
+}
+
+.navcard__sub {
+  margin: 0;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+  font-weight: 400;
+}
+
+/* ── Card Arrow ──────────────────────────────────── */
+.navcard__arrow {
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.875rem;
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  line-height: 1;
+  transition: color 0.2s, transform 0.2s;
+}
+
+.navcard:hover .navcard__arrow {
+  color: var(--cc);
+  transform: translate(2px, -2px);
+}
+
+/* ── Sync Button ─────────────────────────────────── */
+.navcard__action {
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.875rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--cc);
+  background: color-mix(in srgb, var(--cc) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--cc) 30%, transparent);
+  border-radius: 6px;
+  padding: 0.3rem 0.7rem;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.navcard__action:hover {
+  background: color-mix(in srgb, var(--cc) 22%, transparent);
+  border-color: color-mix(in srgb, var(--cc) 50%, transparent);
+}
+
+/* ── Entrance Animations ─────────────────────────── */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.navcard:nth-child(1) { animation-delay: 0.05s; }
+.navcard:nth-child(2) { animation-delay: 0.12s; }
+.navcard:nth-child(3) { animation-delay: 0.19s; }
+
+@media (min-width: 480px) {
+  .topbar__btn {
+    width: 40px;
+    height: 40px;
   }
 }

--- a/src/app/exports/exports.component.html
+++ b/src/app/exports/exports.component.html
@@ -1,56 +1,36 @@
-<div class="container mt-4 exports-shell">
-  <div class="d-flex justify-content-between align-items-center">
-    <h2>Exports</h2>
-    <button mat-icon-button routerLink="/" matTooltip="Back to Home">
+<div class="topbar">
+  <div class="topbar__left">
+    <button class="topbar__btn" routerLink="/">
       <mat-icon>home</mat-icon>
     </button>
   </div>
+  <span class="topbar__icon">&#x2B21;</span>
+  <span class="topbar__title">Exports</span>
+</div>
 
-  <!-- Export Options Cards -->
-  <div class="export-cards-container mt-4">
-    <mat-card class="export-card" routerLink="files">
-      <mat-card-header>
-        <mat-card-title>Files</mat-card-title>
-        <mat-card-subtitle>Quick exports and exported files</mat-card-subtitle>
-      </mat-card-header>
-      <mat-card-content>
-        <div class="card-icon">
-          <mat-icon>folder</mat-icon>
-        </div>
-      </mat-card-content>
-      <mat-card-actions>
-        <button mat-button color="primary">OPEN</button>
-      </mat-card-actions>
-    </mat-card>
+<div class="layout">
+  <div class="navgrid">
 
-    <mat-card class="export-card" routerLink="backups">
-      <mat-card-header>
-        <mat-card-title>Backups</mat-card-title>
-        <mat-card-subtitle>Uploaded backup run history</mat-card-subtitle>
-      </mat-card-header>
-      <mat-card-content>
-        <div class="card-icon">
-          <mat-icon>backup</mat-icon>
-        </div>
-      </mat-card-content>
-      <mat-card-actions>
-        <button mat-button color="primary">OPEN</button>
-      </mat-card-actions>
-    </mat-card>
+    <a class="navcard navcard--files" routerLink="files">
+      <div class="navcard__mark">F</div>
+      <h2 class="navcard__title">Files</h2>
+      <p class="navcard__sub">Quick exports and exported files</p>
+      <span class="navcard__arrow" aria-hidden="true">&#x2197;</span>
+    </a>
 
-    <mat-card class="export-card">
-      <mat-card-header>
-        <mat-card-title>Anki Sync</mat-card-title>
-        <mat-card-subtitle>Synchronization of Anki decks</mat-card-subtitle>
-      </mat-card-header>
-      <mat-card-content>
-        <div class="card-icon">
-          <mat-icon>menu_book</mat-icon>
-        </div>
-      </mat-card-content>
-      <mat-card-actions>
-        <button mat-button color="primary" (click)="syncAnki()">SYNC</button>
-      </mat-card-actions>
-    </mat-card>
+    <a class="navcard navcard--backups" routerLink="backups">
+      <div class="navcard__mark">B</div>
+      <h2 class="navcard__title">Backups</h2>
+      <p class="navcard__sub">Uploaded backup run history</p>
+      <span class="navcard__arrow" aria-hidden="true">&#x2197;</span>
+    </a>
+
+    <div class="navcard navcard--anki">
+      <div class="navcard__mark">A</div>
+      <h2 class="navcard__title">Anki Sync</h2>
+      <p class="navcard__sub">Synchronization of Anki decks</p>
+      <button class="navcard__action" (click)="syncAnki()">Sync</button>
+    </div>
+
   </div>
 </div>

--- a/src/app/exports/exports.component.ts
+++ b/src/app/exports/exports.component.ts
@@ -1,39 +1,27 @@
-import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
-import { MatCardModule } from '@angular/material/card';
-import { MatIconModule } from '@angular/material/icon';
-import { MatButtonModule } from '@angular/material/button';
-import { MatTooltipModule } from '@angular/material/tooltip';
-import {ExportService} from "./services/export.service";
-import {MatSnackBar} from "@angular/material/snack-bar";
+import {Component, inject} from '@angular/core';
+import {RouterModule} from '@angular/router';
+import {MatIconModule} from '@angular/material/icon';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {ExportService} from './services/export.service';
 
 @Component({
   selector: 'app-exports',
-  standalone: true,
   imports: [
-    CommonModule,
     RouterModule,
-    MatCardModule,
     MatIconModule,
-    MatButtonModule,
-    MatTooltipModule
   ],
   templateUrl: './exports.component.html',
   styleUrl: './exports.component.css'
 })
 export class ExportsComponent {
 
-  constructor(
-      private exportService: ExportService,
-      private snackBar: MatSnackBar
-  ) {
-  }
+  private exportService = inject(ExportService);
+  private snackBar = inject(MatSnackBar);
 
   syncAnki() {
     this.exportService.syncAnki().subscribe({
       next: (res) => {
-        if (res && "ok" === res.status) {
+        if (res && 'ok' === res.status) {
           this.snackBar.open('Anki synchronisiert', 'OK', {duration: 3000});
         } else {
           this.snackBar.open('Synchronisierung fehlgeschlagen', 'OK', {duration: 3000});
@@ -42,7 +30,6 @@ export class ExportsComponent {
       error: (err) => {
         this.snackBar.open('Synchronisierung fehlgeschlagen', err, {duration: 3000});
       }
-    })
+    });
   }
-
 }


### PR DESCRIPTION
## Summary
- Restyled all three exports components (hub, files, backups) to match the home component's dark theme design system
- Replaced Material cards and Bootstrap layout with custom topbar, navcard grid, and panel patterns using shared design tokens (Outfit + JetBrains Mono fonts, consistent color palette, dot-grid background)
- Updated TypeScript to use `inject()`, `ChangeDetectionStrategy.OnPush`, and removed unused imports per Angular best practices

## Test plan
- [ ] Verify `/exports` hub page renders 3 navcards (Files, Backups, Anki Sync) with correct accent colors and hover effects
- [ ] Verify `/exports/files` table displays files with dark themed panel, header, and action buttons
- [ ] Verify `/exports/backups` table displays backup runs with status badges, pagination, and upload icons
- [ ] Verify topbar navigation (home + back buttons) works on all three pages
- [ ] Verify Anki Sync button triggers sync and shows snackbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)