### PR TITLE
fix(touch): align top-bar clock to wall-clock minute boundaries

### DIFF
--- a/src/app/touch/components/touch-layout/touch-layout.component.ts
+++ b/src/app/touch/components/touch-layout/touch-layout.component.ts
@@ -16,7 +16,7 @@ export class TouchLayoutComponent {
   private router = inject(Router);
   private route = inject(ActivatedRoute);
 
-  now$ = timer(0, 60_000).pipe(
+  now$ = timer(60_000 - (Date.now() % 60_000) + 50, 60_000).pipe(
     map(() => new Date()),
     startWith(new Date())
   );


### PR DESCRIPTION
## Summary
- The top-right clock in `TouchLayoutComponent` ticked every 60s relative to component mount, so the displayed minute could trail the real wall-clock minute by up to 59s.
- Schedule the first tick at the next wall-clock minute boundary (+50ms guard), then continue every 60s, so the displayed `HH:mm` rolls over together with the OS clock.

## Test plan
- [x] `npm run build`
- [ ] `npm start`, open a touch route, verify the top-right `HH:mm` matches the OS clock and rolls over within ~1s of the OS clock rolling over
- [ ] Reload the touch route at varied moments within a minute; rollover still lands on the wall-clock boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)