### PR TITLE
feat(grocery): add grocery receipt scanner module

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -24,6 +24,11 @@ import {ArticleListComponent} from './it-news/components/article-list/article-li
 import {FeedConfigComponent} from './it-news/components/feed-config/feed-config.component';
 import {TouchLayoutComponent} from './touch/components/touch-layout/touch-layout.component';
 import {TouchDashboardComponent} from './touch/components/touch-dashboard/touch-dashboard.component';
+import {GroceryLayoutComponent} from './grocery/components/grocery-layout/grocery-layout.component';
+import {GroceryHomeComponent} from './grocery/components/grocery-home/grocery-home.component';
+import {ReceiptUploadComponent} from './grocery/components/receipt-upload/receipt-upload.component';
+import {ReceiptListComponent} from './grocery/components/receipt-list/receipt-list.component';
+import {ReceiptItemsComponent} from './grocery/components/receipt-items/receipt-items.component';
 
 export const routes: Routes = [
   {path: '', component: HomeComponent},
@@ -81,6 +86,16 @@ export const routes: Routes = [
     component: TouchLayoutComponent,
     children: [
       {path: '', component: TouchDashboardComponent, data: {home: '/touch'}}
+    ]
+  },
+  {
+    path: 'grocery',
+    component: GroceryLayoutComponent,
+    children: [
+      {path: '', component: GroceryHomeComponent, data: {home: '/'}},
+      {path: 'upload', component: ReceiptUploadComponent, data: {home: '/grocery'}},
+      {path: 'receipts', component: ReceiptListComponent, data: {home: '/grocery'}},
+      {path: 'receipts/:id/items', component: ReceiptItemsComponent, data: {home: '/grocery/receipts'}}
     ]
   }
 ];

--- a/src/app/grocery/components/grocery-home/grocery-home.component.css
+++ b/src/app/grocery/components/grocery-home/grocery-home.component.css
@@ -1,0 +1,163 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-g:  #f97316;  --cg-g: rgba(249, 115,  22, 0.18);
+  --c-a:  #4da6ff;  --cg-a: rgba(77,  166, 255, 0.18);
+
+  display: block;
+  height: 100%;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+}
+
+/* ── Nav Grid ────────────────────────────────────── */
+.navgrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.75rem;
+  padding: 1rem;
+  max-width: 640px;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+@media (min-width: 640px) {
+  .navgrid { gap: 1rem; padding: 1.5rem; }
+}
+
+/* ── Nav Cards ───────────────────────────────────── */
+.navcard {
+  position: relative;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.1rem 1rem 1.75rem;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  min-height: 140px;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
+  animation: fadeUp 0.5s ease both;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.navcard::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 0% 0%, var(--cc-glow, transparent) 0%, transparent 65%);
+  opacity: 0;
+  transition: opacity 0.25s;
+  pointer-events: none;
+}
+
+.navcard::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 22%;
+  bottom: 22%;
+  width: 2px;
+  background: var(--cc, transparent);
+  border-radius: 0 2px 2px 0;
+  opacity: 0.35;
+  transition: opacity 0.2s, top 0.2s, bottom 0.2s;
+}
+
+.navcard:hover {
+  border-color: var(--cc);
+  box-shadow: 0 8px 28px var(--cc-glow);
+  transform: translateY(-3px);
+}
+
+.navcard:hover::before { opacity: 1; }
+
+.navcard:hover::after {
+  opacity: 0.9;
+  top: 12%;
+  bottom: 12%;
+}
+
+.navcard:active { transform: translateY(-1px); }
+
+/* ── Card Accent Variants ────────────────────────── */
+.navcard--g { --cc: var(--c-g); --cc-glow: var(--cg-g); }
+.navcard--a { --cc: var(--c-a); --cc-glow: var(--cg-a); }
+
+/* ── Card Mark ───────────────────────────────────── */
+.navcard__mark {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--cc) 40%, transparent);
+  background: color-mix(in srgb, var(--cc) 10%, transparent);
+  display: grid;
+  place-items: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--cc);
+  flex-shrink: 0;
+  transition: background 0.2s;
+}
+
+.navcard:hover .navcard__mark {
+  background: color-mix(in srgb, var(--cc) 20%, transparent);
+}
+
+/* ── Card Text ───────────────────────────────────── */
+.navcard__title {
+  margin: 0;
+  font-size: clamp(0.95rem, 2.5vw, 1.1rem);
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1.25;
+  letter-spacing: 0.01em;
+}
+
+.navcard__sub {
+  margin: 0;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+  font-weight: 400;
+}
+
+/* ── Card Arrow ──────────────────────────────────── */
+.navcard__arrow {
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.875rem;
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  line-height: 1;
+  transition: color 0.2s, transform 0.2s;
+}
+
+.navcard:hover .navcard__arrow {
+  color: var(--cc);
+  transform: translate(2px, -2px);
+}
+
+/* ── Entrance Animations ─────────────────────────── */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.navcard:nth-child(1) { animation-delay: 0.05s; }
+.navcard:nth-child(2) { animation-delay: 0.12s; }

