### PR TITLE
feat(touch): plants summary tile on dashboard

### DIFF
--- a/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.css
+++ b/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.css
@@ -1,0 +1,105 @@
+:host {
+  display: block;
+  --accent: var(--c-p);
+  --accent-glow: var(--cg-p);
+}
+
+.tile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 56px;
+  min-height: 56px;
+  padding: 1rem 1.25rem;
+  background: var(--surface);
+  border: 1px solid var(--border-mid);
+  border-radius: 12px;
+  color: var(--text);
+  font-family: 'Outfit', sans-serif;
+  text-decoration: none;
+  overflow: hidden;
+  transition: border-color 0.2s, transform 0.05s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.tile::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(ellipse 80% 50% at 0% 0%, var(--accent-glow), transparent 70%);
+}
+
+.tile:hover,
+.tile:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.tile:active {
+  transform: scale(0.99);
+}
+
+.tile__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.tile__label {
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.tile__total {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--accent);
+}
+
+.tile__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.tile__row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+}
+
+.tile__name {
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tile__due {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.tile__due.is-overdue {
+  color: var(--c-e);
+}
+
+.tile__empty,
+.tile__loading {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  letter-spacing: 0.06em;
+}

--- a/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.html
+++ b/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.html
@@ -1,0 +1,22 @@
+<a class="tile" routerLink="/plant-root/gallery" aria-label="Open plant gallery">
+  @if (summary$ | async; as summary) {
+    <header class="tile__header">
+      <span class="tile__label">Plants</span>
+      <span class="tile__total">{{ summary.total }}</span>
+    </header>
+    <ul class="tile__list">
+      @for (plant of summary.upcoming; track plant.id) {
+        <li class="tile__row">
+          <span class="tile__name">{{ plant.name }}</span>
+          <span class="tile__due" [class.is-overdue]="plant.overdue">
+            {{ plant.dueLabel }}
+          </span>
+        </li>
+      } @empty {
+        <li class="tile__empty">No watering scheduled.</li>
+      }
+    </ul>
+  } @else {
+    <span class="tile__loading">Loading plants…</span>
+  }
+</a>

--- a/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.ts
+++ b/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.ts
@@ -1,0 +1,61 @@
+import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
+import {AsyncPipe} from '@angular/common';
+import {RouterLink} from '@angular/router';
+import {map} from 'rxjs';
+import {PlantService} from '../../../plants/services/plant.service';
+import {Plant} from '../../../plants/models/plant.model';
+
+interface UpcomingPlant {
+  id: number;
+  name: string;
+  dueLabel: string;
+  overdue: boolean;
+}
+
+interface PlantsSummary {
+  total: number;
+  upcoming: UpcomingPlant[];
+}
+
+@Component({
+  selector: 'app-plants-summary-tile',
+  imports: [AsyncPipe, RouterLink],
+  templateUrl: './plants-summary-tile.component.html',
+  styleUrl: './plants-summary-tile.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PlantsSummaryTileComponent {
+
+  private plants = inject(PlantService);
+
+  summary$ = this.plants.getPlants().pipe(
+    map(plants => this.buildSummary(plants))
+  );
+
+  private buildSummary(plants: Plant[]): PlantsSummary {
+    const now = Date.now();
+    const upcoming = plants
+      .filter((p): p is Plant & {nextWateredDate: string} => !!p.nextWateredDate)
+      .sort((a, b) => new Date(a.nextWateredDate).getTime() - new Date(b.nextWateredDate).getTime())
+      .slice(0, 3)
+      .map(p => {
+        const dueTime = new Date(p.nextWateredDate).getTime();
+        return {
+          id: p.id,
+          name: p.name,
+          dueLabel: this.formatDue(dueTime, now),
+          overdue: dueTime < now
+        };
+      });
+
+    return {total: plants.length, upcoming};
+  }
+
+  private formatDue(dueTime: number, now: number): string {
+    const diffDays = Math.round((dueTime - now) / 86_400_000);
+    if (diffDays < 0) return `${Math.abs(diffDays)}d overdue`;
+    if (diffDays === 0) return 'today';
+    if (diffDays === 1) return 'tomorrow';
+    return `in ${diffDays}d`;
+  }
+}

--- a/src/app/touch/components/touch-dashboard/touch-dashboard.component.css
+++ b/src/app/touch/components/touch-dashboard/touch-dashboard.component.css
@@ -1,9 +1,27 @@
 .dashboard {
   flex: 1;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+  gap: 1.25rem;
   padding: 1.25rem;
   overflow: auto;
+}
+
+.dashboard__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.dashboard__heading {
+  margin: 0;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-muted);
 }
 
 .dashboard__grid {
@@ -13,10 +31,16 @@
 }
 
 .dashboard__empty {
-  margin: auto;
+  margin: 0;
   font-family: 'Outfit', sans-serif;
   color: var(--text-muted);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   font-size: 0.8rem;
+}
+
+@media (max-width: 900px) {
+  .dashboard {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }

--- a/src/app/touch/components/touch-dashboard/touch-dashboard.component.html
+++ b/src/app/touch/components/touch-dashboard/touch-dashboard.component.html
@@ -1,13 +1,21 @@
 <div class="dashboard">
-  @if (readings$ | async; as readings) {
-    <section class="dashboard__grid">
-      @for (reading of readings; track reading.sensorId) {
-        <app-temperature-card [reading]="reading" />
-      } @empty {
-        <p class="dashboard__empty">No sensors reporting.</p>
-      }
-    </section>
-  } @else {
-    <p class="dashboard__empty">Loading climate readings…</p>
-  }
+  <section class="dashboard__section dashboard__section--climate">
+    <h2 class="dashboard__heading">Climate</h2>
+    @if (readings$ | async; as readings) {
+      <div class="dashboard__grid">
+        @for (reading of readings; track reading.sensorId) {
+          <app-temperature-card [reading]="reading" />
+        } @empty {
+          <p class="dashboard__empty">No sensors reporting.</p>
+        }
+      </div>
+    } @else {
+      <p class="dashboard__empty">Loading climate readings…</p>
+    }
+  </section>
+
+  <section class="dashboard__section dashboard__section--plants">
+    <h2 class="dashboard__heading">Care</h2>
+    <app-plants-summary-tile />
+  </section>
 </div>

--- a/src/app/touch/components/touch-dashboard/touch-dashboard.component.ts
+++ b/src/app/touch/components/touch-dashboard/touch-dashboard.component.ts
@@ -2,10 +2,11 @@ import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
 import {AsyncPipe} from '@angular/common';
 import {ClimateService} from '../../services/climate.service';
 import {TemperatureCardComponent} from '../temperature-card/temperature-card.component';
+import {PlantsSummaryTileComponent} from '../plants-summary-tile/plants-summary-tile.component';
 
 @Component({
   selector: 'app-touch-dashboard',
-  imports: [AsyncPipe, TemperatureCardComponent],
+  imports: [AsyncPipe, TemperatureCardComponent, PlantsSummaryTileComponent],
   templateUrl: './touch-dashboard.component.html',
   styleUrl: './touch-dashboard.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush


### PR DESCRIPTION
## Summary
- **PlantsSummaryTileComponent** — OnPush, consumes `PlantService.getPlants()` directly (no plant logic duplication). Shows total plant count plus the top 3 plants sorted by `nextWateredDate`. Due labels are precomputed in the service-side observable for OnPush-friendly templates; overdue rows highlighted with the error accent.
- Whole tile is an `<a routerLink="/plant-root/gallery">` with `min-width: 56px; min-height: 56px` for touch ergonomics.
- **TouchDashboardComponent** now uses a two-column responsive grid (climate left, care right) that collapses to one column below 900px.

Closes #103. No changes to the plants module.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run lint` — no new errors; only inherent signal-getter warnings in the unrelated `temperature-card` template
- [ ] Tile renders against real backend data
- [ ] Tapping the tile routes to `/plant-root/gallery`

🤖 Generated with [Claude Code](https://claude.com/claude-code)