### PR TITLE
fix(touch): show humidity and updated timestamp on room cards

### DIFF
--- a/src/app/touch/components/temperature-card/temperature-card.component.html
+++ b/src/app/touch/components/temperature-card/temperature-card.component.html
@@ -7,17 +7,15 @@
     <span class="card__temp-value">{{ temperatureDisplay() }}</span>
     <span class="card__temp-unit">°C</span>
   </div>
-  @if (variant() === 'hero' && humidityDisplay() !== null) {
+  @if (humidityDisplay() !== null) {
     <div class="card__humidity">
       <span class="card__humidity-icon" aria-hidden="true">💧</span>
       <span class="card__humidity-value">{{ humidityDisplay() }}</span>
       <span class="card__humidity-unit">%</span>
     </div>
   }
-  @if (variant() === 'hero') {
-    <div class="card__meta">
-      <span class="card__meta-label">Updated</span>
-      <span class="card__meta-value">{{ ageLabel() }}</span>
-    </div>
-  }
+  <div class="card__meta">
+    <span class="card__meta-label">Updated</span>
+    <span class="card__meta-value">{{ ageLabel() }}</span>
+  </div>
 </div>


### PR DESCRIPTION
## Summary
- Indoor room cards now render humidity (when reported by the sensor) alongside temperature
- Indoor room cards now show the "Updated" timestamp, matching the outdoor hero card
- Achieved by lifting the hero-only `@if` guards on the humidity and meta blocks in `temperature-card.component.html`; the cell variant already had matching CSS

## Test plan
- [ ] `npm run build` passes
- [ ] On the touch dashboard, each indoor room card shows temperature, humidity (if available), and an "Updated" age label
- [ ] Outdoor hero card still looks unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)