### PR TITLE
feat(grocery): add edit dialog for receipt items

### DIFF
--- a/src/app/grocery/components/receipt-items/receipt-items.component.css
+++ b/src/app/grocery/components/receipt-items/receipt-items.component.css
@@ -125,3 +125,18 @@ table {
   text-align: right;
   padding-right: 1rem !important;
 }
+
+.mat-column-actions {
+  width: 48px;
+  text-align: right;
+  padding-right: 8px !important;
+}
+
+.btn-edit {
+  color: var(--text-dim);
+  transition: color 0.2s;
+}
+
+.btn-edit:hover {
+  color: var(--c-g);
+}

--- a/src/app/grocery/components/receipt-items/receipt-items.component.html
+++ b/src/app/grocery/components/receipt-items/receipt-items.component.html
@@ -31,6 +31,15 @@
         </td>
       </ng-container>
 
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef class="col-header"></th>
+        <td mat-cell *matCellDef="let item" class="col-actions">
+          <button mat-icon-button class="btn-edit" (click)="openEditDialog(item)">
+            <mat-icon>edit</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+
       <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
       <tr mat-row *matRowDef="let item; columns: columnsToDisplay;"></tr>
 

--- a/src/app/grocery/components/receipt-items/receipt-items.component.ts
+++ b/src/app/grocery/components/receipt-items/receipt-items.component.ts
@@ -14,8 +14,13 @@ import {
 } from '@angular/material/table';
 import {CurrencyPipe} from '@angular/common';
 import {ActivatedRoute} from '@angular/router';
+import {MatDialog} from '@angular/material/dialog';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {MatIconButton} from '@angular/material/button';
+import {MatIcon} from '@angular/material/icon';
 import {ReceiptItem} from '../../models/receipt.model';
 import {ReceiptService} from '../../services/receipt.service';