--- a/src/app/grocery/components/grocery-home/grocery-home.component.html
+++ b/src/app/grocery/components/grocery-home/grocery-home.component.html
@@ -1,0 +1,17 @@
+<div class="navgrid">
+
+  <a class="navcard navcard--g" routerLink="/grocery/upload">
+    <div class="navcard__mark">U</div>
+    <h2 class="navcard__title">Bon hochladen</h2>
+    <p class="navcard__sub">Kassenbon fotografieren & hochladen</p>
+    <span class="navcard__arrow" aria-hidden="true">↗</span>
+  </a>
+
+  <a class="navcard navcard--a" routerLink="/grocery/receipts">
+    <div class="navcard__mark">V</div>
+    <h2 class="navcard__title">Verlauf</h2>
+    <p class="navcard__sub">Gespeicherte Bons anzeigen</p>
+    <span class="navcard__arrow" aria-hidden="true">↗</span>
+  </a>
+
+</div>

--- a/src/app/grocery/components/grocery-home/grocery-home.component.ts
+++ b/src/app/grocery/components/grocery-home/grocery-home.component.ts
@@ -1,0 +1,10 @@
+import {Component} from '@angular/core';
+import {RouterLink} from '@angular/router';
+
+@Component({
+  selector: 'app-grocery-home',
+  imports: [RouterLink],
+  templateUrl: './grocery-home.component.html',
+  styleUrl: './grocery-home.component.css'
+})
+export class GroceryHomeComponent {}

--- a/src/app/grocery/components/grocery-layout/grocery-layout.component.css
+++ b/src/app/grocery/components/grocery-layout/grocery-layout.component.css
@@ -1,0 +1,130 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+/* ── Design Tokens ───────────────────────────────── */
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-g:  #f97316;  --cg-g: rgba(249, 115,  22, 0.18);
+  --c-a:  #4da6ff;  --cg-a: rgba(77,  166, 255, 0.18);
+  --c-p:  #22d35e;  --cg-p: rgba(34,  211,  94, 0.18);
+  --c-v:  #fbbf24;  --cg-v: rgba(251, 191,  36, 0.18);
+
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+  overflow: hidden;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+  background-color: var(--bg);
+  background-image:
+    radial-gradient(ellipse 70% 35% at 0% 0%,    rgba(249, 115,  22, 0.04) 0%, transparent 100%),
+    radial-gradient(ellipse 50% 35% at 100% 100%, rgba(77,  166, 255, 0.04) 0%, transparent 100%),
+    radial-gradient(circle, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+  background-size: auto, auto, 28px 28px;
+}
+
+/* ── Layout ──────────────────────────────────────── */
+.grocery-layout {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+/* ── Topbar ──────────────────────────────────────── */
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: max(0.5rem, env(safe-area-inset-top)) max(1rem, env(safe-area-inset-right)) 0.5rem max(1rem, env(safe-area-inset-left));
+  background: rgba(6, 8, 14, 0.88);
+  border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  box-shadow: 0 1px 0 rgba(249, 115, 22, 0.06);
+}
+
+.topbar__left {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.topbar__right {
+  width: 80px;
+}
+
+.topbar__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  color: var(--text-muted);
+}
+
+.topbar__hex {
+  color: var(--c-g);
+  font-size: 0.9rem;
+  filter: drop-shadow(0 0 6px rgba(249, 115, 22, 0.5));
+}
+
+/* ── Nav Buttons ─────────────────────────────────── */
+.nav-btn {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  padding: 0 !important;
+  color: var(--text-muted) !important;
+  border: 1px solid var(--border) !important;
+  border-radius: 8px !important;
+  width: 36px !important;
+  height: 36px !important;
+  transition: color 0.2s, border-color 0.2s, box-shadow 0.2s !important;
+}
+
+.nav-btn:hover {
+  color: var(--c-g) !important;
+  border-color: var(--c-g) !important;
+  box-shadow: 0 0 10px rgba(249, 115, 22, 0.2) !important;
+}
+
+/* ── Content ─────────────────────────────────────── */
+.content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* ── Menu Panel ──────────────────────────────────── */
+::ng-deep .mat-mdc-menu-panel {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 8px !important;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5) !important;
+}
+
+::ng-deep .mat-mdc-menu-item {
+  color: var(--text) !important;
+  font-family: 'Outfit', sans-serif !important;
+}
+
+::ng-deep .mat-mdc-menu-item:hover .mdc-list-item__primary-text {
+  color: var(--c-g) !important;
+}
+
+::ng-deep .mat-mdc-menu-item:hover {
+  background: var(--raised) !important;
+}

