### PR TITLE
feat(grocery): show quantity and single price in receipt items table

### DIFF
--- a/src/app/grocery/components/receipt-items/receipt-items.component.html
+++ b/src/app/grocery/components/receipt-items/receipt-items.component.html
@@ -12,6 +12,18 @@
         <td mat-cell *matCellDef="let item">{{ item.name }}</td>
       </ng-container>
 
+      <ng-container matColumnDef="quantity">
+        <th mat-header-cell *matHeaderCellDef class="col-header">Menge</th>
+        <td mat-cell *matCellDef="let item">{{ item.quantity }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="singlePrice">
+        <th mat-header-cell *matHeaderCellDef class="col-header">Einzelpreis</th>
+        <td mat-cell *matCellDef="let item">
+          {{ item.singlePrice | currency:'EUR':'symbol':'1.2-2':'de' }}
+        </td>
+      </ng-container>
+
       <ng-container matColumnDef="price">
         <th mat-header-cell *matHeaderCellDef class="col-header">Preis</th>
         <td mat-cell *matCellDef="let item">

--- a/src/app/grocery/components/receipt-items/receipt-items.component.ts
+++ b/src/app/grocery/components/receipt-items/receipt-items.component.ts
@@ -39,7 +39,7 @@ import {ReceiptService} from '../../services/receipt.service';
 export class ReceiptItemsComponent implements OnInit {
 
   items = new MatTableDataSource<ReceiptItem>();
-  columnsToDisplay = ['name', 'price'];
+  columnsToDisplay = ['name', 'quantity', 'singlePrice', 'price'];
 
   constructor(
     private receiptService: ReceiptService,

--- a/src/app/grocery/models/receipt.model.ts
+++ b/src/app/grocery/models/receipt.model.ts
@@ -9,5 +9,7 @@ export interface Receipt {
 export interface ReceiptItem {
   id: string;
   name: string;
+  singlePrice: number;
+  quantity: number;
   price: number;
 }


### PR DESCRIPTION
## Summary
- Adds `singlePrice` and `quantity` fields to the `ReceiptItem` model
- Extends the receipt items table with two new columns: **Menge** (quantity) and **Einzelpreis** (single price, formatted as €)
- The existing **Preis** (total price) column remains unchanged

Closes #131

## Test plan
- [ ] Navigate to a receipt's items view — the table now shows Menge, Einzelpreis, and Preis columns
- [ ] Verify currency formatting on Einzelpreis matches the existing Preis column

🤖 Generated with [Claude Code](https://claude.com/claude-code)