### PR TITLE
feat(touch): wire /climate/readings to live backend

### DIFF
--- a/src/app/touch/components/temperature-card/temperature-card.component.css
+++ b/src/app/touch/components/temperature-card/temperature-card.component.css
@@ -93,20 +93,6 @@
   color: var(--text-muted);
 }
 
-.card__humidity {
-  display: flex;
-  align-items: baseline;
-  gap: 0.3rem;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.9rem;
-  color: var(--text-muted);
-}
-
-.card__humidity-value {
-  color: var(--text);
-  font-weight: 600;
-}
-
 .card__meta {
   display: flex;
   align-items: baseline;
@@ -145,8 +131,4 @@
 
 :host(.is-hero) .card__temp-unit {
   font-size: 1.6rem;
-}
-
-:host(.is-hero) .card__humidity {
-  font-size: 1.2rem;
 }

--- a/src/app/touch/components/temperature-card/temperature-card.component.html
+++ b/src/app/touch/components/temperature-card/temperature-card.component.html
@@ -7,12 +7,6 @@
     <span class="card__temp-value">{{ temperatureDisplay() }}</span>
     <span class="card__temp-unit">°C</span>
   </div>
-  @if (humidityDisplay() !== null) {
-    <div class="card__humidity">
-      <span class="card__humidity-value">{{ humidityDisplay() }}</span>
-      <span class="card__humidity-unit">% RH</span>
-    </div>
-  }
   @if (variant() === 'hero') {
     <div class="card__meta">
       <span class="card__meta-label">Updated</span>

--- a/src/app/touch/components/temperature-card/temperature-card.component.ts
+++ b/src/app/touch/components/temperature-card/temperature-card.component.ts
@@ -24,11 +24,6 @@ export class TemperatureCardComponent {
 
   temperatureDisplay = computed(() => this.reading().temperatureC.toFixed(1));
 
-  humidityDisplay = computed(() => {
-    const h = this.reading().humidityPct;
-    return h === undefined ? null : Math.round(h);
-  });
-
   freshness = computed<Freshness>(() => {
     const ageMin = (Date.now() - new Date(this.reading().measuredAt).getTime()) / 60_000;
     if (ageMin < 2) return 'fresh';

--- a/src/app/touch/models/temperature-reading.model.ts
+++ b/src/app/touch/models/temperature-reading.model.ts
@@ -3,6 +3,5 @@ export interface TemperatureReading {
   label: string;
   location: 'indoor' | 'outdoor';
   temperatureC: number;
-  humidityPct?: number;
   measuredAt: string;
 }


### PR DESCRIPTION
## Summary
- Confirmed `GET /climate/readings` contract against `Marvin1912/backend` climate module — fields are `sensorId`, `label`, `location`, `temperatureC`, `measuredAt` (ISO 8601 UTC `Instant`).
- Removed `humidityPct` from `TemperatureReading` and the temperature card (backend doesn't emit it; only outdoor temperature is currently produced).
- Verified `environment.prod.ts` `apiUrl` already points at `http://backend.home-lab.com` — no change needed.

No mock/stub data was present in the touch module.

Closes #115. Confirms spike #106.

## Test plan
- [x] `npm run build` succeeds
- [ ] Smoke-test on Pi: hero card renders outdoor temp, freshness dot updates over 60 s poll
- [ ] Pi GUI temperature matches Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)