### PR TITLE
fix(touch): poll plants hourly and keep climate stream alive on API errors

### DIFF
--- a/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.ts
+++ b/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.ts
@@ -1,9 +1,11 @@
 import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
 import {AsyncPipe, formatDate} from '@angular/common';
 import {RouterLink} from '@angular/router';
-import {BehaviorSubject, map, switchMap} from 'rxjs';
+import {EMPTY, Subject, catchError, map, merge, switchMap, timer} from 'rxjs';
 import {PlantService} from '../../../plants/services/plant.service';
 import {Plant} from '../../../plants/models/plant.model';
+
+const PLANTS_REFRESH_MS = 3_600_000;
 
 interface UpcomingPlant {
   id: number;
@@ -29,10 +31,12 @@ interface PlantsSummary {
 export class PlantsSummaryTileComponent {
 
   private plants = inject(PlantService);
-  private refresh$ = new BehaviorSubject<void>(undefined);
+  private refresh$ = new Subject<void>();
 
-  summary$ = this.refresh$.pipe(
-    switchMap(() => this.plants.getPlants()),
+  summary$ = merge(timer(0, PLANTS_REFRESH_MS), this.refresh$).pipe(
+    switchMap(() => this.plants.getPlants().pipe(
+      catchError(() => EMPTY)
+    )),
     map(plants => this.buildSummary(plants))
   );
 

--- a/src/app/touch/services/climate.service.ts
+++ b/src/app/touch/services/climate.service.ts
@@ -1,6 +1,6 @@
 import {inject, Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
-import {Observable, switchMap, timer} from 'rxjs';
+import {EMPTY, Observable, catchError, shareReplay, switchMap, timer} from 'rxjs';
 import {environment} from '../../../environments/environment';
 import {TemperatureReading} from '../models/temperature-reading.model';
 
@@ -14,7 +14,10 @@ export class ClimateService {
   private http = inject(HttpClient);
 
   readings$: Observable<TemperatureReading[]> = timer(0, 60_000).pipe(
-    switchMap(() => this.getReadings())
+    switchMap(() => this.getReadings().pipe(
+      catchError(() => EMPTY)
+    )),
+    shareReplay({bufferSize: 1, refCount: true})
   );
 
   getReadings(): Observable<TemperatureReading[]> {


### PR DESCRIPTION
## Summary
- `plants-summary-tile` now refreshes every hour via `timer(0, 3_600_000)` merged with the existing manual refresh subject, so the touch view stays current without a reload.
- `ClimateService.readings$` swallows per-tick HTTP errors with `catchError(() => EMPTY)` inside the `switchMap`, so a backend outage no longer terminates the polling timer. Added `shareReplay({bufferSize: 1, refCount: true})` so the last good readings are preserved across the failing tick.

## Test plan
- [x] `npm run build` passes
- [ ] Touch dashboard: leave the view open and verify plant due-info updates after ~1h (or temporarily lower the interval to confirm).
- [ ] Stop the backend, wait past one 60s tick, restart it and confirm the climate cards resume updating instead of staying frozen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)