### PR TITLE
style(mental-arithmetic): fix WCAG contrast failures

### DIFF
--- a/src/app/mental-arithmetic/components/arithmetic-list/arithmetic-list.component.css
+++ b/src/app/mental-arithmetic/components/arithmetic-list/arithmetic-list.component.css
@@ -79,7 +79,7 @@
 
 .stat-icon {
   font-size: 2rem;
-  color: var(--text-dim, #3d5470);
+  color: var(--text-muted, #7a93b0);
   opacity: 0.8;
   margin-left: 12px;
   display: flex;
@@ -167,7 +167,7 @@
 }
 
 .session-count {
-  color: var(--text-dim, #3d5470);
+  color: var(--text-muted, #7a93b0);
   font-size: 0.8rem;
   font-family: 'JetBrains Mono', monospace;
 }
@@ -279,7 +279,7 @@ table {
 
 .empty-icon {
   font-size: 2.5rem;
-  color: var(--text-dim, #3d5470);
+  color: var(--text-muted, #7a93b0);
   margin-bottom: 1.25rem;
   width: 50px;
   height: 50px;
@@ -292,7 +292,7 @@ table {
 }
 
 .empty-state p {
-  color: var(--text-dim, #3d5470);
+  color: var(--text-muted, #7a93b0);
   margin-bottom: 1.5rem;
   max-width: 400px;
 }
@@ -389,17 +389,17 @@ table {
 
 .problem-item.correct {
   border-left-color: #22d35e;
-  background: rgba(34, 211, 94, 0.05);
+  background: rgba(34, 211, 94, 0.09);
 }
 
 .problem-item.incorrect {
   border-left-color: #fb7185;
-  background: rgba(251, 113, 133, 0.05);
+  background: rgba(251, 113, 133, 0.09);
 }
 
 .problem-number {
   font-weight: bold;
-  color: var(--text-dim, #3d5470);
+  color: var(--text-muted, #7a93b0);
   min-width: 28px;
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.85rem;
@@ -426,7 +426,7 @@ table {
 }
 
 .problem-time {
-  color: var(--text-dim, #3d5470);
+  color: var(--text-muted, #7a93b0);
   font-size: 0.8rem;
   font-family: 'JetBrains Mono', monospace;
   margin-left: auto;

--- a/src/app/mental-arithmetic/components/arithmetic-main/mental-arithmetic-main.component.css
+++ b/src/app/mental-arithmetic/components/arithmetic-main/mental-arithmetic-main.component.css
@@ -136,7 +136,7 @@
   bottom: 0.75rem;
   right: 0.875rem;
   font-size: 0.8rem;
-  color: var(--text-dim, #3d5470);
+  color: var(--text-muted, #7a93b0);
   line-height: 1;
   transition: color 0.2s, transform 0.2s;
 }

--- a/src/app/mental-arithmetic/components/arithmetic-session/arithmetic-session.component.css
+++ b/src/app/mental-arithmetic/components/arithmetic-session/arithmetic-session.component.css
@@ -155,12 +155,12 @@ mat-icon {
 
 .problem-card.correct-feedback {
   border: 2px solid #22d35e;
-  background: rgba(34, 211, 94, 0.05);
+  background: rgba(34, 211, 94, 0.09);
 }
 
 .problem-card.incorrect-feedback {
   border: 2px solid #fb7185;
-  background: rgba(251, 113, 133, 0.05);
+  background: rgba(251, 113, 133, 0.09);
 }
 
 .problem-content {


### PR DESCRIPTION
## Summary
- Replace `--text-dim` (#3d5470, contrast ~2.6:1 — WCAG AA fail) with `--text-muted` (#7a93b0, ~6.5:1 — WCAG AAA pass) in all informational UI elements: stat card icons, session count label, empty-state icon and description, problem-grid sequence numbers, and per-problem time labels
- Fix nav card arrow color in resting state (was invisible at 2.6:1)
- Increase correct/incorrect feedback background opacity from 5% → 9% for clearer visual distinction in both the session problem card and the history problem grid

## Test plan
- [ ] Navigate to `/mental-arithmetic` — stat card icons, session count, and nav card arrows are clearly readable
- [ ] Open session history — problem-grid numbers and time values are legible; correct/incorrect rows have a visible color tint
- [ ] Run a training session — feedback card shows a clear green/red wash on correct/incorrect answers
- [ ] `npm run build` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)