### PR TITLE
feat(grocery): prompt for supermarket after receipt upload

### DIFF
--- a/src/app/grocery/components/receipt-upload/receipt-upload.component.ts
+++ b/src/app/grocery/components/receipt-upload/receipt-upload.component.ts
@@ -1,7 +1,11 @@
 import {Component} from '@angular/core';
 import {Router} from '@angular/router';
+import {MatDialog} from '@angular/material/dialog';
 import {MatProgressBar} from '@angular/material/progress-bar';
+import {switchMap} from 'rxjs';
 import {ReceiptService} from '../../services/receipt.service';
+import {SupermarketSelectDialogComponent} from '../../dialogs/supermarket-select-dialog/supermarket-select-dialog.component';
+import {Supermarket} from '../../models/receipt.model';
 
 @Component({
   selector: 'app-receipt-upload',
@@ -14,7 +18,7 @@ export class ReceiptUploadComponent {
   selectedFile: File | null = null;
   uploading = false;
 
-  constructor(private receiptService: ReceiptService, private router: Router) {}
+  constructor(private receiptService: ReceiptService, private router: Router, private dialog: MatDialog) {}
 
   onFileSelected(event: Event): void {
     const input = event.target as HTMLInputElement;
@@ -26,18 +30,26 @@ export class ReceiptUploadComponent {
   onSubmit(): void {
     if (!this.selectedFile) return;
     this.uploading = true;
-    this.receiptService.uploadReceipt(this.selectedFile).subscribe({
-      next: (response) => {
-        const location = response.headers.get('Location');
-        const id = location?.split('/receipts/')[1];
+    this.receiptService.uploadReceipt(this.selectedFile).pipe(
+      switchMap(response => {
+        const id = response.headers.get('Location')?.split('/receipts/')[1] ?? '';
         this.uploading = false;
-        if (id) {
-          void this.router.navigate(['/grocery/receipts', id, 'items']);
-        }
-      },
-      error: () => {
-        this.uploading = false;
-      }
+        const ref = this.dialog.open(SupermarketSelectDialogComponent, {disableClose: true});
+        return ref.afterClosed().pipe(
+          switchMap((supermarket: Supermarket | undefined) => {
+            const navigate = (): void => { void this.router.navigate(['/grocery/receipts', id, 'items']); };
+            if (supermarket && id) {
+              return this.receiptService.updateSupermarket(id, supermarket).pipe(
+                switchMap(() => { navigate(); return []; })
+              );
+            }
+            navigate();
+            return [];
+          })
+        );
+      })
+    ).subscribe({
+      error: () => { this.uploading = false; }
     });
   }
 }

--- a/src/app/grocery/dialogs/supermarket-select-dialog/supermarket-select-dialog.component.css
+++ b/src/app/grocery/dialogs/supermarket-select-dialog/supermarket-select-dialog.component.css
@@ -1,0 +1,113 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+  --c-g:         #f97316;
+  --c-n:         #2dd4bf;
+  --c-e:         #fb7185;
+}
+
+::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+  min-width: 320px !important;
+}
+
+::ng-deep .mat-mdc-dialog-title {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
+  color: var(--text) !important;
+  letter-spacing: 0.03em;
+}
+
+::ng-deep .mat-mdc-dialog-content {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.9rem !important;
+  overflow: visible !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions {
+  gap: 10px;
+  padding-bottom: 16px !important;
+  justify-content: center !important;
+}
+
+.select-form {
+  display: flex;
+  flex-direction: column;
+  padding-top: 0.5rem;
+}
+
+.field-full { width: 100%; }
+
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__trailing {
+  border-color: var(--border-mid) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined:not(.mdc-text-field--disabled) .mdc-text-field__input {
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-mdc-floating-label {
+  color: var(--text-dim) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__trailing {
+  border-color: var(--c-g) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mat-mdc-floating-label {
+  color: var(--c-g) !important;
+}
+
+::ng-deep .mat-mdc-select-value-text {
+  color: var(--text) !important;
+}
+
+.btn-confirm {
+  background: rgba(45, 212, 191, 0.10) !important;
+  border: 1px solid rgba(45, 212, 191, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-n) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-confirm:hover:not([disabled]) {
+  background: rgba(45, 212, 191, 0.18) !important;
+  box-shadow: 0 0 12px rgba(45, 212, 191, 0.25) !important;
+}
+
+.btn-confirm[disabled] {
+  opacity: 0.4 !important;
+}
+
+.btn-confirm mat-icon { color: var(--c-n) !important; }
+
+.btn-cancel {
+  background: rgba(251, 113, 133, 0.10) !important;
+  border: 1px solid rgba(251, 113, 133, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-e) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-cancel:hover {
+  background: rgba(251, 113, 133, 0.18) !important;
+  box-shadow: 0 0 12px rgba(251, 113, 133, 0.25) !important;
+}
+
+.btn-cancel mat-icon { color: var(--c-e) !important; }

--- a/src/app/grocery/dialogs/supermarket-select-dialog/supermarket-select-dialog.component.html
+++ b/src/app/grocery/dialogs/supermarket-select-dialog/supermarket-select-dialog.component.html
@@ -1,0 +1,23 @@
+<h2 mat-dialog-title>Supermarkt auswählen</h2>
+
+<mat-dialog-content>
+  <form [formGroup]="form" class="select-form">
+    <mat-form-field appearance="outline" class="field-full">
+      <mat-label>Supermarkt</mat-label>
+      <mat-select formControlName="supermarket">
+        @for (market of supermarkets; track market.value) {
+          <mat-option [value]="market.value">{{ market.label }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  </form>
+</mat-dialog-content>
+
+<mat-dialog-actions align="center">
+  <button mat-mini-fab class="btn-confirm" (click)="save()" [disabled]="form.invalid">
+    <mat-icon>check_circle</mat-icon>
+  </button>
+  <button mat-mini-fab mat-dialog-close class="btn-cancel">
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-dialog-actions>

--- a/src/app/grocery/dialogs/supermarket-select-dialog/supermarket-select-dialog.component.ts
+++ b/src/app/grocery/dialogs/supermarket-select-dialog/supermarket-select-dialog.component.ts
@@ -1,0 +1,51 @@
+import {Component, inject, OnInit} from '@angular/core';
+import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
+import {MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MatFormField, MatLabel} from '@angular/material/form-field';
+import {MatSelect} from '@angular/material/select';
+import {MatOption} from '@angular/material/core';
+import {MatIcon} from '@angular/material/icon';
+import {MatMiniFabButton} from '@angular/material/button';
+import {Supermarket} from '../../models/receipt.model';
+
+@Component({
+  selector: 'app-supermarket-select-dialog',
+  imports: [
+    ReactiveFormsModule,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatFormField,
+    MatLabel,
+    MatSelect,
+    MatOption,
+    MatIcon,
+    MatMiniFabButton
+  ],
+  templateUrl: './supermarket-select-dialog.component.html',
+  styleUrl: './supermarket-select-dialog.component.css'
+})
+export class SupermarketSelectDialogComponent implements OnInit {
+
+  private fb = inject(FormBuilder);
+  private dialogRef = inject(MatDialogRef<SupermarketSelectDialogComponent>);
+
+  readonly supermarkets: {value: Supermarket; label: string}[] = [
+    {value: 'LIDL', label: 'Lidl'},
+    {value: 'EDEKA', label: 'Edeka'},
+    {value: 'REWE', label: 'Rewe'}
+  ];
+
+  form!: FormGroup;
+
+  ngOnInit(): void {
+    this.form = this.fb.group({
+      supermarket: ['LIDL', Validators.required]
+    });
+  }
+
+  save(): void {
+    if (this.form.invalid) return;
+    this.dialogRef.close(this.form.value.supermarket as Supermarket);
+  }
+}

--- a/src/app/grocery/models/receipt.model.ts
+++ b/src/app/grocery/models/receipt.model.ts
@@ -1,9 +1,12 @@
+export type Supermarket = 'LIDL' | 'EDEKA' | 'REWE';
+
 export interface Receipt {
   id: string;
   receiptDate: string | null;
   totalAmount: number | null;
   creationDate: string;
   items?: ReceiptItem[];
+  supermarket: Supermarket | null;
 }
 
 export interface ReceiptItem {

--- a/src/app/grocery/services/receipt.service.ts
+++ b/src/app/grocery/services/receipt.service.ts
@@ -2,7 +2,7 @@ import {Injectable} from '@angular/core';
 import {HttpClient, HttpResponse} from '@angular/common/http';
 import {Observable} from 'rxjs';
 import {environment} from '../../../environments/environment';
-import {Receipt, ReceiptItem} from '../models/receipt.model';
+import {Receipt, ReceiptItem, Supermarket} from '../models/receipt.model';
 
 @Injectable({
   providedIn: 'root'
@@ -40,5 +40,9 @@ export class ReceiptService {
 
   addReceiptItem(receiptId: string, item: {name: string; quantity: number; singlePrice: number}): Observable<ReceiptItem> {
     return this.http.post<ReceiptItem>(`${this.host}/receipts/${receiptId}/items`, item);
+  }
+
+  updateSupermarket(id: string, supermarket: Supermarket): Observable<Receipt> {
+    return this.http.patch<Receipt>(`${this.host}/receipts/${id}/supermarket`, {supermarket});
   }
 }


### PR DESCRIPTION
## Summary
- Add a supermarket select dialog shown after uploading a receipt
- Persist the selected supermarket via a new `updateSupermarket` PATCH endpoint
- Add `Supermarket` type and `supermarket` field to the receipt model

## Test plan
- `npm run build` succeeds
- Upload a receipt → dialog prompts for supermarket → selection is saved before navigating to items view

🤖 Generated with [Claude Code](https://claude.com/claude-code)