### PR TITLE
fix(docker): suppress npm deprecation warnings from karma transitive deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY package*.json ./
 
-RUN npm install
+RUN npm ci --loglevel=error
 
 COPY . .
 


### PR DESCRIPTION
## Summary
- Switch `npm install` → `npm ci` for reproducible, lock-file-based Docker builds
- Add `--loglevel=error` to suppress `rimraf@3` and `inflight` deprecation warnings that come from karma's pinned transitive dependencies

## Test plan
- [ ] Docker build completes without deprecation warnings
- [ ] Angular app loads correctly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)