### PR TITLE
feat(grocery): add manual item entry to receipt items view

### DIFF
--- a/src/app/grocery/components/receipt-items/receipt-items.component.css
+++ b/src/app/grocery/components/receipt-items/receipt-items.component.css
@@ -140,3 +140,13 @@ table {
 .btn-edit:hover {
   color: var(--c-g);
 }
+
+.btn-add {
+  margin-left: auto;
+  color: var(--text-dim);
+  transition: color 0.2s;
+}
+
+.btn-add:hover {
+  color: var(--c-g);
+}

--- a/src/app/grocery/components/receipt-items/receipt-items.component.html
+++ b/src/app/grocery/components/receipt-items/receipt-items.component.html
@@ -2,6 +2,9 @@
   <header class="table-header">
     <span class="table-header__dot"></span>
     <span class="table-header__label">ARTIKEL</span>
+    <button mat-icon-button class="btn-add" (click)="openAddDialog()">
+      <mat-icon>add</mat-icon>
+    </button>
   </header>
 
   <div class="table-container">

--- a/src/app/grocery/components/receipt-items/receipt-items.component.ts
+++ b/src/app/grocery/components/receipt-items/receipt-items.component.ts
@@ -21,6 +21,7 @@ import {MatIcon} from '@angular/material/icon';
 import {ReceiptItem} from '../../models/receipt.model';
 import {ReceiptService} from '../../services/receipt.service';
 import {ReceiptItemEditDialogComponent} from '../../dialogs/receipt-item-edit-dialog/receipt-item-edit-dialog.component';
+import {ReceiptItemAddDialogComponent} from '../../dialogs/receipt-item-add-dialog/receipt-item-add-dialog.component';
 
 @Component({
   selector: 'app-receipt-items',
@@ -76,6 +77,22 @@ export class ReceiptItemsComponent implements OnInit {
         },
         error: () => {
           this.snackBar.open('Artikel konnte nicht gespeichert werden', 'Schließen', {duration: 5000});
+        }
+      });
+    });
+  }
+
+  openAddDialog(): void {
+    const ref = this.dialog.open(ReceiptItemAddDialogComponent);
+    ref.afterClosed().subscribe((result: {name: string; quantity: number; singlePrice: number} | undefined) => {
+      if (!result) return;
+      this.receiptService.addReceiptItem(this.receiptId, result).subscribe({
+        next: (created) => {
+          this.items.data = [...this.items.data, created];
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.snackBar.open('Artikel konnte nicht hinzugefügt werden', 'Schließen', {duration: 5000});
         }
       });
     });

--- a/src/app/grocery/dialogs/receipt-item-add-dialog/receipt-item-add-dialog.component.css
+++ b/src/app/grocery/dialogs/receipt-item-add-dialog/receipt-item-add-dialog.component.css
@@ -1,0 +1,149 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+  --c-g:         #f97316;
+  --c-n:         #2dd4bf;
+  --c-e:         #fb7185;
+}
+
+::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+  min-width: 360px !important;
+}
+
+::ng-deep .mat-mdc-dialog-title {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
+  color: var(--text) !important;
+  letter-spacing: 0.03em;
+}
+
+::ng-deep .mat-mdc-dialog-content {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.9rem !important;
+  overflow: visible !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions {
+  gap: 10px;
+  padding-bottom: 16px !important;
+  justify-content: center !important;
+}
+
+/* Form layout */
+.edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.5rem;
+}
+
+.field-full { width: 100%; }
+
+.field-row {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.field-half { flex: 1; }
+
+/* Dark theme form fields */
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__trailing {
+  border-color: var(--border-mid) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined:not(.mdc-text-field--disabled) .mdc-text-field__input {
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-mdc-floating-label {
+  color: var(--text-dim) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__trailing {
+  border-color: var(--c-g) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mat-mdc-floating-label {
+  color: var(--c-g) !important;
+}
+
+/* Calculated price display */
+.price-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  background: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-top: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.price-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.price-value {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--c-g);
+}
+
+/* Buttons */
+.btn-confirm {
+  background: rgba(45, 212, 191, 0.10) !important;
+  border: 1px solid rgba(45, 212, 191, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-n) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-confirm:hover:not([disabled]) {
+  background: rgba(45, 212, 191, 0.18) !important;
+  box-shadow: 0 0 12px rgba(45, 212, 191, 0.25) !important;
+}
+
+.btn-confirm[disabled] {
+  opacity: 0.4 !important;
+}
+
+.btn-confirm mat-icon { color: var(--c-n) !important; }
+
+.btn-cancel {
+  background: rgba(251, 113, 133, 0.10) !important;
+  border: 1px solid rgba(251, 113, 133, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-e) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-cancel:hover {
+  background: rgba(251, 113, 133, 0.18) !important;
+  box-shadow: 0 0 12px rgba(251, 113, 133, 0.25) !important;
+}
+
+.btn-cancel mat-icon { color: var(--c-e) !important; }

--- a/src/app/grocery/dialogs/receipt-item-add-dialog/receipt-item-add-dialog.component.html
+++ b/src/app/grocery/dialogs/receipt-item-add-dialog/receipt-item-add-dialog.component.html
@@ -1,0 +1,36 @@
+<h2 mat-dialog-title>Artikel hinzufügen</h2>
+
+<mat-dialog-content>
+  <form [formGroup]="form" class="edit-form">
+    <mat-form-field appearance="outline" class="field-full">
+      <mat-label>Artikel</mat-label>
+      <input matInput formControlName="name" />
+    </mat-form-field>
+
+    <div class="field-row">
+      <mat-form-field appearance="outline" class="field-half">
+        <mat-label>Menge</mat-label>
+        <input matInput type="number" formControlName="quantity" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="field-half">
+        <mat-label>Einzelpreis (€)</mat-label>
+        <input matInput type="number" step="0.01" formControlName="singlePrice" />
+      </mat-form-field>
+    </div>
+
+    <div class="price-row">
+      <span class="price-label">Gesamtpreis</span>
+      <span class="price-value">{{ calculatedPrice | currency:'EUR':'symbol':'1.2-2':'de' }}</span>
+    </div>
+  </form>
+</mat-dialog-content>
+
+<mat-dialog-actions align="center">
+  <button mat-mini-fab class="btn-confirm" (click)="save()" [disabled]="form.invalid">
+    <mat-icon>check_circle</mat-icon>
+  </button>
+  <button mat-mini-fab mat-dialog-close class="btn-cancel">
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-dialog-actions>

--- a/src/app/grocery/dialogs/receipt-item-add-dialog/receipt-item-add-dialog.component.ts
+++ b/src/app/grocery/dialogs/receipt-item-add-dialog/receipt-item-add-dialog.component.ts
@@ -1,0 +1,58 @@
+import {Component, inject, OnInit} from '@angular/core';
+import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
+import {MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MatFormField, MatLabel} from '@angular/material/form-field';
+import {MatInput} from '@angular/material/input';
+import {MatIcon} from '@angular/material/icon';
+import {MatMiniFabButton} from '@angular/material/button';
+import {CurrencyPipe} from '@angular/common';
+
+@Component({
+  selector: 'app-receipt-item-add-dialog',
+  imports: [
+    ReactiveFormsModule,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatFormField,
+    MatLabel,
+    MatInput,
+    MatIcon,
+    MatMiniFabButton,
+    CurrencyPipe
+  ],
+  templateUrl: './receipt-item-add-dialog.component.html',
+  styleUrl: './receipt-item-add-dialog.component.css'
+})
+export class ReceiptItemAddDialogComponent implements OnInit {
+
+  private fb = inject(FormBuilder);
+  private dialogRef = inject(MatDialogRef<ReceiptItemAddDialogComponent>);
+
+  form!: FormGroup;
+  calculatedPrice = 0;
+
+  ngOnInit(): void {
+    this.form = this.fb.group({
+      name: ['', Validators.required],
+      quantity: [1, [Validators.required, Validators.min(0)]],
+      singlePrice: [0, [Validators.required, Validators.min(0)]]
+    });
+
+    this.form.valueChanges.subscribe(v => {
+      const q = Number(v.quantity) || 0;
+      const p = Number(v.singlePrice) || 0;
+      this.calculatedPrice = Math.round(q * p * 100) / 100;
+    });
+  }
+
+  save(): void {
+    if (this.form.invalid) return;
+    const {name, quantity, singlePrice} = this.form.value;
+    this.dialogRef.close({
+      name,
+      quantity: Number(quantity),
+      singlePrice: Number(singlePrice)
+    });
+  }
+}

--- a/src/app/grocery/services/receipt.service.ts
+++ b/src/app/grocery/services/receipt.service.ts
@@ -37,4 +37,8 @@ export class ReceiptService {
       {name: item.name, quantity: item.quantity, singlePrice: item.singlePrice}
     );
   }
+
+  addReceiptItem(receiptId: string, item: {name: string; quantity: number; singlePrice: number}): Observable<ReceiptItem> {
+    return this.http.post<ReceiptItem>(`${this.host}/receipts/${receiptId}/items`, item);
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `addReceiptItem(receiptId, item)` to `ReceiptService` — calls `POST /receipts/{id}/items`
- Adds `ReceiptItemAddDialogComponent` (new dialog mirroring the edit dialog) with blank form fields and title "Artikel hinzufügen"
- Adds an `add` icon button to the ARTIKEL header in `receipt-items.component`; on confirm, the new item is appended to the table and change detection is triggered
- Error snackbar "Artikel konnte nicht hinzugefügt werden" on failure

## Test plan
- [ ] Navigate to any receipt's items view, click the `+` button — dialog opens
- [ ] Fill in name, quantity, singlePrice — Gesamtpreis updates in real time
- [ ] Save — new row appears in the table immediately
- [ ] Reload page — item is still present (persisted via backend)
- [ ] Cancel — no row is added
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)