### PR TITLE
fix(touch): render plant care needs as Material Icons

### DIFF
--- a/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.css
+++ b/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.css
@@ -126,14 +126,25 @@
 
 .tile__needs {
   display: inline-flex;
+  align-items: center;
   gap: 0.25rem;
   flex-shrink: 0;
-  font-size: 0.95rem;
   line-height: 1;
 }
 
 .tile__need {
-  filter: saturate(1.1);
+  font-size: 1.1rem;
+  width: 1.1rem;
+  height: 1.1rem;
+  line-height: 1.1rem;
+}
+
+.tile__need--water {
+  color: var(--c-p);
+}
+
+.tile__need--fertilize {
+  color: var(--c-v);
 }
 
 .tile__due {

--- a/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.html
+++ b/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.html
@@ -15,10 +15,14 @@
             <span class="tile__name">{{ plant.name }}</span>
             <span class="tile__needs">
               @if (plant.needsWater) {
-                <span class="tile__need" title="Needs watering" aria-label="Needs watering">💧</span>
+                <mat-icon class="tile__need tile__need--water"
+                          title="Needs watering"
+                          aria-label="Needs watering">water_drop</mat-icon>
               }
               @if (plant.needsFertilize) {
-                <span class="tile__need" title="Needs fertilizing" aria-label="Needs fertilizing">🌱</span>
+                <mat-icon class="tile__need tile__need--fertilize"
+                          title="Needs fertilizing"
+                          aria-label="Needs fertilizing">eco</mat-icon>
               }
             </span>
             <span class="tile__due" [class.is-overdue]="plant.overdue">

--- a/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.ts
+++ b/src/app/touch/components/plants-summary-tile/plants-summary-tile.component.ts
@@ -1,6 +1,7 @@
 import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
 import {AsyncPipe, formatDate} from '@angular/common';
 import {RouterLink} from '@angular/router';
+import {MatIconModule} from '@angular/material/icon';
 import {EMPTY, Subject, catchError, map, merge, switchMap, timer} from 'rxjs';
 import {PlantService} from '../../../plants/services/plant.service';
 import {Plant} from '../../../plants/models/plant.model';
@@ -23,7 +24,7 @@ interface PlantsSummary {
 
 @Component({
   selector: 'app-plants-summary-tile',
-  imports: [AsyncPipe, RouterLink],
+  imports: [AsyncPipe, RouterLink, MatIconModule],
   templateUrl: './plants-summary-tile.component.html',
   styleUrl: './plants-summary-tile.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush


### PR DESCRIPTION
## Summary
- Replaces the 💧 / 🌱 emoji indicators in the touch plants summary tile with `<mat-icon>water_drop</mat-icon>` and `<mat-icon>eco</mat-icon>`.
- Raspberry Pi 4 Chromium has no emoji font, so the previous glyphs rendered as tofu boxes. The Material Icons font is already loaded in `src/index.html`, so the icons render reliably.
- The existing template uses two independent `@if` blocks, so a plant needing both water and fertilizer now visibly shows both icons (previously masked by the missing emoji font).
- Color-coded the icons with the same `--c-p` (water) and `--c-v` (fertilize) accents already used for the action buttons.

## Test plan
- [ ] Open `/touch` on Raspberry Pi 4 Chromium and confirm water_drop / eco icons render in place of emojis.
- [ ] Verify a plant due for both watering and fertilizing shows both icons side-by-side.
- [ ] Confirm the icons inherit the water/fertilize accent colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)