### PR TITLE
feat(grocery): add sort by Bon-Datum to receipt list

### DIFF
--- a/src/app/grocery/components/receipt-list/receipt-list.component.css
+++ b/src/app/grocery/components/receipt-list/receipt-list.component.css
@@ -149,3 +149,12 @@ table {
 .btn-delete:hover {
   color: #fb7185 !important;
 }
+
+::ng-deep .mat-sort-header-arrow {
+  color: var(--text-dim) !important;
+}
+
+::ng-deep .mat-sort-header-container:hover .mat-sort-header-arrow,
+::ng-deep [aria-sort] .mat-sort-header-arrow {
+  color: var(--c-g) !important;
+}

--- a/src/app/grocery/components/receipt-list/receipt-list.component.html
+++ b/src/app/grocery/components/receipt-list/receipt-list.component.html
@@ -5,10 +5,10 @@
   </header>
 
   <div class="table-container">
-    <table mat-table [dataSource]="receipts">
+    <table mat-table [dataSource]="receipts" matSort matSortActive="receiptDate" matSortDirection="desc">
 
       <ng-container matColumnDef="receiptDate">
-        <th mat-header-cell *matHeaderCellDef class="col-header">Bon-Datum</th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="col-header">Bon-Datum</th>
         <td mat-cell *matCellDef="let receipt">
           {{ (receipt.receiptDate ?? receipt.creationDate) | date:'dd.MM.yyyy' }}
         </td>

--- a/src/app/grocery/components/receipt-list/receipt-list.component.ts
+++ b/src/app/grocery/components/receipt-list/receipt-list.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, ViewChild} from '@angular/core';
 import {
   MatCell,
   MatCellDef,
@@ -18,6 +18,7 @@ import {MatDialog} from '@angular/material/dialog';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {MatIconButton} from '@angular/material/button';
 import {MatIcon} from '@angular/material/icon';
+import {MatSort, MatSortModule} from '@angular/material/sort';
 import {Receipt} from '../../models/receipt.model';
 import {ReceiptService} from '../../services/receipt.service';
 import {ReceiptDeleteDialogComponent} from '../../dialogs/receipt-delete-dialog/receipt-delete-dialog.component';
@@ -39,12 +40,17 @@ import {ReceiptDeleteDialogComponent} from '../../dialogs/receipt-delete-dialog/
     DatePipe,
     CurrencyPipe,
     MatIconButton,
-    MatIcon
+    MatIcon,
+    MatSortModule
   ],
   templateUrl: './receipt-list.component.html',
   styleUrl: './receipt-list.component.css'
 })
 export class ReceiptListComponent implements OnInit {
+
+  @ViewChild(MatSort) set sort(sort: MatSort) {
+    this.receipts.sort = sort;
+  }
 
   receipts = new MatTableDataSource<Receipt>();
   columnsToDisplay = ['receiptDate', 'creationDate', 'totalAmount', 'actions'];
@@ -55,7 +61,14 @@ export class ReceiptListComponent implements OnInit {
     private dialog: MatDialog,
     private snackBar: MatSnackBar,
     private cdr: ChangeDetectorRef
-  ) {}
+  ) {
+    this.receipts.sortingDataAccessor = (receipt, column) => {
+      if (column === 'receiptDate') {
+        return new Date(receipt.receiptDate ?? receipt.creationDate).getTime();
+      }
+      return '';
+    };
+  }
 
   ngOnInit(): void {
     this.receiptService.getReceipts().subscribe(receipts => {


### PR DESCRIPTION
## Summary
- Adds `MatSort` to the receipt list table with default sort descending by Bon-Datum
- Custom `sortingDataAccessor` handles the `receiptDate ?? creationDate` fallback so null receipt dates sort correctly
- Sort arrow styled to match the existing dark theme (dim by default, orange on active/hover)

## Test plan
- [ ] Open `/grocery/receipts` — list appears sorted newest-first by default
- [ ] Click the "Bon-Datum" column header to toggle sort direction
- [ ] Receipts with no `receiptDate` fall back to `creationDate` for sorting

🤖 Generated with [Claude Code](https://claude.com/claude-code)