### PR TITLE
feat(touch): portfolio tile with total value and Bitcoin data

### DIFF
--- a/src/app/touch/components/portfolio-tile/portfolio-tile.component.css
+++ b/src/app/touch/components/portfolio-tile/portfolio-tile.component.css
@@ -1,0 +1,164 @@
+:host {
+  display: block;
+  height: 100%;
+  --accent: var(--c-v);
+  --accent-glow: var(--cg-v);
+}
+
+.tile {
+  position: relative;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 1rem 1.4rem;
+  background: var(--surface);
+  border: 1px solid var(--border-mid);
+  border-radius: 14px;
+  color: var(--text);
+  font-family: 'Outfit', sans-serif;
+  overflow: hidden;
+}
+
+.tile::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(ellipse 70% 50% at 100% 100%, var(--accent-glow), transparent 70%);
+}
+
+.tile > * {
+  position: relative;
+}
+
+.tile__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 0.65rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.tile__title {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.tile__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.tile__total {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1.8rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--accent);
+}
+
+.tile__total-suffix {
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.tile__timestamp {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.tile__btc {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.tile__btc-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.tile__btc-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.tile__btc-price {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.tile__btc-sep {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.tile__btc-value {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.9rem;
+  color: var(--text-dim);
+}
+
+.tile__btc-pct {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin-left: auto;
+}
+
+/* Loading skeleton */
+.tile--loading {
+  justify-content: space-between;
+}
+
+.tile__skeleton {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  position: relative;
+  overflow: hidden;
+}
+
+.tile__skeleton--header {
+  height: 2.5rem;
+}
+
+.tile__skeleton--row {
+  height: 1.5rem;
+  width: 70%;
+}
+
+.tile__skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.04),
+    transparent
+  );
+  animation: skeleton-pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes skeleton-pulse {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}

--- a/src/app/touch/components/portfolio-tile/portfolio-tile.component.html
+++ b/src/app/touch/components/portfolio-tile/portfolio-tile.component.html
@@ -1,0 +1,26 @@
+@if (view$ | async; as v) {
+  <div class="tile">
+    <div class="tile__header">
+      <div class="tile__title">
+        <span class="tile__label">Portfolio</span>
+        <span class="tile__total">{{ v.total }}</span>
+        <span class="tile__total-suffix">{{ v.currency }}</span>
+      </div>
+      <span class="tile__timestamp">{{ v.asOf }}</span>
+    </div>
+    <div class="tile__btc">
+      <span class="tile__btc-label">Bitcoin</span>
+      <div class="tile__btc-row">
+        <span class="tile__btc-price">{{ v.btcPrice }} {{ v.currency }}</span>
+        <span class="tile__btc-sep">/</span>
+        <span class="tile__btc-value">{{ v.btcValue }} {{ v.currency }}</span>
+        <span class="tile__btc-pct">{{ v.btcPct }}%</span>
+      </div>
+    </div>
+  </div>
+} @else {
+  <div class="tile tile--loading">
+    <div class="tile__skeleton tile__skeleton--header"></div>
+    <div class="tile__skeleton tile__skeleton--row"></div>
+  </div>
+}

--- a/src/app/touch/components/portfolio-tile/portfolio-tile.component.ts
+++ b/src/app/touch/components/portfolio-tile/portfolio-tile.component.ts
@@ -1,0 +1,56 @@
+import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
+import {AsyncPipe} from '@angular/common';
+import {combineLatest, map} from 'rxjs';
+import {PortfolioService} from '../../services/portfolio.service';
+import {BitcoinValue, PortfolioValue} from '../../models/portfolio.model';
+
+interface PortfolioView {
+  total: string;
+  currency: string;
+  asOf: string;
+  btcPrice: string;
+  btcValue: string;
+  btcPct: string;
+}
+
+@Component({
+  selector: 'app-portfolio-tile',
+  imports: [AsyncPipe],
+  templateUrl: './portfolio-tile.component.html',
+  styleUrl: './portfolio-tile.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PortfolioTileComponent {
+
+  private portfolio = inject(PortfolioService);
+
+  view$ = combineLatest([
+    this.portfolio.portfolioValue$,
+    this.portfolio.bitcoinValue$
+  ]).pipe(
+    map(([pv, btc]) => this.toView(pv, btc))
+  );
+
+  private toView(pv: PortfolioValue, btc: BitcoinValue): PortfolioView {
+    return {
+      total: this.formatEur(pv.total_value),
+      currency: pv.currency,
+      asOf: this.formatTimestamp(pv.as_of),
+      btcPrice: this.formatEur(btc.current_price),
+      btcValue: this.formatEur(btc.current_value),
+      btcPct: btc.percentage_of_portfolio
+    };
+  }
+
+  private formatEur(raw: string): string {
+    const n = parseFloat(raw);
+    if (isNaN(n)) return raw;
+    return n.toLocaleString('de-DE', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+  }
+
+  private formatTimestamp(raw: string): string {
+    const d = new Date(raw);
+    if (isNaN(d.getTime())) return raw;
+    return d.toLocaleTimeString('de-DE', {hour: '2-digit', minute: '2-digit'});
+  }
+}

--- a/src/app/touch/components/touch-dashboard/touch-dashboard.component.css
+++ b/src/app/touch/components/touch-dashboard/touch-dashboard.component.css
@@ -34,7 +34,10 @@
   to   { opacity: 1; transform: translateY(0); }
 }
 
-.dashboard__care {
+.dashboard__bottom {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.25rem;
   min-height: 0;
 }
 

--- a/src/app/touch/components/touch-dashboard/touch-dashboard.component.html
+++ b/src/app/touch/components/touch-dashboard/touch-dashboard.component.html
@@ -40,7 +40,8 @@
     }
   </section>
 
-  <section class="dashboard__care">
+  <section class="dashboard__bottom">
     <app-plants-summary-tile />
+    <app-portfolio-tile />
   </section>
 </div>

--- a/src/app/touch/components/touch-dashboard/touch-dashboard.component.ts
+++ b/src/app/touch/components/touch-dashboard/touch-dashboard.component.ts
@@ -5,6 +5,7 @@ import {ClimateService} from '../../services/climate.service';
 import {TemperatureReading} from '../../models/temperature-reading.model';
 import {TemperatureCardComponent} from '../temperature-card/temperature-card.component';
 import {PlantsSummaryTileComponent} from '../plants-summary-tile/plants-summary-tile.component';
+import {PortfolioTileComponent} from '../portfolio-tile/portfolio-tile.component';
 
 interface ClimateView {
   status: 'ready' | 'empty' | 'error';
@@ -17,7 +18,7 @@ const VISIBLE_INDOOR_COUNT = 2;
 
 @Component({
   selector: 'app-touch-dashboard',
-  imports: [AsyncPipe, TemperatureCardComponent, PlantsSummaryTileComponent],
+  imports: [AsyncPipe, TemperatureCardComponent, PlantsSummaryTileComponent, PortfolioTileComponent],
   templateUrl: './touch-dashboard.component.html',
   styleUrl: './touch-dashboard.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/app/touch/models/portfolio.model.ts
+++ b/src/app/touch/models/portfolio.model.ts
@@ -1,0 +1,14 @@
+export interface PortfolioValue {
+  total_value: string;
+  currency: string;
+  as_of: string;
+}
+
+export interface BitcoinValue {
+  ticker: string;
+  name: string;
+  quantity: string;
+  current_price: string;
+  current_value: string;
+  percentage_of_portfolio: string;
+}

--- a/src/app/touch/services/portfolio.service.ts
+++ b/src/app/touch/services/portfolio.service.ts
@@ -1,0 +1,28 @@
+import {inject, Injectable} from '@angular/core';
+import {HttpClient} from '@angular/common/http';
+import {EMPTY, Observable, catchError, shareReplay, switchMap, timer} from 'rxjs';
+import {environment} from '../../../environments/environment';
+import {BitcoinValue, PortfolioValue} from '../models/portfolio.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PortfolioService {
+
+  private host = environment.portfolioApiUrl;
+  private http = inject(HttpClient);
+
+  portfolioValue$: Observable<PortfolioValue> = timer(0, 300_000).pipe(
+    switchMap(() => this.http.get<PortfolioValue>(`${this.host}/portfolio/value`).pipe(
+      catchError(() => EMPTY)
+    )),
+    shareReplay({bufferSize: 1, refCount: true})
+  );
+
+  bitcoinValue$: Observable<BitcoinValue> = timer(0, 300_000).pipe(
+    switchMap(() => this.http.get<BitcoinValue>(`${this.host}/portfolio/bitcoin`).pipe(
+      catchError(() => EMPTY)
+    )),
+    shareReplay({bufferSize: 1, refCount: true})
+  );
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,6 +1,7 @@
 export const environment = {
   production: true,
   apiUrl: 'http://backend.home-lab.com',
+  portfolioApiUrl: 'http://portfolio.home-lab.com',
   buildTime: '2025-12-21T13:08:55.093Z',
   nodeVersion: 'v23.9.0',
   angularVersion: '20.2.8',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,6 +1,7 @@
 export const environment = {
   production: false,
   apiUrl: 'http://localhost:9001',
+  portfolioApiUrl: 'http://localhost:8000',
   buildTime: '2025-12-21T13:08:55.024Z',
   nodeVersion: 'v23.9.0',
   angularVersion: '20.2.8',


### PR DESCRIPTION
## Summary

- Adds `portfolioApiUrl` to both environment files (`localhost:8000` dev, `portfolio.home-lab.com` prod)
- New model `touch/models/portfolio.model.ts` — `PortfolioValue` and `BitcoinValue` interfaces
- New service `touch/services/portfolio.service.ts` — polls `/portfolio/value` and `/portfolio/bitcoin` every 5 minutes with `catchError(() => EMPTY)` for graceful unavailability handling
- New `portfolio-tile` component displaying total portfolio value (large, JetBrains Mono, EUR) and Bitcoin price/holding/percentage, matching existing tile design tokens
- Dashboard bottom row now uses a two-column grid to place `<app-plants-summary-tile>` and `<app-portfolio-tile>` side by side

Closes #126

## Test plan

- [ ] `ng serve` → open touch dashboard → bottom row shows plants tile (left) and portfolio tile (right)
- [ ] Portfolio tile shows total value, currency, last-updated timestamp, and BTC row
- [ ] With portfolio API down: tile shows skeleton loader, no console errors
- [ ] Values update after 5 minutes without page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)