### PR TITLE
feat(touch): ClimateService with polling readings

### DIFF
--- a/src/app/touch/models/temperature-reading.model.ts
+++ b/src/app/touch/models/temperature-reading.model.ts
@@ -1,0 +1,8 @@
+export interface TemperatureReading {
+  sensorId: string;
+  label: string;
+  location: 'indoor' | 'outdoor';
+  temperatureC: number;
+  humidityPct?: number;
+  measuredAt: string;
+}

--- a/src/app/touch/services/climate.service.ts
+++ b/src/app/touch/services/climate.service.ts
@@ -1,0 +1,24 @@
+import {Injectable} from '@angular/core';
+import {HttpClient} from '@angular/common/http';
+import {Observable, switchMap, timer} from 'rxjs';
+import {environment} from '../../../environments/environment';
+import {TemperatureReading} from '../models/temperature-reading.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ClimateService {
+
+  host: string = environment.apiUrl;
+
+  readings$: Observable<TemperatureReading[]> = timer(0, 60_000).pipe(
+    switchMap(() => this.getReadings())
+  );
+
+  constructor(private http: HttpClient) {
+  }
+
+  getReadings(): Observable<TemperatureReading[]> {
+    return this.http.get<TemperatureReading[]>(`${this.host}/climate/readings`);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `TemperatureReading` interface (`src/app/touch/models/temperature-reading.model.ts`) per the spec in #101
- Adds `ClimateService` (`providedIn: 'root'`) with `readings$` driven by `timer(0, 60_000).pipe(switchMap(...))` over `GET \${apiUrl}/climate/readings`
- Follows the shape of `PlantService` — no custom error handling yet (per scope)

Closes #101. Unblocks #102 (temperature grid).

## Test plan
- [x] `npm run build` succeeds
- [ ] Subscribe in a test component, observe network call at t=0 and every 60s in DevTools
- [ ] Backend `/climate/readings` returns array matching `TemperatureReading[]` (depends on #106 spike — revise model if contract differs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)