### PR TITLE
feat(touch): align dashboard with wireframes

### DIFF
--- a/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.css
+++ b/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.css
@@ -8,12 +8,12 @@
 .tile {
   position: relative;
   height: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 0.9rem;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 0.75rem;
   min-width: 56px;
   min-height: 56px;
-  padding: 1.1rem 1.3rem;
+  padding: 1rem 1.4rem;
   background: var(--surface);
   border: 1px solid var(--border-mid);
   border-radius: 14px;
@@ -30,7 +30,7 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: radial-gradient(ellipse 80% 50% at 0% 0%, var(--accent-glow), transparent 70%);
+  background: radial-gradient(ellipse 70% 50% at 0% 0%, var(--accent-glow), transparent 70%);
 }
 
 .tile > * {
@@ -44,7 +44,7 @@
 }
 
 .tile:active {
-  transform: scale(0.99);
+  transform: scale(0.997);
   background: color-mix(in srgb, var(--surface) 92%, var(--accent) 8%);
 }
 
@@ -52,10 +52,18 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.tile__title {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
 }
 
 .tile__label {
-  font-size: 0.72rem;
+  font-size: 0.75rem;
   letter-spacing: 0.22em;
   text-transform: uppercase;
   color: var(--text-muted);
@@ -63,19 +71,34 @@
 
 .tile__total {
   font-family: 'JetBrains Mono', monospace;
-  font-size: 2.5rem;
+  font-size: 1.8rem;
   font-weight: 700;
   line-height: 1;
   color: var(--accent);
+}
+
+.tile__total-suffix {
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.tile__cta {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
 }
 
 .tile__list {
   margin: 0;
   padding: 0;
   list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-content: center;
+  gap: 0.6rem 1.5rem;
 }
 
 .tile__row {
@@ -83,13 +106,8 @@
   align-items: baseline;
   justify-content: space-between;
   gap: 0.75rem;
-  padding: 0.35rem 0;
   font-size: 0.95rem;
-  border-bottom: 1px solid var(--border);
-}
-
-.tile__row:last-child {
-  border-bottom: none;
+  min-width: 0;
 }
 
 .tile__name {
@@ -101,7 +119,7 @@
 
 .tile__due {
   font-family: 'JetBrains Mono', monospace;
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   color: var(--text-muted);
   flex-shrink: 0;
 }

--- a/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.html
+++ b/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.html
@@ -1,8 +1,12 @@
 <a class="tile" routerLink="/plant-root/gallery" aria-label="Open plant gallery">
   @if (summary$ | async; as summary) {
     <header class="tile__header">
-      <span class="tile__label">Plants</span>
-      <span class="tile__total">{{ summary.total }}</span>
+      <div class="tile__title">
+        <span class="tile__label">Plants</span>
+        <span class="tile__total">{{ summary.total }}</span>
+        <span class="tile__total-suffix">total</span>
+      </div>
+      <span class="tile__cta" aria-hidden="true">tap to open gallery ›</span>
     </header>
     <ul class="tile__list">
       @for (plant of summary.upcoming; track plant.id) {

--- a/src/app/touch/components/temperature-card/temperature-card.component.css
+++ b/src/app/touch/components/temperature-card/temperature-card.component.css
@@ -6,8 +6,13 @@
 }
 
 :host(.is-outdoor) {
-  --accent: var(--c-p);
-  --accent-glow: var(--cg-p);
+  --accent: var(--c-c);
+  --accent-glow: var(--cg-c);
+}
+
+:host(.is-indoor) {
+  --accent: var(--c-a);
+  --accent-glow: var(--cg-a);
 }
 
 .card {
@@ -100,4 +105,48 @@
 .card__humidity-value {
   color: var(--text);
   font-weight: 600;
+}
+
+.card__meta {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  margin-top: 0.6rem;
+  padding-top: 0.7rem;
+  border-top: 1px solid var(--border);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--text-dim);
+}
+
+.card__meta-value {
+  color: var(--text-muted);
+}
+
+/* ── Hero variant ────────────────────────────────── */
+:host(.is-hero) .card {
+  padding: 1.5rem 1.75rem;
+  gap: 0.75rem;
+}
+
+:host(.is-hero) .card__header {
+  font-size: 0.78rem;
+  letter-spacing: 0.28em;
+}
+
+:host(.is-hero) .card__dot {
+  width: 12px;
+  height: 12px;
+}
+
+:host(.is-hero) .card__temp-value {
+  font-size: 5.5rem;
+}
+
+:host(.is-hero) .card__temp-unit {
+  font-size: 1.6rem;
+}
+
+:host(.is-hero) .card__humidity {
+  font-size: 1.2rem;
 }

--- a/src/app/touch/components/temperature-card/temperature-card.component.html
+++ b/src/app/touch/components/temperature-card/temperature-card.component.html
@@ -13,4 +13,10 @@
       <span class="card__humidity-unit">% RH</span>
     </div>
   }
+  @if (variant() === 'hero') {
+    <div class="card__meta">
+      <span class="card__meta-label">Updated</span>
+      <span class="card__meta-value">{{ ageLabel() }}</span>
+    </div>
+  }
 </div>

--- a/src/app/touch/components/temperature-card/temperature-card.component.ts
+++ b/src/app/touch/components/temperature-card/temperature-card.component.ts
@@ -2,6 +2,7 @@ import {ChangeDetectionStrategy, Component, computed, input} from '@angular/core
 import {TemperatureReading} from '../../models/temperature-reading.model';
 
 type Freshness = 'fresh' | 'aging' | 'stale';
+export type TemperatureCardVariant = 'hero' | 'cell';
 
 @Component({
   selector: 'app-temperature-card',
@@ -11,12 +12,15 @@ type Freshness = 'fresh' | 'aging' | 'stale';
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     '[class.is-outdoor]': 'reading().location === "outdoor"',
-    '[class.is-indoor]': 'reading().location === "indoor"'
+    '[class.is-indoor]': 'reading().location === "indoor"',
+    '[class.is-hero]': 'variant() === "hero"',
+    '[class.is-cell]': 'variant() === "cell"'
   }
 })
 export class TemperatureCardComponent {
 
   reading = input.required<TemperatureReading>();
+  variant = input<TemperatureCardVariant>('cell');
 
   temperatureDisplay = computed(() => this.reading().temperatureC.toFixed(1));
 
@@ -26,10 +30,18 @@ export class TemperatureCardComponent {
   });
 
   freshness = computed<Freshness>(() => {
-    const ageMs = Date.now() - new Date(this.reading().measuredAt).getTime();
-    const ageMin = ageMs / 60_000;
+    const ageMin = (Date.now() - new Date(this.reading().measuredAt).getTime()) / 60_000;
     if (ageMin < 2) return 'fresh';
     if (ageMin < 10) return 'aging';
     return 'stale';
+  });
+
+  ageLabel = computed(() => {
+    const ageMin = Math.max(0, Math.floor((Date.now() - new Date(this.reading().measuredAt).getTime()) / 60_000));
+    if (ageMin < 1) return 'just now';
+    if (ageMin === 1) return '1 min ago';
+    if (ageMin < 60) return `${ageMin} min ago`;
+    const hours = Math.floor(ageMin / 60);
+    return hours === 1 ? '1 hr ago' : `${hours} hr ago`;
   });
 }

--- a/src/app/touch/components/touch-dashboard/touch-dashboard.component.css
+++ b/src/app/touch/components/touch-dashboard/touch-dashboard.component.css
@@ -1,45 +1,85 @@
 .dashboard {
   flex: 1;
   display: grid;
-  grid-template-columns: minmax(0, 1.75fr) minmax(360px, 1fr);
-  grid-template-rows: 100%;
+  grid-template-rows: minmax(0, 1fr) minmax(180px, 220px);
   gap: 1.25rem;
   padding: 1.25rem;
   overflow: hidden;
 }
 
-.dashboard__section {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  min-width: 0;
+.dashboard__climate {
+  display: grid;
+  grid-template-columns: minmax(360px, 480px) minmax(0, 1fr);
+  gap: 1.25rem;
   min-height: 0;
 }
 
-.dashboard__heading {
-  margin: 0;
-  font-family: 'Outfit', sans-serif;
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  color: var(--text-muted);
+.dashboard__hero {
+  min-height: 0;
 }
 
-.dashboard__grid {
-  flex: 1;
+.dashboard__rooms {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  grid-auto-rows: minmax(140px, 1fr);
+  grid-template-rows: repeat(2, minmax(0, 1fr));
   gap: 1rem;
   min-height: 0;
 }
 
-.dashboard__empty {
-  margin: 0;
+.dashboard__care {
+  min-height: 0;
+}
+
+/* ── Placeholders ────────────────────────────────── */
+.dashboard__placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface);
+  border: 1px dashed var(--border-mid);
+  border-radius: 14px;
   font-family: 'Outfit', sans-serif;
-  color: var(--text-muted);
-  letter-spacing: 0.08em;
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-align: center;
+  padding: 1rem;
+}
+
+.dashboard__placeholder--span {
+  grid-column: 1 / -1;
+  grid-row: 1 / -1;
+}
+
+.dashboard__placeholder--error {
+  color: var(--c-e);
+  border-color: rgba(251, 113, 133, 0.4);
+}
+
+/* ── Skeleton loading ────────────────────────────── */
+.dashboard__skeleton {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  position: relative;
+  overflow: hidden;
+}
+
+.dashboard__skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.04),
+    transparent
+  );
+  animation: skeleton-pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes skeleton-pulse {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
 }

--- a/src/app/touch/components/touch-dashboard/touch-dashboard.component.html
+++ b/src/app/touch/components/touch-dashboard/touch-dashboard.component.html
@@ -1,21 +1,48 @@
 <div class="dashboard">
-  <section class="dashboard__section dashboard__section--climate">
-    <h2 class="dashboard__heading">Climate</h2>
-    @if (readings$ | async; as readings) {
-      <div class="dashboard__grid">
-        @for (reading of readings; track reading.sensorId) {
-          <app-temperature-card [reading]="reading" />
-        } @empty {
-          <p class="dashboard__empty">No sensors reporting.</p>
+  <section class="dashboard__climate">
+    @if (view$ | async; as view) {
+      @switch (view.status) {
+        @case ('ready') {
+          @if (view.hero) {
+            <app-temperature-card class="dashboard__hero" variant="hero" [reading]="view.hero" />
+          } @else {
+            <div class="dashboard__hero dashboard__placeholder">No outdoor sensor.</div>
+          }
+          <div class="dashboard__rooms">
+            @for (reading of view.rooms; track reading.sensorId) {
+              <app-temperature-card variant="cell" [reading]="reading" />
+            } @empty {
+              <div class="dashboard__placeholder dashboard__placeholder--span">No indoor sensors reporting.</div>
+            }
+          </div>
         }
-      </div>
+        @case ('empty') {
+          <div class="dashboard__hero dashboard__placeholder">No readings available.</div>
+          <div class="dashboard__rooms">
+            <div class="dashboard__placeholder dashboard__placeholder--span">Retry in 60 s.</div>
+          </div>
+        }
+        @case ('error') {
+          <div class="dashboard__hero dashboard__placeholder dashboard__placeholder--error">
+            Climate service unreachable.
+          </div>
+          <div class="dashboard__rooms">
+            <div class="dashboard__placeholder dashboard__placeholder--span">Retry in 60 s.</div>
+          </div>
+        }
+      }
     } @else {
-      <p class="dashboard__empty">Loading climate readings…</p>
+      <div class="dashboard__hero dashboard__skeleton"></div>
+      <div class="dashboard__rooms">
+        <div class="dashboard__skeleton"></div>
+        <div class="dashboard__skeleton"></div>
+        <div class="dashboard__skeleton"></div>
+        <div class="dashboard__skeleton"></div>
+      </div>
     }
   </section>
 
-  <section class="dashboard__section dashboard__section--plants">
-    <h2 class="dashboard__heading">Care</h2>
+  <section class="dashboard__care">
     <app-plants-summary-tile />
   </section>
 </div>

--- a/src/app/touch/components/touch-dashboard/touch-dashboard.component.ts
+++ b/src/app/touch/components/touch-dashboard/touch-dashboard.component.ts
@@ -1,8 +1,16 @@
 import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
 import {AsyncPipe} from '@angular/common';
+import {catchError, map, of} from 'rxjs';
 import {ClimateService} from '../../services/climate.service';
+import {TemperatureReading} from '../../models/temperature-reading.model';
 import {TemperatureCardComponent} from '../temperature-card/temperature-card.component';
 import {PlantsSummaryTileComponent} from '../plants-summary-tile/plants-summary-tile.component';
+
+interface ClimateView {
+  status: 'ready' | 'empty' | 'error';
+  hero: TemperatureReading | null;
+  rooms: TemperatureReading[];
+}
 
 @Component({
   selector: 'app-touch-dashboard',
@@ -15,5 +23,15 @@ export class TouchDashboardComponent {
 
   private climate = inject(ClimateService);
 
-  readings$ = this.climate.readings$;
+  view$ = this.climate.readings$.pipe(
+    map(readings => this.toView(readings)),
+    catchError(() => of<ClimateView>({status: 'error', hero: null, rooms: []}))
+  );
+
+  private toView(readings: TemperatureReading[]): ClimateView {
+    if (!readings.length) return {status: 'empty', hero: null, rooms: []};
+    const hero = readings.find(r => r.location === 'outdoor') ?? null;
+    const rooms = readings.filter(r => r !== hero);
+    return {status: 'ready', hero, rooms};
+  }
 }

--- a/src/app/touch/components/touch-layout/touch-layout.component.css
+++ b/src/app/touch/components/touch-layout/touch-layout.component.css
@@ -23,11 +23,11 @@
 
 .topbar {
   flex: 0 0 auto;
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
+  display: flex;
   align-items: center;
+  justify-content: space-between;
   height: 64px;
-  padding: 0 1.25rem;
+  padding: 0 1.5rem;
   background: rgba(6, 8, 14, 0.88);
   border-bottom: 1px solid var(--border);
 }
@@ -35,62 +35,41 @@
 .topbar__left {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-}
-
-.topbar__right {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-}
-
-.topbar__btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 56px;
-  height: 56px;
-  padding: 0;
-  background: transparent;
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  color: var(--text-muted);
-  cursor: pointer;
-  transition: color 0.2s, border-color 0.2s, background 0.2s;
-  -webkit-tap-highlight-color: transparent;
-}
-
-.topbar__btn:hover,
-.topbar__btn:focus-visible {
-  color: var(--c-c);
-  border-color: var(--c-c);
-  outline: none;
-}
-
-.topbar__btn:active {
-  background: rgba(249, 115, 22, 0.08);
-}
-
-.topbar__btn mat-icon {
-  font-size: 28px;
-  width: 28px;
-  height: 28px;
-}
-
-.topbar__brand {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  font-weight: 700;
-  font-size: 0.8rem;
-  letter-spacing: 0.22em;
-  color: var(--text-muted);
+  gap: 0.7rem;
 }
 
 .topbar__hex {
   color: var(--c-c);
-  font-size: 1rem;
+  font-size: 1.2rem;
   filter: drop-shadow(0 0 6px var(--cg-c));
+}
+
+.topbar__section {
+  font-weight: 700;
+  font-size: 0.9rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--text);
+}
+
+.topbar__right {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.topbar__date {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  letter-spacing: 0.06em;
+}
+
+.topbar__time {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: 0.04em;
 }
 
 .content {

--- a/src/app/touch/components/touch-layout/touch-layout.component.html
+++ b/src/app/touch/components/touch-layout/touch-layout.component.html
@@ -1,15 +1,15 @@
 <div class="touch-layout">
   <header class="topbar">
     <div class="topbar__left">
-      <button class="topbar__btn" aria-label="Go home" [routerLink]="homeLink">
-        <mat-icon>home</mat-icon>
-      </button>
-    </div>
-    <div class="topbar__brand">
       <span class="topbar__hex">⬡</span>
-      <span class="topbar__name">TOUCH</span>
+      <span class="topbar__section">Climate</span>
     </div>
-    <div class="topbar__right"></div>
+    @if (now$ | async; as now) {
+      <div class="topbar__right">
+        <span class="topbar__date">{{ now | date:'EEE d MMM y' }}</span>
+        <span class="topbar__time">{{ now | date:'HH:mm' }}</span>
+      </div>
+    }
   </header>
 
   <main class="content">

--- a/src/app/touch/components/touch-layout/touch-layout.component.ts
+++ b/src/app/touch/components/touch-layout/touch-layout.component.ts
@@ -1,15 +1,11 @@
 import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
-import {MatIcon} from '@angular/material/icon';
-import {ActivatedRoute, NavigationEnd, Router, RouterLink, RouterOutlet} from '@angular/router';
-import {filter} from 'rxjs';
+import {AsyncPipe, DatePipe} from '@angular/common';
+import {ActivatedRoute, NavigationEnd, Router, RouterOutlet} from '@angular/router';
+import {filter, map, startWith, timer} from 'rxjs';
 
 @Component({
   selector: 'app-touch-layout',
-  imports: [
-    MatIcon,
-    RouterLink,
-    RouterOutlet
-  ],
+  imports: [AsyncPipe, DatePipe, RouterOutlet],
   templateUrl: './touch-layout.component.html',
   styleUrl: './touch-layout.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -19,6 +15,11 @@ export class TouchLayoutComponent {
   homeLink: string = '/';
   private router = inject(Router);
   private route = inject(ActivatedRoute);
+
+  now$ = timer(0, 60_000).pipe(
+    map(() => new Date()),
+    startWith(new Date())
+  );
 
   constructor() {
     this.router.events


### PR DESCRIPTION
## Summary
Aligns the touch dashboard with the wireframes in #107.

**Topbar** — "CLIMATE" label on the left, date + time on the right (refreshed each minute). Home button removed (kiosk landing).

**Dashboard** — two-row layout:
- Climate region: hero outdoor card on the left (~480 px) + 2×2 indoor room grid on the right (~720 px).
- Plants strip: full-width tile at the bottom (~200 px), upcoming plants laid out as three columns.

**Card states** — explicit handling for:
- Loading: pulsing skeleton blocks (CSS keyframe shimmer, no spinners).
- Empty: "No readings available." with a calm retry hint.
- Error: distinct red-tinted message that doesn't crash the polling loop.

**TemperatureCardComponent** gains a `variant: 'hero' | 'cell'` signal input. Hero scales the temp to 5.5rem and appends "Updated X min ago"; indoor cells switch to the blue accent so they read differently from the outdoor hero (orange).

**PlantsSummaryTileComponent** reshaped from a side column to a full-width strip with the "tap to open gallery ›" affordance from the wireframe.

Closes #107.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run lint` — no new errors; only inherent signal-getter warnings + a cyclomatic-complexity soft warning from the state switch
- [ ] Visual review at 1280×720 in Chromium against the ASCII wireframes in #107
- [ ] Stop the backend → confirm the error state renders without crashing the dashboard
- [ ] Restart the backend → cards recover on the next 60 s tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)