--- a/src/app/grocery/components/grocery-layout/grocery-layout.component.html
+++ b/src/app/grocery/components/grocery-layout/grocery-layout.component.html
@@ -1,0 +1,34 @@
+<div class="grocery-layout">
+  <header class="topbar">
+    <div class="topbar__left">
+      <button mat-icon-button [routerLink]="homeLink" class="nav-btn" aria-label="Go home">
+        <mat-icon>home</mat-icon>
+      </button>
+      <button mat-icon-button [matMenuTriggerFor]="menu" class="nav-btn" aria-label="Open menu">
+        <mat-icon>more_vert</mat-icon>
+      </button>
+      <mat-menu #menu="matMenu">
+        <button mat-menu-item routerLink="/grocery/upload">
+          <span>Bon hochladen</span>
+        </button>
+        <button mat-menu-item routerLink="/grocery/receipts">
+          <span>Verlauf</span>
+        </button>
+        <button mat-menu-item routerLink="/grocery">
+          <span>Home</span>
+        </button>
+      </mat-menu>
+    </div>
+
+    <div class="topbar__brand">
+      <span class="topbar__hex">⬡</span>
+      <span class="topbar__name">GROCERY</span>
+    </div>
+
+    <div class="topbar__right"></div>
+  </header>
+
+  <main class="content">
+    <router-outlet></router-outlet>
+  </main>
+</div>

--- a/src/app/grocery/components/grocery-layout/grocery-layout.component.ts
+++ b/src/app/grocery/components/grocery-layout/grocery-layout.component.ts
@@ -1,0 +1,41 @@
+import {Component} from '@angular/core';
+import {MatIconButton} from '@angular/material/button';
+import {MatIcon} from '@angular/material/icon';
+import {ActivatedRoute, NavigationEnd, Router, RouterLink, RouterOutlet} from '@angular/router';
+import {filter} from 'rxjs';
+import {MatMenu, MatMenuItem, MatMenuTrigger} from '@angular/material/menu';
+
+@Component({
+  selector: 'app-grocery-layout',
+  imports: [
+    MatIconButton,
+    MatIcon,
+    RouterLink,
+    RouterOutlet,
+    MatMenuTrigger,
+    MatMenu,
+    MatMenuItem
+  ],
+  templateUrl: './grocery-layout.component.html',
+  styleUrl: './grocery-layout.component.css'
+})
+export class GroceryLayoutComponent {
+
+  homeLink = '/';
+
+  constructor(private router: Router, private route: ActivatedRoute) {
+    this.router.events
+      .pipe(filter(event => event instanceof NavigationEnd))
+      .subscribe(() => {
+        const home = this.getDeepestChild(this.route).snapshot.data['home'];
+        this.homeLink = home || '/';
+      });
+  }
+
+  private getDeepestChild(route: ActivatedRoute): ActivatedRoute {
+    while (route.firstChild) {
+      route = route.firstChild;
+    }
+    return route;
+  }
+}

