### PR TITLE
chore(touch): scaffold touch module + /touch route

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -22,6 +22,8 @@ import {ExportsBackupsComponent} from './exports/exports-backups.component';
 import {ItNewsLayoutComponent} from './it-news/components/it-news-layout/it-news-layout.component';
 import {ArticleListComponent} from './it-news/components/article-list/article-list.component';
 import {FeedConfigComponent} from './it-news/components/feed-config/feed-config.component';
+import {TouchLayoutComponent} from './touch/components/touch-layout/touch-layout.component';
+import {TouchDashboardComponent} from './touch/components/touch-dashboard/touch-dashboard.component';
 
 export const routes: Routes = [
   {path: '', component: HomeComponent},
@@ -72,6 +74,13 @@ export const routes: Routes = [
     children: [
       {path: '', component: ArticleListComponent, data: {home: '/'}},
       {path: 'feeds', component: FeedConfigComponent, data: {home: '/it-news'}}
+    ]
+  },
+  {
+    path: 'touch',
+    component: TouchLayoutComponent,
+    children: [
+      {path: '', component: TouchDashboardComponent, data: {home: '/touch'}}
     ]
   }
 ];

--- a/src/app/touch/components/touch-dashboard/touch-dashboard.component.css
+++ b/src/app/touch/components/touch-dashboard/touch-dashboard.component.css
@@ -1,0 +1,5 @@
+.dashboard {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}

--- a/src/app/touch/components/touch-dashboard/touch-dashboard.component.html
+++ b/src/app/touch/components/touch-dashboard/touch-dashboard.component.html
@@ -1,0 +1,2 @@
+<div class="dashboard">
+</div>

--- a/src/app/touch/components/touch-dashboard/touch-dashboard.component.ts
+++ b/src/app/touch/components/touch-dashboard/touch-dashboard.component.ts
@@ -1,0 +1,11 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+
+@Component({
+  selector: 'app-touch-dashboard',
+  imports: [],
+  templateUrl: './touch-dashboard.component.html',
+  styleUrl: './touch-dashboard.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class TouchDashboardComponent {
+}

--- a/src/app/touch/components/touch-layout/touch-layout.component.css
+++ b/src/app/touch/components/touch-layout/touch-layout.component.css
@@ -1,0 +1,88 @@
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --border:      rgba(255, 255, 255, 0.07);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+
+  --c-c:         #4da6ff;
+
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+  overflow: hidden;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+  background-color: var(--bg);
+}
+
+.touch-layout {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background: rgba(6, 8, 14, 0.88);
+  border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+}
+
+.topbar__left,
+.topbar__right {
+  width: 80px;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.topbar__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.topbar__btn:hover {
+  color: var(--c-c);
+  border-color: var(--c-c);
+}
+
+.topbar__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  color: var(--text-muted);
+}
+
+.topbar__hex {
+  color: var(--c-c);
+  font-size: 0.9rem;
+}
+
+.content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}

--- a/src/app/touch/components/touch-layout/touch-layout.component.html
+++ b/src/app/touch/components/touch-layout/touch-layout.component.html
@@ -1,0 +1,18 @@
+<div class="touch-layout">
+  <header class="topbar">
+    <div class="topbar__left">
+      <button class="topbar__btn" [routerLink]="homeLink" aria-label="Go home">
+        <mat-icon>home</mat-icon>
+      </button>
+    </div>
+    <div class="topbar__brand">
+      <span class="topbar__hex">⬡</span>
+      <span class="topbar__name">TOUCH</span>
+    </div>
+    <div class="topbar__right"></div>
+  </header>
+
+  <main class="content">
+    <router-outlet></router-outlet>
+  </main>
+</div>

--- a/src/app/touch/components/touch-layout/touch-layout.component.ts
+++ b/src/app/touch/components/touch-layout/touch-layout.component.ts
@@ -1,0 +1,38 @@
+import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
+import {MatIcon} from '@angular/material/icon';
+import {ActivatedRoute, NavigationEnd, Router, RouterLink, RouterOutlet} from '@angular/router';
+import {filter} from 'rxjs';
+
+@Component({
+  selector: 'app-touch-layout',
+  imports: [
+    MatIcon,
+    RouterLink,
+    RouterOutlet
+  ],
+  templateUrl: './touch-layout.component.html',
+  styleUrl: './touch-layout.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class TouchLayoutComponent {
+
+  homeLink: string = '/';
+  private router = inject(Router);
+  private route = inject(ActivatedRoute);
+
+  constructor() {
+    this.router.events
+      .pipe(filter(event => event instanceof NavigationEnd))
+      .subscribe(() => {
+        const home = this.getDeepestChild(this.route).snapshot.data['home'];
+        this.homeLink = home || '/';
+      });
+  }
+
+  private getDeepestChild(route: ActivatedRoute): ActivatedRoute {
+    while (route.firstChild) {
+      route = route.firstChild;
+    }
+    return route;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `src/app/touch/` with `components/`, `services/`, `models/` folders
- Adds standalone `TouchLayoutComponent` shell (sticky top bar + `RouterOutlet`) following the `PlantLayoutComponent` / `MentalArithmeticRootComponent` pattern
- Adds empty `TouchDashboardComponent` placeholder
- Registers `/touch` route with child dashboard route in `app.routes.ts`

Closes #100. Unblocks the rest of the `area:touch` issues (#101–#107).

## Test plan
- [x] `npm run build` succeeds
- [ ] `npm start` → navigate to http://localhost:4200/touch renders the empty shell
- [ ] Other modules (`/`, `/plant-root`, `/mental-arithmetic`, `/it-news`, `/exports`, `/vocabulary`, `/account`) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)