### PR TITLE
feat(touch): per-row water/fertilize actions on plants tile

### DIFF
--- a/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.css
+++ b/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.css
@@ -19,10 +19,7 @@
   border-radius: 14px;
   color: var(--text);
   font-family: 'Outfit', sans-serif;
-  text-decoration: none;
   overflow: hidden;
-  transition: border-color 0.2s, background 0.2s, transform 0.05s;
-  -webkit-tap-highlight-color: transparent;
 }
 
 .tile::before {
@@ -35,17 +32,6 @@
 
 .tile > * {
   position: relative;
-}
-
-.tile:hover,
-.tile:focus-visible {
-  border-color: var(--accent);
-  outline: none;
-}
-
-.tile:active {
-  transform: scale(0.997);
-  background: color-mix(in srgb, var(--surface) 92%, var(--accent) 8%);
 }
 
 .tile__header {
@@ -89,29 +75,50 @@
   font-size: 0.78rem;
   letter-spacing: 0.08em;
   color: var(--text-muted);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.tile__cta:hover,
+.tile__cta:focus-visible {
+  color: var(--accent);
+  outline: none;
 }
 
 .tile__list {
   margin: 0;
   padding: 0;
   list-style: none;
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  display: flex;
+  flex-direction: column;
   align-content: center;
-  gap: 0.6rem 1.5rem;
 }
 
 .tile__row {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  font-size: 0.95rem;
+  padding: 0.55rem 0;
   min-width: 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.tile__row:last-child {
+  border-bottom: none;
+}
+
+.tile__row-info {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  min-width: 0;
+  flex: 1 1 auto;
 }
 
 .tile__name {
   color: var(--text);
+  font-size: 0.95rem;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -126,6 +133,55 @@
 
 .tile__due.is-overdue {
   color: var(--c-e);
+}
+
+.tile__row-actions {
+  display: flex;
+  gap: 0.4rem;
+  flex-shrink: 0;
+}
+
+.tile__btn {
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 0.35rem 0.65rem;
+  border-radius: 8px;
+  background: transparent;
+  border: 1px solid var(--border-mid);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, color 0.15s, transform 0.05s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.tile__btn:active {
+  transform: scale(0.96);
+}
+
+.tile__btn--water {
+  border-color: color-mix(in srgb, var(--c-p) 55%, var(--border-mid));
+  color: var(--c-p);
+}
+
+.tile__btn--water:hover,
+.tile__btn--water:focus-visible {
+  border-color: var(--c-p);
+  background: var(--cg-p);
+  outline: none;
+}
+
+.tile__btn--fertilize {
+  border-color: color-mix(in srgb, var(--c-v) 55%, var(--border-mid));
+  color: var(--c-v);
+}
+
+.tile__btn--fertilize:hover,
+.tile__btn--fertilize:focus-visible {
+  border-color: var(--c-v);
+  background: var(--cg-v);
+  outline: none;
 }
 
 .tile__empty,

--- a/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.html
+++ b/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.html
@@ -1,4 +1,4 @@
-<a class="tile" routerLink="/plant-root/gallery" aria-label="Open plant gallery">
+<section class="tile">
   @if (summary$ | async; as summary) {
     <header class="tile__header">
       <div class="tile__title">
@@ -6,15 +6,29 @@
         <span class="tile__total">{{ summary.total }}</span>
         <span class="tile__total-suffix">total</span>
       </div>
-      <span class="tile__cta" aria-hidden="true">tap to open gallery ›</span>
+      <a class="tile__cta" routerLink="/plant-root/gallery">tap to open gallery ›</a>
     </header>
     <ul class="tile__list">
       @for (plant of summary.upcoming; track plant.id) {
         <li class="tile__row">
-          <span class="tile__name">{{ plant.name }}</span>
-          <span class="tile__due" [class.is-overdue]="plant.overdue">
-            {{ plant.dueLabel }}
-          </span>
+          <div class="tile__row-info">
+            <span class="tile__name">{{ plant.name }}</span>
+            <span class="tile__due" [class.is-overdue]="plant.overdue">
+              {{ plant.dueLabel }}
+            </span>
+          </div>
+          <div class="tile__row-actions">
+            <button type="button"
+                    class="tile__btn tile__btn--water"
+                    (click)="water(plant.id, $event)"
+                    aria-label="Mark watered today">Water
+            </button>
+            <button type="button"
+                    class="tile__btn tile__btn--fertilize"
+                    (click)="fertilize(plant.id, $event)"
+                    aria-label="Mark fertilized today">Fertilize
+            </button>
+          </div>
         </li>
       } @empty {
         <li class="tile__empty">No watering scheduled.</li>
@@ -23,4 +37,4 @@
   } @else {
     <span class="tile__loading">Loading plants…</span>
   }
-</a>
+</section>

--- a/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.ts
+++ b/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.ts
@@ -1,7 +1,7 @@
 import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
-import {AsyncPipe} from '@angular/common';
+import {AsyncPipe, formatDate} from '@angular/common';
 import {RouterLink} from '@angular/router';
-import {map} from 'rxjs';
+import {BehaviorSubject, map, switchMap} from 'rxjs';
 import {PlantService} from '../../../plants/services/plant.service';
 import {Plant} from '../../../plants/models/plant.model';
 
@@ -27,10 +27,34 @@ interface PlantsSummary {
 export class PlantsSummaryTileComponent {
 
   private plants = inject(PlantService);
+  private refresh$ = new BehaviorSubject<void>(undefined);
 
-  summary$ = this.plants.getPlants().pipe(
+  summary$ = this.refresh$.pipe(
+    switchMap(() => this.plants.getPlants()),
     map(plants => this.buildSummary(plants))
   );
+
+  water(id: number, ev: Event): void {
+    ev.stopPropagation();
+    ev.preventDefault();
+    this.plants.wateredPlant(id, this.today()).subscribe({
+      next: () => this.refresh$.next(),
+      error: err => console.error('Watering plant failed', err)
+    });
+  }
+
+  fertilize(id: number, ev: Event): void {
+    ev.stopPropagation();
+    ev.preventDefault();
+    this.plants.fertilizedPlant(id, this.today()).subscribe({
+      next: () => this.refresh$.next(),
+      error: err => console.error('Fertilizing plant failed', err)
+    });
+  }
+
+  private today(): string {
+    return formatDate(new Date(), 'yyyy-MM-dd', 'en-US');
+  }
 
   private buildSummary(plants: Plant[]): PlantsSummary {
     const now = Date.now();


### PR DESCRIPTION
## Summary
- Adds per-row **Water** and **Fertilize** buttons to each upcoming plant in the touch dashboard's plants tile, calling the existing `PATCH /plants/{id}/watered` and `/fertilized` endpoints with today's date.
- Switches the row layout from a 3-column grid to a vertical stack with a thin separator between rows.
- Drops the card-wide `<a>` link; the `tap to open gallery ›` text in the header is now the only navigation target, so per-row buttons get their own touch targets.
- Subtle dark-touch button styling uses `--c-p` (plants green) for Water and `--c-v` (warning yellow) for Fertilize; on success the list re-fetches via a `BehaviorSubject` refresh trigger.

## Test plan
- [ ] `npm run build` succeeds.
- [ ] Touch dashboard renders: header has count + gallery link; each row shows name, due label, and two buttons; thin border between rows; no border under last row.
- [ ] Tapping the empty card body does **not** navigate to the gallery.
- [ ] Tapping **Water** on a row issues `PATCH /plants/{id}/watered?last-watered=YYYY-MM-DD`; the list refreshes.
- [ ] Tapping **Fertilize** on a row issues the analogous fertilize PATCH; list refreshes.
- [ ] Tab order reaches the gallery link and both buttons with visible focus rings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)