### PR TITLE
feat(grocery): add delete button for receipts

### DIFF
--- a/src/app/grocery/components/receipt-list/receipt-list.component.css
+++ b/src/app/grocery/components/receipt-list/receipt-list.component.css
@@ -134,3 +134,18 @@ table {
 .clickable-row:hover ::ng-deep .mat-mdc-cell {
   background-color: transparent !important;
 }
+
+.col-actions {
+  width: 48px;
+  padding: 0 4px !important;
+  text-align: right;
+}
+
+.btn-delete {
+  color: rgba(251, 113, 133, 0.5) !important;
+  transition: color 0.2s;
+}
+
+.btn-delete:hover {
+  color: #fb7185 !important;
+}

--- a/src/app/grocery/components/receipt-list/receipt-list.component.html
+++ b/src/app/grocery/components/receipt-list/receipt-list.component.html
@@ -32,6 +32,15 @@
         </td>
       </ng-container>
 
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef class="col-header"></th>
+        <td mat-cell *matCellDef="let receipt" class="col-actions">
+          <button mat-icon-button class="btn-delete" (click)="openDeleteDialog($event, receipt)" title="Bon löschen">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+
       <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
       <tr
         mat-row

--- a/src/app/grocery/components/receipt-list/receipt-list.component.ts
+++ b/src/app/grocery/components/receipt-list/receipt-list.component.ts
@@ -14,8 +14,13 @@ import {
 } from '@angular/material/table';
 import {CurrencyPipe, DatePipe} from '@angular/common';
 import {Router} from '@angular/router';
+import {MatDialog} from '@angular/material/dialog';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {MatIconButton} from '@angular/material/button';
+import {MatIcon} from '@angular/material/icon';
 import {Receipt} from '../../models/receipt.model';
 import {ReceiptService} from '../../services/receipt.service';
+import {ReceiptDeleteDialogComponent} from '../../dialogs/receipt-delete-dialog/receipt-delete-dialog.component';
 
 @Component({
   selector: 'app-receipt-list',
@@ -32,7 +37,9 @@ import {ReceiptService} from '../../services/receipt.service';
     MatRow,
     MatRowDef,
     DatePipe,
-    CurrencyPipe
+    CurrencyPipe,
+    MatIconButton,
+    MatIcon
   ],
   templateUrl: './receipt-list.component.html',
   styleUrl: './receipt-list.component.css'
@@ -40,11 +47,13 @@ import {ReceiptService} from '../../services/receipt.service';
 export class ReceiptListComponent implements OnInit {
 
   receipts = new MatTableDataSource<Receipt>();
-  columnsToDisplay = ['receiptDate', 'creationDate', 'totalAmount'];
+  columnsToDisplay = ['receiptDate', 'creationDate', 'totalAmount', 'actions'];
 
   constructor(
     private receiptService: ReceiptService,
     private router: Router,
+    private dialog: MatDialog,
+    private snackBar: MatSnackBar,
     private cdr: ChangeDetectorRef
   ) {}
 
@@ -57,5 +66,24 @@ export class ReceiptListComponent implements OnInit {
 
   navigateToItems(id: string): void {
     void this.router.navigate(['/grocery/receipts', id, 'items']);
+  }
+
+  openDeleteDialog(event: MouseEvent, receipt: Receipt): void {
+    event.stopPropagation();
+    const ref = this.dialog.open(ReceiptDeleteDialogComponent);
+    ref.afterClosed().subscribe(result => {
+      if (result === 'confirmed') {
+        this.receiptService.deleteReceipt(receipt.id).subscribe({
+          next: () => {
+            this.receipts.data = this.receipts.data.filter(r => r.id !== receipt.id);
+            this.cdr.markForCheck();
+          },
+          error: (err) => {
+            const msg = err.status === 404 ? 'Bon nicht gefunden' : 'Bon konnte nicht gelöscht werden';
+            this.snackBar.open(msg, 'Schließen', {duration: 5000});
+          }
+        });
+      }
+    });
   }
 }

--- a/src/app/grocery/dialogs/receipt-delete-dialog/receipt-delete-dialog.component.css
+++ b/src/app/grocery/dialogs/receipt-delete-dialog/receipt-delete-dialog.component.css
@@ -1,0 +1,69 @@
+:host {
+  --surface:     #0c1018;
+  --border-mid:  rgba(255, 255, 255, 0.13);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --c-n:         #2dd4bf;
+  --c-e:         #fb7185;
+}
+
+::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-dialog-title {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
+  color: var(--text) !important;
+  letter-spacing: 0.03em;
+}
+
+::ng-deep .mat-mdc-dialog-content {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.9rem !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions {
+  gap: 10px;
+  padding-bottom: 16px !important;
+  justify-content: center !important;
+}
+
+.btn-confirm {
+  background: rgba(45, 212, 191, 0.10) !important;
+  border: 1px solid rgba(45, 212, 191, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-n) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-confirm:hover {
+  background: rgba(45, 212, 191, 0.18) !important;
+  box-shadow: 0 0 12px rgba(45, 212, 191, 0.25) !important;
+}
+
+.btn-confirm mat-icon {
+  color: var(--c-n) !important;
+}
+
+.btn-cancel {
+  background: rgba(251, 113, 133, 0.10) !important;
+  border: 1px solid rgba(251, 113, 133, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-e) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-cancel:hover {
+  background: rgba(251, 113, 133, 0.18) !important;
+  box-shadow: 0 0 12px rgba(251, 113, 133, 0.25) !important;
+}
+
+.btn-cancel mat-icon {
+  color: var(--c-e) !important;
+}

--- a/src/app/grocery/dialogs/receipt-delete-dialog/receipt-delete-dialog.component.html
+++ b/src/app/grocery/dialogs/receipt-delete-dialog/receipt-delete-dialog.component.html
@@ -1,0 +1,14 @@
+<h2 mat-dialog-title>Bon löschen</h2>
+
+<mat-dialog-content>
+  <span>Diesen Bon wirklich löschen?</span>
+</mat-dialog-content>
+
+<mat-dialog-actions align="center">
+  <button mat-mini-fab class="btn-confirm" (click)="confirm()">
+    <mat-icon>check_circle</mat-icon>
+  </button>
+  <button mat-mini-fab mat-dialog-close class="btn-cancel">
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-dialog-actions>

--- a/src/app/grocery/dialogs/receipt-delete-dialog/receipt-delete-dialog.component.ts
+++ b/src/app/grocery/dialogs/receipt-delete-dialog/receipt-delete-dialog.component.ts
@@ -1,0 +1,26 @@
+import {Component} from '@angular/core';
+import {MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MatIcon} from '@angular/material/icon';
+import {MatMiniFabButton} from '@angular/material/button';
+
+@Component({
+  selector: 'app-receipt-delete-dialog',
+  imports: [
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatIcon,
+    MatMiniFabButton
+  ],
+  templateUrl: './receipt-delete-dialog.component.html',
+  styleUrl: './receipt-delete-dialog.component.css'
+})
+export class ReceiptDeleteDialogComponent {
+
+  constructor(private dialogRef: MatDialogRef<ReceiptDeleteDialogComponent>) {}
+
+  confirm() {
+    this.dialogRef.close('confirmed');
+  }
+}

--- a/src/app/grocery/services/receipt.service.ts
+++ b/src/app/grocery/services/receipt.service.ts
@@ -26,4 +26,8 @@ export class ReceiptService {
   getReceiptItems(id: string): Observable<ReceiptItem[]> {
     return this.http.get<ReceiptItem[]>(`${this.host}/receipts/${id}/items`);
   }
+
+  deleteReceipt(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.host}/receipts/${id}`);
+  }
 }


### PR DESCRIPTION
## Summary
- Adds a trash icon button per receipt row in the receipt list table
- Opens a confirmation dialog (Bon löschen) before calling `DELETE /receipts/{id}`
- On 204: removes the entry from the list without a reload
- On 404: shows a German-language error snackbar

Closes #133

## Test plan
- [ ] Navigate to `/grocery`, verify each receipt row now has a delete icon on the right
- [ ] Click delete icon — confirm dialog appears, cancel keeps the row
- [ ] Confirm deletion — row disappears from the list (204 path)
- [ ] Mock/force a 404 response — snackbar shows "Bon nicht gefunden"
- [ ] Clicking the delete button does not navigate to the receipt items view (stopPropagation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)