--- a/src/app/grocery/components/receipt-items/receipt-items.component.css
+++ b/src/app/grocery/components/receipt-items/receipt-items.component.css
@@ -1,0 +1,127 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-g:  #f97316;
+
+  display: block;
+  min-height: 100%;
+  background: var(--bg);
+  background-image:
+    radial-gradient(ellipse 80% 50% at 50% -10%, rgba(249, 115, 22, 0.06) 0%, transparent 70%);
+  background-attachment: fixed;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+  position: relative;
+}
+
+:host::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image: radial-gradient(circle, rgba(255,255,255,0.03) 1px, transparent 1px);
+  background-size: 28px 28px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.receipt-items {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 2rem 4rem;
+  gap: 1rem;
+}
+
+@media (max-width: 640px) {
+  .receipt-items { padding: 1rem; }
+}
+
+/* Header */
+.table-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.table-header__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--c-g);
+  box-shadow: 0 0 6px var(--c-g);
+  animation: blink 2s ease-in-out infinite;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+.table-header__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+}
+
+/* Table container */
+.table-container {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  max-height: 75vh;
+  overflow-y: auto;
+}
+
+.table-container::-webkit-scrollbar { width: 4px; }
+.table-container::-webkit-scrollbar-track { background: var(--surface); }
+.table-container::-webkit-scrollbar-thumb { background: var(--border-mid); border-radius: 2px; }
+
+table {
+  width: 100%;
+  background: transparent !important;
+}
+
+.col-header {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.6rem !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.12em !important;
+  text-transform: uppercase !important;
+  color: var(--text-dim) !important;
+  background: var(--raised) !important;
+  border-bottom: 1px solid var(--border-mid) !important;
+  height: 36px !important;
+  padding: 0 16px !important;
+}
+
+::ng-deep .mat-mdc-header-row {
+  background: var(--raised) !important;
+}
+
+::ng-deep .mat-mdc-cell {
+  font-size: 0.8rem !important;
+  color: var(--text) !important;
+  background: transparent !important;
+  border-bottom: 1px solid var(--border) !important;
+}
+
+.mat-column-price {
+  text-align: right;
+  padding-right: 1rem !important;
+}

--- a/src/app/grocery/components/receipt-items/receipt-items.component.html
+++ b/src/app/grocery/components/receipt-items/receipt-items.component.html
@@ -1,0 +1,27 @@
+<div class="receipt-items">
+  <header class="table-header">
+    <span class="table-header__dot"></span>
+    <span class="table-header__label">ARTIKEL</span>
+  </header>
+
+  <div class="table-container">
+    <table mat-table [dataSource]="items">
+
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef class="col-header">Artikel</th>
+        <td mat-cell *matCellDef="let item">{{ item.name }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="price">
+        <th mat-header-cell *matHeaderCellDef class="col-header">Preis</th>
+        <td mat-cell *matCellDef="let item">
+          {{ item.price | currency:'EUR':'symbol':'1.2-2':'de' }}
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
+      <tr mat-row *matRowDef="let item; columns: columnsToDisplay;"></tr>
+
+    </table>
+  </div>
+</div>

--- a/src/app/grocery/components/receipt-items/receipt-items.component.ts
+++ b/src/app/grocery/components/receipt-items/receipt-items.component.ts
@@ -1,0 +1,57 @@
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit} from '@angular/core';
+import {
+  MatCell,
+  MatCellDef,
+  MatColumnDef,
+  MatHeaderCell,
+  MatHeaderCellDef,
+  MatHeaderRow,
+  MatHeaderRowDef,
+  MatRow,
+  MatRowDef,
+  MatTable,
+  MatTableDataSource
+} from '@angular/material/table';
+import {CurrencyPipe} from '@angular/common';
+import {ActivatedRoute} from '@angular/router';
+import {ReceiptItem} from '../../models/receipt.model';
+import {ReceiptService} from '../../services/receipt.service';
+
+@Component({
+  selector: 'app-receipt-items',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    MatTable,
+    MatColumnDef,
+    MatHeaderCell,
+    MatHeaderCellDef,
+    MatCellDef,
+    MatCell,
+    MatHeaderRow,
+    MatHeaderRowDef,
+    MatRow,
+    MatRowDef,
+    CurrencyPipe
+  ],
+  templateUrl: './receipt-items.component.html',
+  styleUrl: './receipt-items.component.css'
+})
+export class ReceiptItemsComponent implements OnInit {
+
+  items = new MatTableDataSource<ReceiptItem>();
+  columnsToDisplay = ['name', 'price'];
+
+  constructor(
+    private receiptService: ReceiptService,
+    private route: ActivatedRoute,
+    private cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('id')!;
+    this.receiptService.getReceiptItems(id).subscribe(items => {
+      this.items.data = items;
+      this.cdr.markForCheck();
+    });
+  }
+}

