### PR TITLE
feat(touch): show outdoor humidity on dashboard hero card

### DIFF
--- a/src/app/touch/components/temperature-card/temperature-card.component.css
+++ b/src/app/touch/components/temperature-card/temperature-card.component.css
@@ -93,6 +93,29 @@
   color: var(--text-muted);
 }
 
+.card__humidity {
+  display: flex;
+  align-items: baseline;
+  gap: 0.3rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1rem;
+  color: var(--text-muted);
+}
+
+.card__humidity-icon {
+  font-size: 0.95em;
+  filter: drop-shadow(0 0 6px var(--accent-glow));
+}
+
+.card__humidity-value {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.card__humidity-unit {
+  color: var(--text-dim);
+}
+
 .card__meta {
   display: flex;
   align-items: baseline;
@@ -131,4 +154,9 @@
 
 :host(.is-hero) .card__temp-unit {
   font-size: 1.6rem;
+}
+
+:host(.is-hero) .card__humidity {
+  font-size: 1.25rem;
+  margin-top: 0.25rem;
 }

--- a/src/app/touch/components/temperature-card/temperature-card.component.html
+++ b/src/app/touch/components/temperature-card/temperature-card.component.html
@@ -7,6 +7,13 @@
     <span class="card__temp-value">{{ temperatureDisplay() }}</span>
     <span class="card__temp-unit">°C</span>
   </div>
+  @if (variant() === 'hero' && humidityDisplay() !== null) {
+    <div class="card__humidity">
+      <span class="card__humidity-icon" aria-hidden="true">💧</span>
+      <span class="card__humidity-value">{{ humidityDisplay() }}</span>
+      <span class="card__humidity-unit">%</span>
+    </div>
+  }
   @if (variant() === 'hero') {
     <div class="card__meta">
       <span class="card__meta-label">Updated</span>

--- a/src/app/touch/components/temperature-card/temperature-card.component.ts
+++ b/src/app/touch/components/temperature-card/temperature-card.component.ts
@@ -24,6 +24,11 @@ export class TemperatureCardComponent {
 
   temperatureDisplay = computed(() => this.reading().temperatureC.toFixed(1));
 
+  humidityDisplay = computed(() => {
+    const h = this.reading().humidityPct;
+    return h === undefined || h === null ? null : Math.round(h).toString();
+  });
+
   freshness = computed<Freshness>(() => {
     const ageMin = (Date.now() - new Date(this.reading().measuredAt).getTime()) / 60_000;
     if (ageMin < 2) return 'fresh';

--- a/src/app/touch/models/temperature-reading.model.ts
+++ b/src/app/touch/models/temperature-reading.model.ts
@@ -3,5 +3,6 @@ export interface TemperatureReading {
   label: string;
   location: 'indoor' | 'outdoor';
   temperatureC: number;
+  humidityPct?: number;
   measuredAt: string;
 }


### PR DESCRIPTION
## Summary
- Re-add optional `humidityPct` to `TemperatureReading` (backend Marvin1912/backend#91 now ships it).
- Render humidity as a subordinate row on the **hero** variant of `app-temperature-card`, styled with the `--c-c` climate accent and a glow that matches the existing meta row.
- Gracefully hide the humidity row when `humidityPct` is missing or null — no "0 %" or placeholder dash. Cell-variant indoor cards stay unchanged.

Closes #117. Related: spike #106, backend Marvin1912/backend#91.

## Test plan
- [x] `npm run build` succeeds
- [ ] Kiosk view: outdoor hero card shows current temperature and humidity when backend reports it
- [ ] When backend omits `humidityPct`, the card renders only the temperature (no empty row, no NaN)
- [ ] Indoor cell cards unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)