### PR TITLE
feat(touch): temperature grid on touch dashboard

### DIFF
--- a/src/app/touch/components/temperature-card/temperature-card.component.css
+++ b/src/app/touch/components/temperature-card/temperature-card.component.css
@@ -1,0 +1,95 @@
+:host {
+  display: block;
+  --accent: var(--c-c, var(--c-a));
+  --accent-glow: rgba(77, 166, 255, 0.18);
+}
+
+:host(.is-outdoor) {
+  --accent: var(--c-p);
+  --accent-glow: var(--cg-p);
+}
+
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem 1.25rem;
+  background: var(--surface);
+  border: 1px solid var(--border-mid);
+  border-radius: 12px;
+  overflow: hidden;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+}
+
+.card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(ellipse 80% 50% at 100% 0%, var(--accent-glow), transparent 70%);
+}
+
+.card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.card__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--c-p);
+  box-shadow: 0 0 6px var(--cg-p);
+}
+
+.card__dot[data-freshness='aging'] {
+  background: var(--c-v);
+  box-shadow: 0 0 6px var(--cg-v);
+}
+
+.card__dot[data-freshness='stale'] {
+  background: var(--c-e);
+  box-shadow: 0 0 6px var(--cg-e);
+}
+
+.card__temp {
+  display: flex;
+  align-items: baseline;
+  gap: 0.25rem;
+  color: var(--accent);
+}
+
+.card__temp-value {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 2.75rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.card__temp-unit {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.card__humidity {
+  display: flex;
+  align-items: baseline;
+  gap: 0.25rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.card__humidity-value {
+  color: var(--text);
+  font-weight: 600;
+}

--- a/src/app/touch/components/temperature-card/temperature-card.component.html
+++ b/src/app/touch/components/temperature-card/temperature-card.component.html
@@ -1,0 +1,16 @@
+<div class="card">
+  <div class="card__header">
+    <span class="card__label">{{ reading().label }}</span>
+    <span class="card__dot" aria-hidden="true" [attr.data-freshness]="freshness()"></span>
+  </div>
+  <div class="card__temp">
+    <span class="card__temp-value">{{ temperatureDisplay() }}</span>
+    <span class="card__temp-unit">°C</span>
+  </div>
+  @if (humidityDisplay() !== null) {
+    <div class="card__humidity">
+      <span class="card__humidity-value">{{ humidityDisplay() }}</span>
+      <span class="card__humidity-unit">% RH</span>
+    </div>
+  }
+</div>

--- a/src/app/touch/components/temperature-card/temperature-card.component.ts
+++ b/src/app/touch/components/temperature-card/temperature-card.component.ts
@@ -1,0 +1,35 @@
+import {ChangeDetectionStrategy, Component, computed, input} from '@angular/core';
+import {TemperatureReading} from '../../models/temperature-reading.model';
+
+type Freshness = 'fresh' | 'aging' | 'stale';
+
+@Component({
+  selector: 'app-temperature-card',
+  imports: [],
+  templateUrl: './temperature-card.component.html',
+  styleUrl: './temperature-card.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[class.is-outdoor]': 'reading().location === "outdoor"',
+    '[class.is-indoor]': 'reading().location === "indoor"'
+  }
+})
+export class TemperatureCardComponent {
+
+  reading = input.required<TemperatureReading>();
+
+  temperatureDisplay = computed(() => this.reading().temperatureC.toFixed(1));
+
+  humidityDisplay = computed(() => {
+    const h = this.reading().humidityPct;
+    return h === undefined ? null : Math.round(h);
+  });
+
+  freshness = computed<Freshness>(() => {
+    const ageMs = Date.now() - new Date(this.reading().measuredAt).getTime();
+    const ageMin = ageMs / 60_000;
+    if (ageMin < 2) return 'fresh';
+    if (ageMin < 10) return 'aging';
+    return 'stale';
+  });
+}

--- a/src/app/touch/components/touch-dashboard/touch-dashboard.component.css
+++ b/src/app/touch/components/touch-dashboard/touch-dashboard.component.css
@@ -2,4 +2,21 @@
   flex: 1;
   display: flex;
   flex-direction: column;
+  padding: 1.25rem;
+  overflow: auto;
+}
+
+.dashboard__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.dashboard__empty {
+  margin: auto;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
 }

--- a/src/app/touch/components/touch-dashboard/touch-dashboard.component.html
+++ b/src/app/touch/components/touch-dashboard/touch-dashboard.component.html
@@ -1,2 +1,13 @@
 <div class="dashboard">
+  @if (readings$ | async; as readings) {
+    <section class="dashboard__grid">
+      @for (reading of readings; track reading.sensorId) {
+        <app-temperature-card [reading]="reading" />
+      } @empty {
+        <p class="dashboard__empty">No sensors reporting.</p>
+      }
+    </section>
+  } @else {
+    <p class="dashboard__empty">Loading climate readings…</p>
+  }
 </div>

--- a/src/app/touch/components/touch-dashboard/touch-dashboard.component.ts
+++ b/src/app/touch/components/touch-dashboard/touch-dashboard.component.ts
@@ -1,11 +1,18 @@
-import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
+import {AsyncPipe} from '@angular/common';
+import {ClimateService} from '../../services/climate.service';
+import {TemperatureCardComponent} from '../temperature-card/temperature-card.component';
 
 @Component({
   selector: 'app-touch-dashboard',
-  imports: [],
+  imports: [AsyncPipe, TemperatureCardComponent],
   templateUrl: './touch-dashboard.component.html',
   styleUrl: './touch-dashboard.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TouchDashboardComponent {
+
+  private climate = inject(ClimateService);
+
+  readings$ = this.climate.readings$;
 }

--- a/src/app/touch/components/touch-layout/touch-layout.component.html
+++ b/src/app/touch/components/touch-layout/touch-layout.component.html
@@ -1,7 +1,7 @@
 <div class="touch-layout">
   <header class="topbar">
     <div class="topbar__left">
-      <button class="topbar__btn" [routerLink]="homeLink" aria-label="Go home">
+      <button class="topbar__btn" aria-label="Go home" [routerLink]="homeLink">
         <mat-icon>home</mat-icon>
       </button>
     </div>
@@ -13,6 +13,6 @@
   </header>
 
   <main class="content">
-    <router-outlet></router-outlet>
+    <router-outlet />
   </main>
 </div>

--- a/src/app/touch/services/climate.service.ts
+++ b/src/app/touch/services/climate.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {Observable, switchMap, timer} from 'rxjs';
 import {environment} from '../../../environments/environment';
@@ -11,12 +11,11 @@ export class ClimateService {
 
   host: string = environment.apiUrl;
 
+  private http = inject(HttpClient);
+
   readings$: Observable<TemperatureReading[]> = timer(0, 60_000).pipe(
     switchMap(() => this.getReadings())
   );
-
-  constructor(private http: HttpClient) {
-  }
 
   getReadings(): Observable<TemperatureReading[]> {
     return this.http.get<TemperatureReading[]>(`${this.host}/climate/readings`);


### PR DESCRIPTION
## Summary
- Adds **TemperatureCardComponent** — standalone, OnPush, signal-input. Renders room label, °C, optional humidity, and a freshness dot derived from `measuredAt` (fresh < 2 min, aging < 10 min, stale ≥ 10 min). Outdoor cards take the green accent (`--c-p`), indoor cards default to climate accent (`--c-c` if defined by #104, falls back to `--c-a`).
- Wires **TouchDashboardComponent** to `ClimateService.readings$` via async pipe; lays cards out in an auto-fill grid (`minmax(220px, 1fr)`).
- Drive-by fixups from lint: `ClimateService` migrated to `inject()`, layout uses self-closing `<router-outlet />`, attribute ordering tweaks.

Closes #102. Uses the dark-theme tokens already in `src/styles.css`.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run lint` — only pre-existing warnings + 5 `no-call-expression` warnings inherent to signal getters in templates (consistent with rest of codebase)
- [ ] Backend `/climate/readings` returns sample data → cards render in browser
- [ ] OnPush respected: cards re-render only when `readings$` emits

🤖 Generated with [Claude Code](https://claude.com/claude-code)