+import {ReceiptItemEditDialogComponent} from '../../dialogs/receipt-item-edit-dialog/receipt-item-edit-dialog.component';
 
 @Component({
   selector: 'app-receipt-items',
@@ -31,7 +36,9 @@ import {ReceiptService} from '../../services/receipt.service';
     MatHeaderRowDef,
     MatRow,
     MatRowDef,
-    CurrencyPipe
+    CurrencyPipe,
+    MatIconButton,
+    MatIcon
   ],
   templateUrl: './receipt-items.component.html',
   styleUrl: './receipt-items.component.css'
@@ -39,19 +46,38 @@ import {ReceiptService} from '../../services/receipt.service';
 export class ReceiptItemsComponent implements OnInit {
 
   items = new MatTableDataSource<ReceiptItem>();
-  columnsToDisplay = ['name', 'quantity', 'singlePrice', 'price'];
+  columnsToDisplay = ['name', 'quantity', 'singlePrice', 'price', 'actions'];
+  receiptId = '';
 
   constructor(
     private receiptService: ReceiptService,
     private route: ActivatedRoute,
+    private dialog: MatDialog,
+    private snackBar: MatSnackBar,
     private cdr: ChangeDetectorRef
   ) {}
 
   ngOnInit(): void {
-    const id = this.route.snapshot.paramMap.get('id')!;
-    this.receiptService.getReceiptItems(id).subscribe(items => {
+    this.receiptId = this.route.snapshot.paramMap.get('id')!;
+    this.receiptService.getReceiptItems(this.receiptId).subscribe(items => {
       this.items.data = items;
       this.cdr.markForCheck();
+    });
+  }
+
+  openEditDialog(item: ReceiptItem): void {
+    const ref = this.dialog.open(ReceiptItemEditDialogComponent, {data: item});
+    ref.afterClosed().subscribe((result: ReceiptItem | undefined) => {
+      if (!result) return;
+      this.receiptService.updateReceiptItem(this.receiptId, result).subscribe({
+        next: (updated) => {
+          this.items.data = this.items.data.map(i => i.id === updated.id ? updated : i);
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.snackBar.open('Artikel konnte nicht gespeichert werden', 'Schließen', {duration: 5000});
+        }
+      });
     });
   }
 }

--- a/src/app/grocery/dialogs/receipt-item-edit-dialog/receipt-item-edit-dialog.component.css
+++ b/src/app/grocery/dialogs/receipt-item-edit-dialog/receipt-item-edit-dialog.component.css
@@ -1,0 +1,149 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+  --c-g:         #f97316;
+  --c-n:         #2dd4bf;
+  --c-e:         #fb7185;
+}
+
+::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+  min-width: 360px !important;
+}
+
+::ng-deep .mat-mdc-dialog-title {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
+  color: var(--text) !important;
+  letter-spacing: 0.03em;
+}
+
+::ng-deep .mat-mdc-dialog-content {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.9rem !important;
+  overflow: visible !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions {
+  gap: 10px;
+  padding-bottom: 16px !important;
+  justify-content: center !important;
+}
+
+/* Form layout */
+.edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.5rem;
+}
+
+.field-full { width: 100%; }
+
+.field-row {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.field-half { flex: 1; }
+
+/* Dark theme form fields */
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__trailing {
+  border-color: var(--border-mid) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined:not(.mdc-text-field--disabled) .mdc-text-field__input {
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-mdc-floating-label {
+  color: var(--text-dim) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__trailing {
+  border-color: var(--c-g) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mat-mdc-floating-label {
+  color: var(--c-g) !important;
+}
+
+/* Calculated price display */
+.price-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  background: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-top: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.price-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.price-value {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--c-g);
+}
+
+/* Buttons */
+.btn-confirm {
+  background: rgba(45, 212, 191, 0.10) !important;
+  border: 1px solid rgba(45, 212, 191, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-n) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-confirm:hover:not([disabled]) {
+  background: rgba(45, 212, 191, 0.18) !important;
+  box-shadow: 0 0 12px rgba(45, 212, 191, 0.25) !important;
+}
+
+.btn-confirm[disabled] {
+  opacity: 0.4 !important;
+}
+
+.btn-confirm mat-icon { color: var(--c-n) !important; }
+
+.btn-cancel {
+  background: rgba(251, 113, 133, 0.10) !important;
+  border: 1px solid rgba(251, 113, 133, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-e) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-cancel:hover {
+  background: rgba(251, 113, 133, 0.18) !important;
+  box-shadow: 0 0 12px rgba(251, 113, 133, 0.25) !important;
+}
+
+.btn-cancel mat-icon { color: var(--c-e) !important; }

--- a/src/app/grocery/dialogs/receipt-item-edit-dialog/receipt-item-edit-dialog.component.html
+++ b/src/app/grocery/dialogs/receipt-item-edit-dialog/receipt-item-edit-dialog.component.html
@@ -1,0 +1,36 @@
+<h2 mat-dialog-title>Artikel bearbeiten</h2>
+
+<mat-dialog-content>
+  <form [formGroup]="form" class="edit-form">
+    <mat-form-field appearance="outline" class="field-full">
+      <mat-label>Artikel</mat-label>
+      <input matInput formControlName="name" />
+    </mat-form-field>
+
+    <div class="field-row">
+      <mat-form-field appearance="outline" class="field-half">
+        <mat-label>Menge</mat-label>
+        <input matInput type="number" formControlName="quantity" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="field-half">
+        <mat-label>Einzelpreis (€)</mat-label>
+        <input matInput type="number" step="0.01" formControlName="singlePrice" />
+      </mat-form-field>
+    </div>
+
+    <div class="price-row">
+      <span class="price-label">Gesamtpreis</span>
+      <span class="price-value">{{ calculatedPrice | currency:'EUR':'symbol':'1.2-2':'de' }}</span>
+    </div>
+  </form>
+</mat-dialog-content>
+
+<mat-dialog-actions align="center">
+  <button mat-mini-fab class="btn-confirm" (click)="save()" [disabled]="form.invalid">
+    <mat-icon>check_circle</mat-icon>
+  </button>
+  <button mat-mini-fab mat-dialog-close class="btn-cancel">
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-dialog-actions>

--- a/src/app/grocery/dialogs/receipt-item-edit-dialog/receipt-item-edit-dialog.component.ts
+++ b/src/app/grocery/dialogs/receipt-item-edit-dialog/receipt-item-edit-dialog.component.ts
@@ -1,0 +1,64 @@
+import {Component, inject, OnInit} from '@angular/core';
+import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
+import {MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MatFormField, MatLabel} from '@angular/material/form-field';
+import {MatInput} from '@angular/material/input';
+import {MatIcon} from '@angular/material/icon';
+import {MatMiniFabButton} from '@angular/material/button';
+import {CurrencyPipe} from '@angular/common';
+import {ReceiptItem} from '../../models/receipt.model';
+
+@Component({
+  selector: 'app-receipt-item-edit-dialog',
+  imports: [
+    ReactiveFormsModule,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatFormField,
+    MatLabel,
+    MatInput,
+    MatIcon,
+    MatMiniFabButton,
+    CurrencyPipe
+  ],
+  templateUrl: './receipt-item-edit-dialog.component.html',
+  styleUrl: './receipt-item-edit-dialog.component.css'
+})
+export class ReceiptItemEditDialogComponent implements OnInit {
+
+  private fb = inject(FormBuilder);
+  private dialogRef = inject(MatDialogRef<ReceiptItemEditDialogComponent>);
+  item: ReceiptItem = inject(MAT_DIALOG_DATA);
+
+  form!: FormGroup;
+  calculatedPrice = 0;
+
+  ngOnInit(): void {
+    this.form = this.fb.group({
+      name: [this.item.name, Validators.required],
+      quantity: [this.item.quantity, [Validators.required, Validators.min(0)]],
+      singlePrice: [this.item.singlePrice, [Validators.required, Validators.min(0)]]
+    });
+
+    this.calculatedPrice = this.item.price;
+
+    this.form.valueChanges.subscribe(v => {
+      const q = Number(v.quantity) || 0;
+      const p = Number(v.singlePrice) || 0;
+      this.calculatedPrice = Math.round(q * p * 100) / 100;
+    });
+  }
+
+  save(): void {
+    if (this.form.invalid) return;
+    const {name, quantity, singlePrice} = this.form.value;
+    this.dialogRef.close({
+      ...this.item,
+      name,
+      quantity: Number(quantity),
+      singlePrice: Number(singlePrice),
+      price: this.calculatedPrice
+    } as ReceiptItem);
+  }
+}

--- a/src/app/grocery/services/receipt.service.ts
+++ b/src/app/grocery/services/receipt.service.ts
@@ -30,4 +30,11 @@ export class ReceiptService {
   deleteReceipt(id: string): Observable<void> {
     return this.http.delete<void>(`${this.host}/receipts/${id}`);
   }
+
+  updateReceiptItem(receiptId: string, item: ReceiptItem): Observable<ReceiptItem> {
+    return this.http.put<ReceiptItem>(
+      `${this.host}/receipts/${receiptId}/items/${item.id}`,
+      {name: item.name, quantity: item.quantity, singlePrice: item.singlePrice}
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- Adds an edit pencil button to each row in the receipt items table
- Opens a pre-filled dialog with editable fields for name, quantity, and single price; total price auto-recalculates live
- Persists changes via `PUT /receipts/{receiptId}/items/{itemId}` and updates the table in place without reload

## Test plan
- [ ] Open a receipt's items view — edit button appears on every row
- [ ] Click edit — dialog opens pre-filled with the item's current values
- [ ] Change name/quantity/singlePrice — total price recalculates live
- [ ] Save — row updates in the table, no page reload
- [ ] Cancel — no change to the row
- [ ] Network tab shows correct `PUT` request payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)