--- a/src/app/grocery/components/receipt-list/receipt-list.component.css
+++ b/src/app/grocery/components/receipt-list/receipt-list.component.css
@@ -1,0 +1,136 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-g:  #f97316;
+
+  display: block;
+  min-height: 100%;
+  background: var(--bg);
+  background-image:
+    radial-gradient(ellipse 80% 50% at 50% -10%, rgba(249, 115, 22, 0.06) 0%, transparent 70%),
+    radial-gradient(circle at 85% 85%, rgba(77, 166, 255, 0.04) 0%, transparent 50%);
+  background-attachment: fixed;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+  position: relative;
+}
+
+:host::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image: radial-gradient(circle, rgba(255,255,255,0.03) 1px, transparent 1px);
+  background-size: 28px 28px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.receipt-list {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 2rem 4rem;
+  gap: 1rem;
+}
+
+@media (max-width: 640px) {
+  .receipt-list { padding: 1rem; }
+}
+
+/* Header */
+.table-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.table-header__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--c-g);
+  box-shadow: 0 0 6px var(--c-g);
+  animation: blink 2s ease-in-out infinite;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+.table-header__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+}
+
+/* Table container */
+.table-container {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  max-height: 75vh;
+  overflow-y: auto;
+}
+
+.table-container::-webkit-scrollbar { width: 4px; }
+.table-container::-webkit-scrollbar-track { background: var(--surface); }
+.table-container::-webkit-scrollbar-thumb { background: var(--border-mid); border-radius: 2px; }
+
+table {
+  width: 100%;
+  background: transparent !important;
+}
+
+.col-header {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.6rem !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.12em !important;
+  text-transform: uppercase !important;
+  color: var(--text-dim) !important;
+  background: var(--raised) !important;
+  border-bottom: 1px solid var(--border-mid) !important;
+  height: 36px !important;
+  padding: 0 16px !important;
+}
+
+::ng-deep .mat-mdc-header-row {
+  background: var(--raised) !important;
+}
+
+::ng-deep .mat-mdc-cell {
+  font-size: 0.8rem !important;
+  color: var(--text) !important;
+  background: transparent !important;
+  border-bottom: 1px solid var(--border) !important;
+}
+
+.clickable-row {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.clickable-row:hover {
+  background-color: rgba(249, 115, 22, 0.08) !important;
+}
+
+.clickable-row:hover ::ng-deep .mat-mdc-cell {
+  background-color: transparent !important;
+}

--- a/src/app/grocery/components/receipt-list/receipt-list.component.html
+++ b/src/app/grocery/components/receipt-list/receipt-list.component.html
@@ -1,0 +1,45 @@
+<div class="receipt-list">
+  <header class="table-header">
+    <span class="table-header__dot"></span>
+    <span class="table-header__label">VERLAUF</span>
+  </header>
+
+  <div class="table-container">
+    <table mat-table [dataSource]="receipts">
+
+      <ng-container matColumnDef="receiptDate">
+        <th mat-header-cell *matHeaderCellDef class="col-header">Bon-Datum</th>
+        <td mat-cell *matCellDef="let receipt">
+          {{ (receipt.receiptDate ?? receipt.creationDate) | date:'dd.MM.yyyy' }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="creationDate">
+        <th mat-header-cell *matHeaderCellDef class="col-header">Hochgeladen</th>
+        <td mat-cell *matCellDef="let receipt">
+          {{ receipt.creationDate | date:'dd.MM.yyyy HH:mm' }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="totalAmount">
+        <th mat-header-cell *matHeaderCellDef class="col-header">Gesamt</th>
+        <td mat-cell *matCellDef="let receipt">
+          @if (receipt.totalAmount !== null) {
+            {{ receipt.totalAmount | currency:'EUR':'symbol':'1.2-2':'de' }}
+          } @else {
+            —
+          }
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
+      <tr
+        mat-row
+        *matRowDef="let receipt; columns: columnsToDisplay;"
+        class="clickable-row"
+        (click)="navigateToItems(receipt.id)">
+      </tr>
+
+    </table>
+  </div>
+</div>

--- a/src/app/grocery/components/receipt-list/receipt-list.component.ts
+++ b/src/app/grocery/components/receipt-list/receipt-list.component.ts
@@ -1,0 +1,61 @@
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit} from '@angular/core';
+import {
+  MatCell,
+  MatCellDef,
+  MatColumnDef,
+  MatHeaderCell,
+  MatHeaderCellDef,
+  MatHeaderRow,
+  MatHeaderRowDef,
+  MatRow,
+  MatRowDef,
+  MatTable,
+  MatTableDataSource
+} from '@angular/material/table';
+import {CurrencyPipe, DatePipe} from '@angular/common';
+import {Router} from '@angular/router';
+import {Receipt} from '../../models/receipt.model';
+import {ReceiptService} from '../../services/receipt.service';
+
+@Component({
+  selector: 'app-receipt-list',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    MatTable,
+    MatColumnDef,
+    MatHeaderCell,
+    MatHeaderCellDef,
+    MatCellDef,
+    MatCell,
+    MatHeaderRow,
+    MatHeaderRowDef,
+    MatRow,
+    MatRowDef,
+    DatePipe,
+    CurrencyPipe
+  ],
+  templateUrl: './receipt-list.component.html',
+  styleUrl: './receipt-list.component.css'
+})
+export class ReceiptListComponent implements OnInit {
+
+  receipts = new MatTableDataSource<Receipt>();
+  columnsToDisplay = ['receiptDate', 'creationDate', 'totalAmount'];
+
+  constructor(
+    private receiptService: ReceiptService,
+    private router: Router,
+    private cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit(): void {
+    this.receiptService.getReceipts().subscribe(receipts => {
+      this.receipts.data = receipts;
+      this.cdr.markForCheck();
+    });
+  }
+
+  navigateToItems(id: string): void {
+    void this.router.navigate(['/grocery/receipts', id, 'items']);
+  }
+}

--- a/src/app/grocery/components/receipt-upload/receipt-upload.component.css
+++ b/src/app/grocery/components/receipt-upload/receipt-upload.component.css
@@ -1,0 +1,149 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-g:  #f97316;  --cg-g: rgba(249, 115,  22, 0.18);
+
+  display: block;
+  min-height: 100%;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+  background: var(--bg);
+  background-image:
+    radial-gradient(ellipse 80% 50% at 50% -10%, rgba(249, 115, 22, 0.06) 0%, transparent 70%);
+  background-attachment: fixed;
+}
+
+.upload-page {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+.upload-card {
+  width: 100%;
+  max-width: 480px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.upload-card__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--raised);
+}
+
+.upload-card__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--c-g);
+  box-shadow: 0 0 6px var(--c-g);
+  animation: blink 2s ease-in-out infinite;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+.upload-card__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--text-dim);
+}
+
+.upload-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem 1.25rem;
+}
+
+/* File label */
+.file-label {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 2rem 1rem;
+  background: var(--raised);
+  border: 1px dashed var(--border-mid);
+  border-radius: 10px;
+  cursor: pointer;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.file-label:hover,
+.file-label--selected {
+  border-color: var(--c-g);
+  background: rgba(249, 115, 22, 0.04);
+}
+
+.file-input {
+  display: none;
+}
+
+.file-label__icon {
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.file-label__text {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-align: center;
+  word-break: break-all;
+}
+
+.file-label--selected .file-label__text {
+  color: var(--c-g);
+}
+
+/* Progress bar */
+.progress {
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+/* Submit button */
+.submit-btn {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: var(--c-g);
+  color: #000;
+  border: none;
+  border-radius: 8px;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: opacity 0.2s, transform 0.1s;
+}
+
+.submit-btn:hover:not(:disabled) {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+
+.submit-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}

--- a/src/app/grocery/components/receipt-upload/receipt-upload.component.html
+++ b/src/app/grocery/components/receipt-upload/receipt-upload.component.html
@@ -1,0 +1,36 @@
+<div class="upload-page">
+  <div class="upload-card">
+    <header class="upload-card__header">
+      <span class="upload-card__dot"></span>
+      <span class="upload-card__label">KASSENBON HOCHLADEN</span>
+    </header>
+
+    <div class="upload-card__body">
+      <label class="file-label" [class.file-label--selected]="selectedFile">
+        <input
+          type="file"
+          accept="image/*"
+          capture="environment"
+          (change)="onFileSelected($event)"
+          class="file-input"
+        />
+        <span class="file-label__icon">{{ selectedFile ? '✓' : '📷' }}</span>
+        <span class="file-label__text">
+          {{ selectedFile ? selectedFile.name : 'Bon auswählen oder fotografieren' }}
+        </span>
+      </label>
+
+      @if (uploading) {
+        <mat-progress-bar mode="indeterminate" class="progress"></mat-progress-bar>
+      }
+
+      <button
+        class="submit-btn"
+        [disabled]="!selectedFile || uploading"
+        (click)="onSubmit()"
+      >
+        {{ uploading ? 'Wird hochgeladen…' : 'Hochladen' }}
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/app/grocery/components/receipt-upload/receipt-upload.component.ts
+++ b/src/app/grocery/components/receipt-upload/receipt-upload.component.ts
@@ -1,0 +1,43 @@
+import {Component} from '@angular/core';
+import {Router} from '@angular/router';
+import {MatProgressBar} from '@angular/material/progress-bar';
+import {ReceiptService} from '../../services/receipt.service';
+
+@Component({
+  selector: 'app-receipt-upload',
+  imports: [MatProgressBar],
+  templateUrl: './receipt-upload.component.html',
+  styleUrl: './receipt-upload.component.css'
+})
+export class ReceiptUploadComponent {
+
+  selectedFile: File | null = null;
+  uploading = false;
+
+  constructor(private receiptService: ReceiptService, private router: Router) {}
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (input.files?.length) {
+      this.selectedFile = input.files[0];
+    }
+  }
+
+  onSubmit(): void {
+    if (!this.selectedFile) return;
+    this.uploading = true;
+    this.receiptService.uploadReceipt(this.selectedFile).subscribe({
+      next: (response) => {
+        const location = response.headers.get('Location');
+        const id = location?.split('/receipts/')[1];
+        this.uploading = false;
+        if (id) {
+          void this.router.navigate(['/grocery/receipts', id, 'items']);
+        }
+      },
+      error: () => {
+        this.uploading = false;
+      }
+    });
+  }
+}

--- a/src/app/grocery/models/receipt.model.ts
+++ b/src/app/grocery/models/receipt.model.ts
@@ -1,0 +1,13 @@
+export interface Receipt {
+  id: string;
+  receiptDate: string | null;
+  totalAmount: number | null;
+  creationDate: string;
+  items?: ReceiptItem[];
+}
+
+export interface ReceiptItem {
+  id: string;
+  name: string;
+  price: number;
+}

--- a/src/app/grocery/services/receipt.service.ts
+++ b/src/app/grocery/services/receipt.service.ts
@@ -1,0 +1,29 @@
+import {Injectable} from '@angular/core';
+import {HttpClient, HttpResponse} from '@angular/common/http';
+import {Observable} from 'rxjs';
+import {environment} from '../../../environments/environment';
+import {Receipt, ReceiptItem} from '../models/receipt.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ReceiptService {
+
+  private host = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  uploadReceipt(file: File): Observable<HttpResponse<any>> {
+    const formData = new FormData();
+    formData.append('file', file);
+    return this.http.post<any>(`${this.host}/receipts`, formData, {observe: 'response'});
+  }
+
+  getReceipts(): Observable<Receipt[]> {
+    return this.http.get<Receipt[]>(`${this.host}/receipts`);
+  }
+
+  getReceiptItems(id: string): Observable<ReceiptItem[]> {
+    return this.http.get<ReceiptItem[]>(`${this.host}/receipts/${id}/items`);
+  }
+}

--- a/src/app/home/home.component.css
+++ b/src/app/home/home.component.css
@@ -19,6 +19,7 @@
   --c-m:  #a78bfa;  --cg-m: rgba(167, 139, 250, 0.18);
   --c-e:  #fb7185;  --cg-e: rgba(251, 113, 133, 0.18);
   --c-n:  #2dd4bf;  --cg-n: rgba(45,  212, 191, 0.18);
+  --c-g:  #f97316;  --cg-g: rgba(249, 115,  22, 0.18);
 
   display: block;
   min-height: 100dvh;
@@ -196,6 +197,7 @@
 .navcard--m { --cc: var(--c-m); --cc-glow: var(--cg-m); }
 .navcard--e { --cc: var(--c-e); --cc-glow: var(--cg-e); }
 .navcard--n { --cc: var(--c-n); --cc-glow: var(--cg-n); }
+.navcard--g { --cc: var(--c-g); --cc-glow: var(--cg-g); }
 
 /* ── Card Mark ───────────────────────────────────── */
 .navcard__mark {
@@ -362,3 +364,4 @@
 .navcard:nth-child(4)  { animation-delay: 0.26s; }
 .navcard:nth-child(5)  { animation-delay: 0.33s; }
 .navcard:nth-child(6)  { animation-delay: 0.40s; }
+.navcard:nth-child(7)  { animation-delay: 0.47s; }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -93,6 +93,13 @@
           <span class="navcard__arrow" aria-hidden="true">↗</span>
         </a>
 
+        <a class="navcard navcard--g" routerLink="/grocery">
+          <div class="navcard__mark">G</div>
+          <h2 class="navcard__title">Grocery</h2>
+          <p class="navcard__sub">Receipt scanner</p>
+          <span class="navcard__arrow" aria-hidden="true">↗</span>
+        </a>
+
       </div>
     </main>
 


### PR DESCRIPTION
## Summary

Implements issue #128 — full grocery receipt scanner module.

- `GroceryLayoutComponent` — topbar with nav menu, mirrors PlantLayoutComponent pattern
- `GroceryHomeComponent` — landing page with "Bon hochladen" and "Verlauf" buttons
- `ReceiptUploadComponent` — file input with `capture="environment"` for rear camera on mobile, `MatProgressBar` spinner during upload, navigates to items view on success using UUID from `Location` header
- `ReceiptListComponent` — `MatTable` of past receipts (date, upload time, total); row click navigates to items; `OnPush` CD
- `ReceiptItemsComponent` — `MatTable` of items for one receipt (name + price formatted as EUR); `OnPush` CD
- `ReceiptService` — `uploadReceipt`, `getReceipts`, `getReceiptItems` wired to `/receipts` API
- `Receipt` / `ReceiptItem` models
- Routing added under `/grocery` in `app.routes.ts`
- Grocery nav card (orange accent) added to home dashboard

## Test plan

- [ ] Home dashboard shows new "Grocery" card with orange glow
- [ ] `/grocery` renders home page with two action cards
- [ ] `/grocery/upload` shows file picker; selecting a file enables submit button; uploading shows progress bar
- [ ] Successful upload navigates to `/grocery/receipts/:id/items`
- [ ] `/grocery/receipts` shows table of past receipts; clicking a row navigates to items view
- [ ] `/grocery/receipts/:id/items` shows item name and EUR-formatted price
- [ ] Menu back-navigation uses correct `home` data per route

🤖 Generated with [Claude Code](https://claude.com/claude-code)