### PR TITLE
feat(touch): rotate two indoor sensor cards every 30s

### DIFF
--- a/src/app/touch/components/touch-dashboard/touch-dashboard.component.css
+++ b/src/app/touch/components/touch-dashboard/touch-dashboard.component.css
@@ -21,9 +21,17 @@
 .dashboard__rooms {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  grid-template-rows: repeat(2, minmax(0, 1fr));
   gap: 1rem;
   min-height: 0;
+}
+
+.dashboard__rooms app-temperature-card {
+  animation: room-fade-in 420ms ease-out;
+}
+
+@keyframes room-fade-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 .dashboard__care {

--- a/src/app/touch/components/touch-dashboard/touch-dashboard.component.html
+++ b/src/app/touch/components/touch-dashboard/touch-dashboard.component.html
@@ -36,8 +36,6 @@
       <div class="dashboard__rooms">
         <div class="dashboard__skeleton"></div>
         <div class="dashboard__skeleton"></div>
-        <div class="dashboard__skeleton"></div>
-        <div class="dashboard__skeleton"></div>
       </div>
     }
   </section>

--- a/src/app/touch/components/touch-dashboard/touch-dashboard.component.ts
+++ b/src/app/touch/components/touch-dashboard/touch-dashboard.component.ts
@@ -1,6 +1,6 @@
 import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
 import {AsyncPipe} from '@angular/common';
-import {catchError, map, of} from 'rxjs';
+import {catchError, combineLatest, map, of, timer} from 'rxjs';
 import {ClimateService} from '../../services/climate.service';
 import {TemperatureReading} from '../../models/temperature-reading.model';
 import {TemperatureCardComponent} from '../temperature-card/temperature-card.component';
@@ -11,6 +11,9 @@ interface ClimateView {
   hero: TemperatureReading | null;
   rooms: TemperatureReading[];
 }
+
+const ROOM_ROTATION_MS = 30_000;
+const VISIBLE_INDOOR_COUNT = 2;
 
 @Component({
   selector: 'app-touch-dashboard',
@@ -23,15 +26,25 @@ export class TouchDashboardComponent {
 
   private climate = inject(ClimateService);
 
-  view$ = this.climate.readings$.pipe(
-    map(readings => this.toView(readings)),
+  view$ = combineLatest([
+    this.climate.readings$,
+    timer(0, ROOM_ROTATION_MS)
+  ]).pipe(
+    map(([readings, tick]) => this.toView(readings, tick)),
     catchError(() => of<ClimateView>({status: 'error', hero: null, rooms: []}))
   );
 
-  private toView(readings: TemperatureReading[]): ClimateView {
+  private toView(readings: TemperatureReading[], tick: number): ClimateView {
     if (!readings.length) return {status: 'empty', hero: null, rooms: []};
     const hero = readings.find(r => r.location === 'outdoor') ?? null;
-    const rooms = readings.filter(r => r !== hero);
-    return {status: 'ready', hero, rooms};
+    const indoor = readings.filter(r => r.location === 'indoor');
+    return {status: 'ready', hero, rooms: this.windowFrom(indoor, tick)};
+  }
+
+  private windowFrom(indoor: TemperatureReading[], tick: number): TemperatureReading[] {
+    if (!indoor.length) return [];
+    if (indoor.length <= VISIBLE_INDOOR_COUNT) return indoor;
+    const start = tick % indoor.length;
+    return Array.from({length: VISIBLE_INDOOR_COUNT}, (_, i) => indoor[(start + i) % indoor.length]);
   }
 }


### PR DESCRIPTION
## Summary
- Consume the indoor readings now emitted by `/climate/readings` (Badezimmer, Flur, Küche, Schlafzimmer, Wohnzimmer) on the touch dashboard.
- Show two indoor sensor cards at a time and rotate through all reporting rooms with a 30 s sliding window (`[0,1] → [1,2] → … → [4,0]`), so each transition swaps only one card.
- Indoor grid switches from 2×2 to 2×1; added a short fade-in animation on the card that gets swapped in. Skeleton placeholder reduced to two boxes to match.

> ℹ️ Requires the matching backend PR (Marvin1912/backend#93) to land — without it, the endpoint still only returns the outdoor reading and the indoor area will just show "No outdoor sensor."-style placeholders.

## Test plan
- [x] `npm run build` passes locally.
- [ ] Manual: with the backend PR running, open the touch dashboard and verify the 2 indoor cards rotate every 30 s and the outdoor hero stays put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)