### PR TITLE
feat(touch): filter plants tile to plants needing water/fertilizer

### DIFF
--- a/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.css
+++ b/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.css
@@ -124,6 +124,18 @@
   white-space: nowrap;
 }
 
+.tile__needs {
+  display: inline-flex;
+  gap: 0.25rem;
+  flex-shrink: 0;
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+.tile__need {
+  filter: saturate(1.1);
+}
+
 .tile__due {
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.78rem;

--- a/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.html
+++ b/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.html
@@ -13,6 +13,14 @@
         <li class="tile__row">
           <div class="tile__row-info">
             <span class="tile__name">{{ plant.name }}</span>
+            <span class="tile__needs">
+              @if (plant.needsWater) {
+                <span class="tile__need" title="Needs watering" aria-label="Needs watering">💧</span>
+              }
+              @if (plant.needsFertilize) {
+                <span class="tile__need" title="Needs fertilizing" aria-label="Needs fertilizing">🌱</span>
+              }
+            </span>
             <span class="tile__due" [class.is-overdue]="plant.overdue">
               {{ plant.dueLabel }}
             </span>
@@ -31,7 +39,7 @@
           </div>
         </li>
       } @empty {
-        <li class="tile__empty">No watering scheduled.</li>
+        <li class="tile__empty">All plants are happy 🌿</li>
       }
     </ul>
   } @else {

--- a/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.ts
+++ b/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.ts
@@ -10,6 +10,8 @@ interface UpcomingPlant {
   name: string;
   dueLabel: string;
   overdue: boolean;
+  needsWater: boolean;
+  needsFertilize: boolean;
 }
 
 interface PlantsSummary {
@@ -57,22 +59,45 @@ export class PlantsSummaryTileComponent {
   }
 
   private buildSummary(plants: Plant[]): PlantsSummary {
-    const now = Date.now();
+    const today = this.today();
+    const nowMidnight = new Date(today).getTime();
     const upcoming = plants
-      .filter((p): p is Plant & {nextWateredDate: string} => !!p.nextWateredDate)
-      .sort((a, b) => new Date(a.nextWateredDate).getTime() - new Date(b.nextWateredDate).getTime())
+      .map(p => this.toDuePlant(p, today, nowMidnight))
+      .filter((p): p is UpcomingPlant & {referenceTime: number} => p !== null)
+      .sort((a, b) => a.referenceTime - b.referenceTime)
       .slice(0, 3)
-      .map(p => {
-        const dueTime = new Date(p.nextWateredDate).getTime();
-        return {
-          id: p.id,
-          name: p.name,
-          dueLabel: this.formatDue(dueTime, now),
-          overdue: dueTime < now
-        };
-      });
+      .map(({referenceTime, ...rest}) => rest);
 
     return {total: plants.length, upcoming};
+  }
+
+  private toDuePlant(
+    plant: Plant,
+    today: string,
+    nowMidnight: number
+  ): (UpcomingPlant & {referenceTime: number}) | null {
+    const needsWater = !!plant.nextWateredDate && plant.nextWateredDate <= today;
+    const needsFertilize = !!plant.nextFertilizedDate && plant.nextFertilizedDate <= today;
+    if (!needsWater && !needsFertilize) {
+      return null;
+    }
+    const candidates: number[] = [];
+    if (needsWater && plant.nextWateredDate) {
+      candidates.push(new Date(plant.nextWateredDate).getTime());
+    }
+    if (needsFertilize && plant.nextFertilizedDate) {
+      candidates.push(new Date(plant.nextFertilizedDate).getTime());
+    }
+    const referenceTime = Math.min(...candidates);
+    return {
+      id: plant.id,
+      name: plant.name,
+      dueLabel: this.formatDue(referenceTime, nowMidnight),
+      overdue: referenceTime < nowMidnight,
+      needsWater,
+      needsFertilize,
+      referenceTime
+    };
   }
 
   private formatDue(dueTime: number, now: number): string {


### PR DESCRIPTION
## Summary
- Plants summary tile on the touch dashboard now lists only plants currently due for watering or fertilizing (was: next 3 by watering date regardless of need).
- Each row shows 💧 / 🌱 icons indicating which task is pending — both icons appear when both are due.
- Due label uses whichever care date is more overdue; existing Water / Fertilize per-row buttons and overdue styling are preserved.

## Test plan
- [ ] `npm start` and open the touch dashboard.
- [ ] Plant overdue for water only → row shows 💧 and a red overdue label.
- [ ] Plant overdue for fertilizer only → row shows 🌱.
- [ ] Plant overdue for both → row shows both icons; label reflects the more overdue date.
- [ ] Plant with `nextWateredDate` in the future and no fertilizing due → hidden from the tile.
- [ ] When no plants are due, tile shows "All plants are happy 🌿".
- [ ] Tapping Water / Fertilize updates the plant and refreshes the tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)