### PR TITLE
feat(nutrition): weight log, profile & targets UI

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -31,6 +31,8 @@ import {ReceiptListComponent} from './grocery/components/receipt-list/receipt-li
 import {ReceiptItemsComponent} from './grocery/components/receipt-items/receipt-items.component';
 import {NutritionLayoutComponent} from './nutrition/components/nutrition-layout/nutrition-layout.component';
 import {NutritionHomeComponent} from './nutrition/components/nutrition-home/nutrition-home.component';
+import {NutritionWeightComponent} from './nutrition/components/nutrition-weight/nutrition-weight.component';
+import {NutritionProfileComponent} from './nutrition/components/nutrition-profile/nutrition-profile.component';
 
 export const routes: Routes = [
   {path: '', component: HomeComponent},
@@ -104,7 +106,9 @@ export const routes: Routes = [
     path: 'nutrition',
     component: NutritionLayoutComponent,
     children: [
-      {path: '', component: NutritionHomeComponent, data: {home: '/'}}
+      {path: '', component: NutritionHomeComponent, data: {home: '/'}},
+      {path: 'weight', component: NutritionWeightComponent, data: {home: '/nutrition'}},
+      {path: 'profile', component: NutritionProfileComponent, data: {home: '/nutrition'}}
     ]
   }
 ];

--- a/src/app/nutrition/components/nutrition-home/nutrition-home.component.css
+++ b/src/app/nutrition/components/nutrition-home/nutrition-home.component.css
@@ -1,58 +1,137 @@
 @import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
 
 :host {
+  --surface:     #0c1018;
+  --border:      rgba(255, 255, 255, 0.07);
+
   --text:        #c8d4e8;
   --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
 
-  --c-g:  #a3e635;  --cg-g: rgba(163, 230, 53, 0.18);
+  --c-w:  #a3e635;  --cg-w: rgba(163, 230,  53, 0.18);
+  --c-p:  #4da6ff;  --cg-p: rgba(77,  166, 255, 0.18);
 
   display: block;
   height: 100%;
+  overflow-y: auto;
   font-family: 'Outfit', sans-serif;
   color: var(--text);
 }
 
-/* ── Empty State ─────────────────────────────────── */
-.empty {
+.dashboard {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.75rem;
-  height: 100%;
-  padding: 2rem 1rem;
-  text-align: center;
-  animation: fadeUp 0.5s ease both;
+  gap: 1.5rem;
+  padding: 2rem clamp(1rem, 6vw, 4rem);
+  max-width: 760px;
+  margin: 0 auto;
+  box-sizing: border-box;
 }
 
-.empty__mark {
-  width: 56px;
-  height: 56px;
+/* ── Nav Grid ────────────────────────────────────── */
+.navgrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.75rem;
+}
+
+@media (max-width: 480px) {
+  .navgrid { grid-template-columns: 1fr; }
+}
+
+/* ── Nav Cards ───────────────────────────────────── */
+.navcard {
+  position: relative;
+  background: var(--surface);
+  border: 1px solid var(--border);
   border-radius: 12px;
-  border: 1px solid color-mix(in srgb, var(--c-g) 40%, transparent);
-  background: color-mix(in srgb, var(--c-g) 10%, transparent);
+  padding: 1.1rem 1rem 1.75rem;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  min-height: 130px;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
+  animation: fadeUp 0.5s ease both;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.navcard::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 0% 0%, var(--cc-glow, transparent) 0%, transparent 65%);
+  opacity: 0;
+  transition: opacity 0.25s;
+  pointer-events: none;
+}
+
+.navcard:hover {
+  border-color: var(--cc);
+  box-shadow: 0 8px 28px var(--cc-glow);
+  transform: translateY(-3px);
+}
+
+.navcard:hover::before { opacity: 1; }
+
+.navcard--w { --cc: var(--c-w); --cc-glow: var(--cg-w); }
+.navcard--p { --cc: var(--c-p); --cc-glow: var(--cg-p); }
+
+.navcard__mark {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--cc) 40%, transparent);
+  background: color-mix(in srgb, var(--cc) 10%, transparent);
   display: grid;
   place-items: center;
-  font-size: 1.6rem;
-  color: var(--c-g);
+  font-size: 1.1rem;
+  color: var(--cc);
+  flex-shrink: 0;
+  transition: background 0.2s;
 }
 
-.empty__title {
+.navcard:hover .navcard__mark {
+  background: color-mix(in srgb, var(--cc) 20%, transparent);
+}
+
+.navcard__title {
   margin: 0;
-  font-size: clamp(1.1rem, 3vw, 1.4rem);
+  font-size: clamp(0.95rem, 2.5vw, 1.1rem);
   font-weight: 600;
-  letter-spacing: 0.01em;
+  color: var(--text);
+  line-height: 1.25;
 }
 
-.empty__sub {
+.navcard__sub {
   margin: 0;
-  max-width: 28ch;
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   color: var(--text-muted);
-  line-height: 1.5;
+  line-height: 1.4;
+}
+
+.navcard__arrow {
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.875rem;
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  line-height: 1;
+  transition: color 0.2s, transform 0.2s;
+}
+
+.navcard:hover .navcard__arrow {
+  color: var(--cc);
+  transform: translate(2px, -2px);
 }
 
 @keyframes fadeUp {
   from { opacity: 0; transform: translateY(12px); }
   to   { opacity: 1; transform: translateY(0); }
 }
+
+.navcard:nth-child(1) { animation-delay: 0.05s; }
+.navcard:nth-child(2) { animation-delay: 0.12s; }

--- a/src/app/nutrition/components/nutrition-home/nutrition-home.component.html
+++ b/src/app/nutrition/components/nutrition-home/nutrition-home.component.html
@@ -1,5 +1,21 @@
-<div class="empty">
-  <div class="empty__mark">⚖</div>
-  <h2 class="empty__title">Nutrition</h2>
-  <p class="empty__sub">Kalorien- &amp; Ernährungs-Tracker — in Vorbereitung.</p>
+<div class="dashboard">
+
+  <app-targets-card />
+
+  <div class="navgrid">
+    <a class="navcard navcard--w" routerLink="/nutrition/weight">
+      <div class="navcard__mark">⚖</div>
+      <h2 class="navcard__title">Gewicht</h2>
+      <p class="navcard__sub">Gewicht erfassen & Verlauf</p>
+      <span class="navcard__arrow" aria-hidden="true">↗</span>
+    </a>
+
+    <a class="navcard navcard--p" routerLink="/nutrition/profile">
+      <div class="navcard__mark">☰</div>
+      <h2 class="navcard__title">Profil</h2>
+      <p class="navcard__sub">Eckdaten & Zielvorgaben</p>
+      <span class="navcard__arrow" aria-hidden="true">↗</span>
+    </a>
+  </div>
+
 </div>

--- a/src/app/nutrition/components/nutrition-home/nutrition-home.component.ts
+++ b/src/app/nutrition/components/nutrition-home/nutrition-home.component.ts
@@ -1,8 +1,11 @@
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {RouterLink} from '@angular/router';
+import {TargetsCardComponent} from '../targets-card/targets-card.component';
 
 @Component({
   selector: 'app-nutrition-home',
-  imports: [],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink, TargetsCardComponent],
   templateUrl: './nutrition-home.component.html',
   styleUrl: './nutrition-home.component.css'
 })

--- a/src/app/nutrition/components/nutrition-layout/nutrition-layout.component.html
+++ b/src/app/nutrition/components/nutrition-layout/nutrition-layout.component.html
@@ -1,15 +1,21 @@
 <div class="nutrition-layout">
   <header class="topbar">
     <div class="topbar__left">
-      <button mat-icon-button [routerLink]="homeLink" class="nav-btn" aria-label="Go home">
+      <button mat-icon-button class="nav-btn" aria-label="Go home" [routerLink]="homeLink">
         <mat-icon>home</mat-icon>
       </button>
-      <button mat-icon-button [matMenuTriggerFor]="menu" class="nav-btn" aria-label="Open menu">
+      <button mat-icon-button class="nav-btn" aria-label="Open menu" [matMenuTriggerFor]="menu">
         <mat-icon>more_vert</mat-icon>
       </button>
       <mat-menu #menu="matMenu">
         <button mat-menu-item routerLink="/nutrition">
           <span>Home</span>
+        </button>
+        <button mat-menu-item routerLink="/nutrition/weight">
+          <span>Gewicht</span>
+        </button>
+        <button mat-menu-item routerLink="/nutrition/profile">
+          <span>Profil</span>
         </button>
       </mat-menu>
     </div>
@@ -23,6 +29,6 @@
   </header>
 
   <main class="content">
-    <router-outlet></router-outlet>
+    <router-outlet />
   </main>
 </div>

--- a/src/app/nutrition/components/nutrition-profile/nutrition-profile.component.css
+++ b/src/app/nutrition/components/nutrition-profile/nutrition-profile.component.css
@@ -1,0 +1,144 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-g:  #a3e635;
+
+  display: block;
+  height: 100%;
+  overflow-y: auto;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+}
+
+.profile {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem clamp(1rem, 6vw, 4rem);
+  max-width: 760px;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+/* ── Panel ───────────────────────────────────────── */
+.panel__head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.panel__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--c-g);
+  box-shadow: 0 0 6px var(--c-g);
+}
+
+.panel__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+}
+
+/* ── Form ────────────────────────────────────────── */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem 0.75rem;
+}
+
+@media (max-width: 560px) {
+  .grid { grid-template-columns: 1fr; }
+}
+
+.grid mat-form-field { width: 100%; }
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+}
+
+.btn-save {
+  background: color-mix(in srgb, var(--c-g) 14%, transparent) !important;
+  border: 1px solid color-mix(in srgb, var(--c-g) 35%, transparent) !important;
+  border-radius: 8px !important;
+  color: var(--c-g) !important;
+  font-weight: 600 !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-save:hover:not([disabled]) {
+  background: color-mix(in srgb, var(--c-g) 22%, transparent) !important;
+  box-shadow: 0 0 12px rgba(163, 230, 53, 0.25) !important;
+}
+
+.btn-save[disabled] { opacity: 0.4 !important; }
+
+/* ── Dark form fields ────────────────────────────── */
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__trailing {
+  border-color: var(--border-mid) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined:not(.mdc-text-field--disabled) .mdc-text-field__input {
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-mdc-floating-label,
+::ng-deep .mat-mdc-form-field .mat-mdc-select-value-text,
+::ng-deep .mat-mdc-form-field .mat-mdc-select-min-line {
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-mdc-floating-label {
+  color: var(--text-dim) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-mdc-form-field-text-suffix,
+::ng-deep .mat-mdc-form-field .mat-mdc-form-field-hint-wrapper,
+::ng-deep .mat-mdc-form-field .mat-mdc-select-arrow,
+::ng-deep .mat-mdc-form-field .mat-datepicker-toggle {
+  color: var(--text-dim) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__trailing {
+  border-color: var(--c-g) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mat-mdc-floating-label {
+  color: var(--c-g) !important;
+}
+
+/* Select dropdown panel */
+::ng-deep .mat-mdc-select-panel {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+}
+
+::ng-deep .mat-mdc-option .mdc-list-item__primary-text {
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-option:hover,
+::ng-deep .mat-mdc-option.mdc-list-item--selected {
+  background: var(--raised) !important;
+}

--- a/src/app/nutrition/components/nutrition-profile/nutrition-profile.component.html
+++ b/src/app/nutrition/components/nutrition-profile/nutrition-profile.component.html
@@ -1,0 +1,82 @@
+<div class="profile">
+
+  <app-targets-card />
+
+  <section class="panel">
+    <header class="panel__head">
+      <span class="panel__dot"></span>
+      <span class="panel__label">PROFIL</span>
+    </header>
+
+    <form class="profile-form" [formGroup]="form" (ngSubmit)="save()">
+
+      <div class="grid">
+        <mat-form-field appearance="outline">
+          <mat-label>Geschlecht</mat-label>
+          <mat-select formControlName="sex">
+            @for (s of sexes; track s.value) {
+              <mat-option [value]="s.value">{{ s.label }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Geburtsdatum</mat-label>
+          <input matInput formControlName="birthDate" [matDatepicker]="picker" />
+          <mat-datepicker-toggle matIconSuffix [for]="picker" />
+          <mat-datepicker #picker />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Größe (cm)</mat-label>
+          <input matInput type="number" formControlName="heightCm" />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Aktivitätslevel</mat-label>
+          <mat-select formControlName="activityLevel">
+            @for (a of activityLevels; track a.value) {
+              <mat-option [value]="a.value">{{ a.label }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Ziel</mat-label>
+          <mat-select formControlName="goal">
+            @for (g of goals; track g.value) {
+              <mat-option [value]="g.value">{{ g.label }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Protein pro kg</mat-label>
+          <input matInput type="number" step="0.1" formControlName="proteinPerKg" />
+          <span matTextSuffix>g/kg</span>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Fettanteil</mat-label>
+          <input matInput type="number" formControlName="fatPctPercent" />
+          <span matTextSuffix>%</span>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Grundumsatz (manuell)</mat-label>
+          <input matInput type="number" formControlName="basalKcal" />
+          <span matTextSuffix>kcal</span>
+          <mat-hint>Optional — überschreibt die Formel, wenn gesetzt</mat-hint>
+        </mat-form-field>
+      </div>
+
+      <div class="actions">
+        <button mat-flat-button type="submit" class="btn-save" [disabled]="form.invalid || saving">
+          <mat-icon>save</mat-icon>
+          Speichern
+        </button>
+      </div>
+    </form>
+  </section>
+
+</div>

--- a/src/app/nutrition/components/nutrition-profile/nutrition-profile.component.ts
+++ b/src/app/nutrition/components/nutrition-profile/nutrition-profile.component.ts
@@ -1,0 +1,135 @@
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit, ViewChild} from '@angular/core';
+import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
+import {HttpErrorResponse} from '@angular/common/http';
+import {MatFormField, MatHint, MatLabel, MatSuffix} from '@angular/material/form-field';
+import {MatInput} from '@angular/material/input';
+import {MatOption, MatSelect} from '@angular/material/select';
+import {MatDatepicker, MatDatepickerInput, MatDatepickerToggle} from '@angular/material/datepicker';
+import {MatButton} from '@angular/material/button';
+import {MatIcon} from '@angular/material/icon';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {format, parseISO} from 'date-fns';
+import {NutritionService} from '../../services/nutrition.service';
+import {ActivityLevel, Goal, ProfileInput, Sex} from '../../models/nutrition.model';
+import {TargetsCardComponent} from '../targets-card/targets-card.component';
+
+@Component({
+  selector: 'app-nutrition-profile',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ReactiveFormsModule,
+    MatFormField,
+    MatLabel,
+    MatHint,
+    MatSuffix,
+    MatInput,
+    MatSelect,
+    MatOption,
+    MatDatepicker,
+    MatDatepickerInput,
+    MatDatepickerToggle,
+    MatButton,
+    MatIcon,
+    TargetsCardComponent
+  ],
+  templateUrl: './nutrition-profile.component.html',
+  styleUrl: './nutrition-profile.component.css'
+})
+export class NutritionProfileComponent implements OnInit {
+
+  @ViewChild(TargetsCardComponent) targetsCard?: TargetsCardComponent;
+
+  form!: FormGroup;
+  saving = false;
+
+  readonly sexes: {value: Sex; label: string}[] = [
+    {value: 'MALE', label: 'Männlich'},
+    {value: 'FEMALE', label: 'Weiblich'}
+  ];
+
+  readonly activityLevels: {value: ActivityLevel; label: string}[] = [
+    {value: 'SEDENTARY', label: 'Sitzend (wenig Bewegung)'},
+    {value: 'LIGHT', label: 'Leicht aktiv'},
+    {value: 'MODERATE', label: 'Mäßig aktiv'},
+    {value: 'ACTIVE', label: 'Aktiv'},
+    {value: 'VERY_ACTIVE', label: 'Sehr aktiv'}
+  ];
+
+  readonly goals: {value: Goal; label: string}[] = [
+    {value: 'CUT', label: 'Abnehmen'},
+    {value: 'MAINTAIN', label: 'Halten'},
+    {value: 'BULK', label: 'Aufbauen'}
+  ];
+
+  private fb = inject(FormBuilder);
+  private nutritionService = inject(NutritionService);
+  private snackBar = inject(MatSnackBar);
+  private cdr = inject(ChangeDetectorRef);
+
+  ngOnInit(): void {
+    this.form = this.fb.group({
+      sex: ['MALE' as Sex, Validators.required],
+      birthDate: [null as Date | null, Validators.required],
+      heightCm: [null as number | null, [Validators.required, Validators.min(0)]],
+      activityLevel: ['MODERATE' as ActivityLevel, Validators.required],
+      goal: ['MAINTAIN' as Goal, Validators.required],
+      proteinPerKg: [2.0, [Validators.required, Validators.min(0)]],
+      // Presented as a percentage (e.g. 30 for 30 %); converted to a fraction on save.
+      fatPctPercent: [30, [Validators.required, Validators.min(0), Validators.max(100)]],
+      basalKcal: [null as number | null, Validators.min(0)]
+    });
+
+    this.nutritionService.getProfile().subscribe({
+      next: profile => {
+        this.form.patchValue({
+          sex: profile.sex,
+          birthDate: parseISO(profile.birthDate),
+          heightCm: profile.heightCm,
+          activityLevel: profile.activityLevel,
+          goal: profile.goal,
+          proteinPerKg: profile.proteinPerKg,
+          fatPctPercent: Math.round(profile.fatPct * 100),
+          basalKcal: profile.basalKcal
+        });
+        this.cdr.markForCheck();
+      },
+      error: (err: HttpErrorResponse) => {
+        // 404 simply means no profile yet — keep the form defaults.
+        if (err.status !== 404) {
+          this.snackBar.open('Profil konnte nicht geladen werden', 'Schließen', {duration: 5000});
+        }
+      }
+    });
+  }
+
+  save(): void {
+    if (this.form.invalid) return;
+    const v = this.form.value;
+    const payload: ProfileInput = {
+      sex: v.sex,
+      birthDate: format(v.birthDate, 'yyyy-MM-dd'),
+      heightCm: Number(v.heightCm),
+      activityLevel: v.activityLevel,
+      goal: v.goal,
+      proteinPerKg: Number(v.proteinPerKg),
+      fatPct: Number(v.fatPctPercent) / 100,
+      basalKcal: v.basalKcal === null || v.basalKcal === '' ? null : Number(v.basalKcal)
+    };
+
+    this.saving = true;
+    this.cdr.markForCheck();
+    this.nutritionService.updateProfile(payload).subscribe({
+      next: () => {
+        this.saving = false;
+        this.targetsCard?.reload();
+        this.cdr.markForCheck();
+        this.snackBar.open('Profil gespeichert', 'OK', {duration: 3000});
+      },
+      error: () => {
+        this.saving = false;
+        this.cdr.markForCheck();
+        this.snackBar.open('Profil konnte nicht gespeichert werden', 'Schließen', {duration: 5000});
+      }
+    });
+  }
+}

--- a/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.css
+++ b/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.css
@@ -1,0 +1,183 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-g:  #a3e635;
+  --c-e:  #fb7185;
+
+  display: block;
+  height: 100%;
+  overflow-y: auto;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+}
+
+.weight {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem clamp(1rem, 6vw, 4rem);
+  max-width: 760px;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+/* ── Panels ──────────────────────────────────────── */
+.panel__head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.panel__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--c-g);
+  box-shadow: 0 0 6px var(--c-g);
+}
+
+.panel__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+}
+
+/* ── Add form ────────────────────────────────────── */
+.add-form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.field-date { flex: 1 1 180px; }
+.field-weight { flex: 1 1 140px; }
+
+.btn-add {
+  height: 56px;
+  background: color-mix(in srgb, var(--c-g) 14%, transparent) !important;
+  border: 1px solid color-mix(in srgb, var(--c-g) 35%, transparent) !important;
+  border-radius: 8px !important;
+  color: var(--c-g) !important;
+  font-weight: 600 !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-add:hover:not([disabled]) {
+  background: color-mix(in srgb, var(--c-g) 22%, transparent) !important;
+  box-shadow: 0 0 12px rgba(163, 230, 53, 0.25) !important;
+}
+
+.btn-add[disabled] { opacity: 0.4 !important; }
+
+/* ── Table ───────────────────────────────────────── */
+.table-container {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+table {
+  width: 100%;
+  background: transparent !important;
+}
+
+.col-header {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.6rem !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.12em !important;
+  text-transform: uppercase !important;
+  color: var(--text-dim) !important;
+  background: var(--raised) !important;
+  border-bottom: 1px solid var(--border-mid) !important;
+  height: 36px !important;
+  padding: 0 16px !important;
+}
+
+::ng-deep .mat-mdc-header-row {
+  background: var(--raised) !important;
+}
+
+::ng-deep .mat-mdc-cell {
+  font-size: 0.85rem !important;
+  color: var(--text) !important;
+  background: transparent !important;
+  border-bottom: 1px solid var(--border) !important;
+}
+
+.col-actions {
+  width: 96px;
+  text-align: right;
+  padding-right: 8px !important;
+}
+
+.btn-edit {
+  color: var(--text-dim);
+  transition: color 0.2s;
+}
+
+.btn-edit:hover { color: var(--c-g); }
+
+.btn-del {
+  color: var(--text-dim);
+  transition: color 0.2s;
+}
+
+.btn-del:hover { color: var(--c-e); }
+
+/* ── Empty ───────────────────────────────────────── */
+.empty {
+  margin: 0;
+  padding: 1.5rem;
+  text-align: center;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  background: var(--surface);
+  border: 1px dashed var(--border-mid);
+  border-radius: 12px;
+}
+
+/* ── Dark form fields ────────────────────────────── */
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__trailing {
+  border-color: var(--border-mid) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined:not(.mdc-text-field--disabled) .mdc-text-field__input {
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-mdc-floating-label {
+  color: var(--text-dim) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-datepicker-toggle {
+  color: var(--text-dim) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__trailing {
+  border-color: var(--c-g) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mat-mdc-floating-label {
+  color: var(--c-g) !important;
+}

--- a/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.html
+++ b/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.html
@@ -1,0 +1,73 @@
+<div class="weight">
+
+  <app-targets-card />
+
+  <section class="panel">
+    <header class="panel__head">
+      <span class="panel__dot"></span>
+      <span class="panel__label">GEWICHT ERFASSEN</span>
+    </header>
+
+    <form class="add-form" [formGroup]="form" (ngSubmit)="add()">
+      <mat-form-field appearance="outline" class="field-date">
+        <mat-label>Datum</mat-label>
+        <input matInput formControlName="entryDate" [matDatepicker]="picker" />
+        <mat-datepicker-toggle matIconSuffix [for]="picker" />
+        <mat-datepicker #picker />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="field-weight">
+        <mat-label>Gewicht (kg)</mat-label>
+        <input matInput type="number" step="0.1" formControlName="weightKg" />
+      </mat-form-field>
+
+      <button mat-flat-button type="submit" class="btn-add" [disabled]="form.invalid">
+        <mat-icon>add</mat-icon>
+        Hinzufügen
+      </button>
+    </form>
+  </section>
+
+  <section class="panel">
+    <header class="panel__head">
+      <span class="panel__dot"></span>
+      <span class="panel__label">VERLAUF</span>
+    </header>
+
+    @if (entries.data.length) {
+      <div class="table-container">
+        <table mat-table [dataSource]="entries">
+
+          <ng-container matColumnDef="entryDate">
+            <th *matHeaderCellDef mat-header-cell class="col-header">Datum</th>
+            <td *matCellDef="let entry" mat-cell>{{ entry.entryDate | date:'dd.MM.yyyy':'':'de' }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="weightKg">
+            <th *matHeaderCellDef mat-header-cell class="col-header">Gewicht</th>
+            <td *matCellDef="let entry" mat-cell>{{ entry.weightKg | number:'1.1-1':'de' }} kg</td>
+          </ng-container>
+
+          <ng-container matColumnDef="actions">
+            <th *matHeaderCellDef mat-header-cell class="col-header"></th>
+            <td *matCellDef="let entry" mat-cell class="col-actions">
+              <button mat-icon-button class="btn-edit" (click)="openEditDialog(entry)">
+                <mat-icon>edit</mat-icon>
+              </button>
+              <button mat-icon-button class="btn-del" (click)="openDeleteDialog(entry)">
+                <mat-icon>delete</mat-icon>
+              </button>
+            </td>
+          </ng-container>
+
+          <tr *matHeaderRowDef="columnsToDisplay" mat-header-row></tr>
+          <tr *matRowDef="let entry; columns: columnsToDisplay;" mat-row></tr>
+
+        </table>
+      </div>
+    } @else {
+      <p class="empty">Noch keine Gewichtseinträge.</p>
+    }
+  </section>
+
+</div>

--- a/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.ts
+++ b/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.ts
@@ -1,0 +1,153 @@
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit, ViewChild} from '@angular/core';
+import {DatePipe, DecimalPipe} from '@angular/common';
+import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
+import {
+  MatCell,
+  MatCellDef,
+  MatColumnDef,
+  MatHeaderCell,
+  MatHeaderCellDef,
+  MatHeaderRow,
+  MatHeaderRowDef,
+  MatRow,
+  MatRowDef,
+  MatTable,
+  MatTableDataSource
+} from '@angular/material/table';
+import {MatFormField, MatLabel, MatSuffix} from '@angular/material/form-field';
+import {MatInput} from '@angular/material/input';
+import {MatDatepicker, MatDatepickerInput, MatDatepickerToggle} from '@angular/material/datepicker';
+import {MatButton, MatIconButton} from '@angular/material/button';
+import {MatIcon} from '@angular/material/icon';
+import {MatDialog} from '@angular/material/dialog';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {format} from 'date-fns';
+import {NutritionService} from '../../services/nutrition.service';
+import {WeightEntry, WeightEntryInput} from '../../models/nutrition.model';
+import {TargetsCardComponent} from '../targets-card/targets-card.component';
+import {WeightEditDialogComponent} from '../../dialogs/weight-edit-dialog/weight-edit-dialog.component';
+import {WeightDeleteDialogComponent} from '../../dialogs/weight-delete-dialog/weight-delete-dialog.component';
+
+@Component({
+  selector: 'app-nutrition-weight',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ReactiveFormsModule,
+    DatePipe,
+    DecimalPipe,
+    MatTable,
+    MatColumnDef,
+    MatHeaderCell,
+    MatHeaderCellDef,
+    MatCellDef,
+    MatCell,
+    MatHeaderRow,
+    MatHeaderRowDef,
+    MatRow,
+    MatRowDef,
+    MatFormField,
+    MatLabel,
+    MatSuffix,
+    MatInput,
+    MatDatepicker,
+    MatDatepickerInput,
+    MatDatepickerToggle,
+    MatButton,
+    MatIconButton,
+    MatIcon,
+    TargetsCardComponent
+  ],
+  templateUrl: './nutrition-weight.component.html',
+  styleUrl: './nutrition-weight.component.css'
+})
+export class NutritionWeightComponent implements OnInit {
+
+  @ViewChild(TargetsCardComponent) targetsCard?: TargetsCardComponent;
+
+  form!: FormGroup;
+  entries = new MatTableDataSource<WeightEntry>();
+  columnsToDisplay = ['entryDate', 'weightKg', 'actions'];
+
+  private fb = inject(FormBuilder);
+  private nutritionService = inject(NutritionService);
+  private dialog = inject(MatDialog);
+  private snackBar = inject(MatSnackBar);
+  private cdr = inject(ChangeDetectorRef);
+
+  ngOnInit(): void {
+    this.form = this.fb.group({
+      entryDate: [new Date(), Validators.required],
+      weightKg: [null, [Validators.required, Validators.min(0)]]
+    });
+    this.loadEntries();
+  }
+
+  private loadEntries(): void {
+    this.nutritionService.getWeightEntries().subscribe(entries => {
+      this.entries.data = this.sortDesc(entries);
+      this.cdr.markForCheck();
+    });
+  }
+
+  private sortDesc(entries: WeightEntry[]): WeightEntry[] {
+    return [...entries].sort((a, b) => b.entryDate.localeCompare(a.entryDate));
+  }
+
+  add(): void {
+    if (this.form.invalid) return;
+    const {entryDate, weightKg} = this.form.value;
+    const payload: WeightEntryInput = {
+      entryDate: format(entryDate, 'yyyy-MM-dd'),
+      weightKg: Number(weightKg)
+    };
+    this.nutritionService.addWeightEntry(payload).subscribe({
+      next: created => {
+        this.entries.data = this.sortDesc([...this.entries.data, created]);
+        this.form.reset({entryDate: new Date(), weightKg: null});
+        this.targetsCard?.reload();
+        this.cdr.markForCheck();
+        this.snackBar.open('Gewicht gespeichert', 'OK', {duration: 3000});
+      },
+      error: () => {
+        this.snackBar.open('Gewicht konnte nicht gespeichert werden', 'Schließen', {duration: 5000});
+      }
+    });
+  }
+
+  openEditDialog(entry: WeightEntry): void {
+    const ref = this.dialog.open(WeightEditDialogComponent, {data: entry});
+    ref.afterClosed().subscribe((result: WeightEntryInput | undefined) => {
+      if (!result) return;
+      this.nutritionService.updateWeightEntry(entry.id, result).subscribe({
+        next: updated => {
+          this.entries.data = this.sortDesc(this.entries.data.map(e => e.id === updated.id ? updated : e));
+          this.targetsCard?.reload();
+          this.cdr.markForCheck();
+          this.snackBar.open('Gewicht aktualisiert', 'OK', {duration: 3000});
+        },
+        error: () => {
+          this.snackBar.open('Gewicht konnte nicht aktualisiert werden', 'Schließen', {duration: 5000});
+        }
+      });
+    });
+  }
+
+  openDeleteDialog(entry: WeightEntry): void {
+    const ref = this.dialog.open(WeightDeleteDialogComponent);
+    ref.afterClosed().subscribe(result => {
+      if (result !== 'confirmed') return;
+      this.nutritionService.deleteWeightEntry(entry.id).subscribe({
+        next: () => {
+          this.entries.data = this.entries.data.filter(e => e.id !== entry.id);
+          this.targetsCard?.reload();
+          this.cdr.markForCheck();
+          this.snackBar.open('Gewicht gelöscht', 'OK', {duration: 3000});
+        },
+        error: err => {
+          const msg = err.status === 404 ? 'Eintrag nicht gefunden' : 'Gewicht konnte nicht gelöscht werden';
+          this.snackBar.open(msg, 'Schließen', {duration: 5000});
+        }
+      });
+    });
+  }
+}

--- a/src/app/nutrition/components/targets-card/targets-card.component.css
+++ b/src/app/nutrition/components/targets-card/targets-card.component.css
@@ -1,0 +1,212 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-g:  #a3e635;   /* lime — nutrition accent */
+  --c-p:  #4da6ff;   /* protein */
+  --c-c:  #fbbf24;   /* carbs */
+  --c-f:  #fb7185;   /* fat */
+
+  display: block;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1.25rem 1.5rem 1.5rem;
+  animation: fadeUp 0.5s ease both;
+}
+
+/* ── Head ────────────────────────────────────────── */
+.card__head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.card__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--c-g);
+  box-shadow: 0 0 6px var(--c-g);
+  animation: blink 2s ease-in-out infinite;
+}
+
+.card__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+}
+
+/* ── States ──────────────────────────────────────── */
+.card__state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+}
+
+.card__state--empty {
+  flex-direction: column;
+  gap: 0.6rem;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.card__state--empty mat-icon {
+  color: var(--c-g);
+  width: 28px;
+  height: 28px;
+  font-size: 28px;
+}
+
+.card__state--empty p {
+  margin: 0;
+  max-width: 36ch;
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+/* ── Calories ────────────────────────────────────── */
+.kcal {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.kcal__main {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.kcal__value {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 2.6rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--c-g);
+  text-shadow: 0 0 18px rgba(163, 230, 53, 0.25);
+}
+
+.kcal__unit {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.kcal__sub {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.kcal__sub-item {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.kcal__sub-label {
+  font-size: 0.7rem;
+  color: var(--text-dim);
+}
+
+.kcal__sub-value {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+/* ── Macros ──────────────────────────────────────── */
+.macros {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.macro {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.9rem 0.5rem;
+  background: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  border-top: 2px solid var(--mc, var(--border-mid));
+}
+
+.macro--p { --mc: var(--c-p); }
+.macro--c { --mc: var(--c-c); }
+.macro--f { --mc: var(--c-f); }
+
+.macro__value {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--mc);
+}
+
+.macro__unit {
+  font-size: 0.8rem;
+  margin-left: 1px;
+}
+
+.macro__label {
+  font-size: 0.65rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+/* ── Basis flag ──────────────────────────────────── */
+.basis {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 1.1rem;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.basis mat-icon {
+  width: 16px;
+  height: 16px;
+  font-size: 16px;
+  color: var(--text-dim);
+}
+
+.basis--manual mat-icon { color: var(--c-g); }
+
+/* ── Animations ──────────────────────────────────── */
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}

--- a/src/app/nutrition/components/targets-card/targets-card.component.html
+++ b/src/app/nutrition/components/targets-card/targets-card.component.html
@@ -1,0 +1,58 @@
+<section class="card">
+  <header class="card__head">
+    <span class="card__dot"></span>
+    <span class="card__label">TAGESZIELE</span>
+  </header>
+
+  @if (loading) {
+    <div class="card__state">
+      <mat-progress-spinner mode="indeterminate" diameter="28" />
+    </div>
+  } @else if (unavailable) {
+    <div class="card__state card__state--empty">
+      <mat-icon>info</mat-icon>
+      <p>{{ unavailable }}</p>
+    </div>
+  } @else if (targets) {
+    <div class="kcal">
+      <div class="kcal__main">
+        <span class="kcal__value">{{ targets.targetKcal | number:'1.0-0':'de' }}</span>
+        <span class="kcal__unit">kcal / Tag</span>
+      </div>
+      <div class="kcal__sub">
+        <div class="kcal__sub-item">
+          <span class="kcal__sub-label">Grundumsatz (BMR)</span>
+          <span class="kcal__sub-value">{{ targets.bmr | number:'1.0-0':'de' }} kcal</span>
+        </div>
+        <div class="kcal__sub-item">
+          <span class="kcal__sub-label">Erhaltungsbedarf</span>
+          <span class="kcal__sub-value">{{ targets.maintenanceKcal | number:'1.0-0':'de' }} kcal</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="macros">
+      <div class="macro macro--p">
+        <span class="macro__value">{{ targets.proteinG | number:'1.0-0':'de' }}<span class="macro__unit">g</span></span>
+        <span class="macro__label">Protein</span>
+      </div>
+      <div class="macro macro--c">
+        <span class="macro__value">{{ targets.carbsG | number:'1.0-0':'de' }}<span class="macro__unit">g</span></span>
+        <span class="macro__label">Kohlenhydrate</span>
+      </div>
+      <div class="macro macro--f">
+        <span class="macro__value">{{ targets.fatG | number:'1.0-0':'de' }}<span class="macro__unit">g</span></span>
+        <span class="macro__label">Fett</span>
+      </div>
+    </div>
+
+    <div class="basis" [class.basis--manual]="targets.basis === 'MANUAL'">
+      <mat-icon>{{ targets.basis === 'MANUAL' ? 'tune' : 'functions' }}</mat-icon>
+      <span>
+        {{ targets.basis === 'MANUAL'
+          ? 'BMR aus manuellem Wert'
+          : 'BMR aus Mifflin–St-Jeor-Formel' }}
+      </span>
+    </div>
+  }
+</section>

--- a/src/app/nutrition/components/targets-card/targets-card.component.ts
+++ b/src/app/nutrition/components/targets-card/targets-card.component.ts
@@ -1,0 +1,56 @@
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit} from '@angular/core';
+import {DecimalPipe} from '@angular/common';
+import {HttpErrorResponse} from '@angular/common/http';
+import {MatIcon} from '@angular/material/icon';
+import {MatProgressSpinner} from '@angular/material/progress-spinner';
+import {NutritionService} from '../../services/nutrition.service';
+import {Targets} from '../../models/nutrition.model';
+
+/**
+ * Reusable card that shows the computed daily targets from
+ * `GET /nutrition/targets`. Parents can trigger a re-fetch via {@link reload}
+ * after the profile or weight log changes.
+ */
+@Component({
+  selector: 'app-targets-card',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DecimalPipe, MatIcon, MatProgressSpinner],
+  templateUrl: './targets-card.component.html',
+  styleUrl: './targets-card.component.css'
+})
+export class TargetsCardComponent implements OnInit {
+
+  targets: Targets | null = null;
+  loading = false;
+  /** Set when targets cannot be computed (e.g. no profile / no weight yet). */
+  unavailable: string | null = null;
+
+  private nutritionService = inject(NutritionService);
+  private cdr = inject(ChangeDetectorRef);
+
+  ngOnInit(): void {
+    this.reload();
+  }
+
+  reload(): void {
+    this.loading = true;
+    this.unavailable = null;
+    this.cdr.markForCheck();
+
+    this.nutritionService.getTargets().subscribe({
+      next: targets => {
+        this.targets = targets;
+        this.loading = false;
+        this.cdr.markForCheck();
+      },
+      error: (err: HttpErrorResponse) => {
+        this.targets = null;
+        this.loading = false;
+        this.unavailable = err.status >= 400 && err.status < 500
+          ? 'Noch keine Ziele berechenbar. Bitte zuerst ein Profil und mindestens einen Gewichtseintrag erfassen.'
+          : 'Ziele konnten nicht geladen werden.';
+        this.cdr.markForCheck();
+      }
+    });
+  }
+}

--- a/src/app/nutrition/dialogs/weight-delete-dialog/weight-delete-dialog.component.css
+++ b/src/app/nutrition/dialogs/weight-delete-dialog/weight-delete-dialog.component.css
@@ -1,0 +1,69 @@
+:host {
+  --surface:     #0c1018;
+  --border-mid:  rgba(255, 255, 255, 0.13);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --c-n:         #2dd4bf;
+  --c-e:         #fb7185;
+}
+
+::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-dialog-title {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
+  color: var(--text) !important;
+  letter-spacing: 0.03em;
+}
+
+::ng-deep .mat-mdc-dialog-content {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.9rem !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions {
+  gap: 10px;
+  padding-bottom: 16px !important;
+  justify-content: center !important;
+}
+
+.btn-confirm {
+  background: rgba(45, 212, 191, 0.10) !important;
+  border: 1px solid rgba(45, 212, 191, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-n) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-confirm:hover {
+  background: rgba(45, 212, 191, 0.18) !important;
+  box-shadow: 0 0 12px rgba(45, 212, 191, 0.25) !important;
+}
+
+.btn-confirm mat-icon {
+  color: var(--c-n) !important;
+}
+
+.btn-cancel {
+  background: rgba(251, 113, 133, 0.10) !important;
+  border: 1px solid rgba(251, 113, 133, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-e) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-cancel:hover {
+  background: rgba(251, 113, 133, 0.18) !important;
+  box-shadow: 0 0 12px rgba(251, 113, 133, 0.25) !important;
+}
+
+.btn-cancel mat-icon {
+  color: var(--c-e) !important;
+}

--- a/src/app/nutrition/dialogs/weight-delete-dialog/weight-delete-dialog.component.html
+++ b/src/app/nutrition/dialogs/weight-delete-dialog/weight-delete-dialog.component.html
@@ -1,0 +1,14 @@
+<h2 mat-dialog-title>Gewicht löschen</h2>
+
+<mat-dialog-content>
+  <span>Diesen Gewichtseintrag wirklich löschen?</span>
+</mat-dialog-content>
+
+<mat-dialog-actions align="center">
+  <button mat-mini-fab class="btn-confirm" (click)="confirm()">
+    <mat-icon>check_circle</mat-icon>
+  </button>
+  <button mat-mini-fab mat-dialog-close class="btn-cancel">
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-dialog-actions>

--- a/src/app/nutrition/dialogs/weight-delete-dialog/weight-delete-dialog.component.ts
+++ b/src/app/nutrition/dialogs/weight-delete-dialog/weight-delete-dialog.component.ts
@@ -1,0 +1,27 @@
+import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
+import {MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MatIcon} from '@angular/material/icon';
+import {MatMiniFabButton} from '@angular/material/button';
+
+@Component({
+  selector: 'app-weight-delete-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatIcon,
+    MatMiniFabButton
+  ],
+  templateUrl: './weight-delete-dialog.component.html',
+  styleUrl: './weight-delete-dialog.component.css'
+})
+export class WeightDeleteDialogComponent {
+
+  private dialogRef = inject(MatDialogRef<WeightDeleteDialogComponent>);
+
+  confirm() {
+    this.dialogRef.close('confirmed');
+  }
+}

--- a/src/app/nutrition/dialogs/weight-edit-dialog/weight-edit-dialog.component.css
+++ b/src/app/nutrition/dialogs/weight-edit-dialog/weight-edit-dialog.component.css
@@ -1,0 +1,117 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+  --c-g:         #a3e635;
+  --c-n:         #2dd4bf;
+  --c-e:         #fb7185;
+}
+
+::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+  min-width: 320px !important;
+}
+
+::ng-deep .mat-mdc-dialog-title {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
+  color: var(--text) !important;
+  letter-spacing: 0.03em;
+}
+
+::ng-deep .mat-mdc-dialog-content {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.9rem !important;
+  overflow: visible !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions {
+  gap: 10px;
+  padding-bottom: 16px !important;
+  justify-content: center !important;
+}
+
+/* Form layout */
+.edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.5rem;
+}
+
+.field-full { width: 100%; }
+
+/* Dark theme form fields */
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__trailing {
+  border-color: var(--border-mid) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined:not(.mdc-text-field--disabled) .mdc-text-field__input {
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-mdc-floating-label {
+  color: var(--text-dim) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-datepicker-toggle {
+  color: var(--text-dim) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__trailing {
+  border-color: var(--c-g) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mat-mdc-floating-label {
+  color: var(--c-g) !important;
+}
+
+/* Buttons */
+.btn-confirm {
+  background: rgba(45, 212, 191, 0.10) !important;
+  border: 1px solid rgba(45, 212, 191, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-n) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-confirm:hover:not([disabled]) {
+  background: rgba(45, 212, 191, 0.18) !important;
+  box-shadow: 0 0 12px rgba(45, 212, 191, 0.25) !important;
+}
+
+.btn-confirm[disabled] {
+  opacity: 0.4 !important;
+}
+
+.btn-confirm mat-icon { color: var(--c-n) !important; }
+
+.btn-cancel {
+  background: rgba(251, 113, 133, 0.10) !important;
+  border: 1px solid rgba(251, 113, 133, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-e) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-cancel:hover {
+  background: rgba(251, 113, 133, 0.18) !important;
+  box-shadow: 0 0 12px rgba(251, 113, 133, 0.25) !important;
+}
+
+.btn-cancel mat-icon { color: var(--c-e) !important; }

--- a/src/app/nutrition/dialogs/weight-edit-dialog/weight-edit-dialog.component.html
+++ b/src/app/nutrition/dialogs/weight-edit-dialog/weight-edit-dialog.component.html
@@ -1,0 +1,26 @@
+<h2 mat-dialog-title>Gewicht bearbeiten</h2>
+
+<mat-dialog-content>
+  <form class="edit-form" [formGroup]="form">
+    <mat-form-field appearance="outline" class="field-full">
+      <mat-label>Datum</mat-label>
+      <input matInput formControlName="entryDate" [matDatepicker]="picker" />
+      <mat-datepicker-toggle matIconSuffix [for]="picker" />
+      <mat-datepicker #picker />
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="field-full">
+      <mat-label>Gewicht (kg)</mat-label>
+      <input matInput type="number" step="0.1" formControlName="weightKg" />
+    </mat-form-field>
+  </form>
+</mat-dialog-content>
+
+<mat-dialog-actions align="center">
+  <button mat-mini-fab class="btn-confirm" [disabled]="form.invalid" (click)="save()">
+    <mat-icon>check_circle</mat-icon>
+  </button>
+  <button mat-mini-fab mat-dialog-close class="btn-cancel">
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-dialog-actions>

--- a/src/app/nutrition/dialogs/weight-edit-dialog/weight-edit-dialog.component.ts
+++ b/src/app/nutrition/dialogs/weight-edit-dialog/weight-edit-dialog.component.ts
@@ -1,0 +1,57 @@
+import {ChangeDetectionStrategy, Component, inject, OnInit} from '@angular/core';
+import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
+import {MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MatFormField, MatLabel, MatSuffix} from '@angular/material/form-field';
+import {MatInput} from '@angular/material/input';
+import {MatDatepicker, MatDatepickerInput, MatDatepickerToggle} from '@angular/material/datepicker';
+import {MatIcon} from '@angular/material/icon';
+import {MatMiniFabButton} from '@angular/material/button';
+import {format, parseISO} from 'date-fns';
+import {WeightEntry, WeightEntryInput} from '../../models/nutrition.model';
+
+@Component({
+  selector: 'app-weight-edit-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ReactiveFormsModule,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatFormField,
+    MatLabel,
+    MatSuffix,
+    MatInput,
+    MatDatepicker,
+    MatDatepickerInput,
+    MatDatepickerToggle,
+    MatIcon,
+    MatMiniFabButton
+  ],
+  templateUrl: './weight-edit-dialog.component.html',
+  styleUrl: './weight-edit-dialog.component.css'
+})
+export class WeightEditDialogComponent implements OnInit {
+
+  private fb = inject(FormBuilder);
+  private dialogRef = inject(MatDialogRef<WeightEditDialogComponent>);
+  private data = inject<WeightEntry>(MAT_DIALOG_DATA);
+
+  form!: FormGroup;
+
+  ngOnInit(): void {
+    this.form = this.fb.group({
+      entryDate: [parseISO(this.data.entryDate), Validators.required],
+      weightKg: [this.data.weightKg, [Validators.required, Validators.min(0)]]
+    });
+  }
+
+  save(): void {
+    if (this.form.invalid) return;
+    const {entryDate, weightKg} = this.form.value;
+    const result: WeightEntryInput = {
+      entryDate: format(entryDate, 'yyyy-MM-dd'),
+      weightKg: Number(weightKg)
+    };
+    this.dialogRef.close(result);
+  }
+}

--- a/src/app/nutrition/models/nutrition.model.ts
+++ b/src/app/nutrition/models/nutrition.model.ts
@@ -7,9 +7,12 @@ export type Sex = 'MALE' | 'FEMALE';
 
 export type ActivityLevel = 'SEDENTARY' | 'LIGHT' | 'MODERATE' | 'ACTIVE' | 'VERY_ACTIVE';
 
-export type Goal = 'LOSE' | 'MAINTAIN' | 'GAIN';
+export type Goal = 'CUT' | 'MAINTAIN' | 'BULK';
 
 export type MealType = 'BREAKFAST' | 'LUNCH' | 'DINNER' | 'SNACK';
+
+/** Whether the BMR used for the targets came from the manual value or the formula. */
+export type TargetBasis = 'MANUAL' | 'FORMULA';
 
 export interface Profile {
   id: string;
@@ -18,19 +21,36 @@ export interface Profile {
   heightCm: number;
   activityLevel: ActivityLevel;
   goal: Goal;
+  proteinPerKg: number;
+  /** Fat share of target kcal as a fraction, e.g. 0.30 for 30 %. */
+  fatPct: number;
+  /** Manual basal kcal; when set it overrides the Mifflin–St Jeor formula. */
+  basalKcal: number | null;
 }
+
+/** Editable profile payload sent on PUT /nutrition/profile (no audit/id fields). */
+export type ProfileInput = Omit<Profile, 'id'>;
 
 export interface WeightEntry {
   id: string;
-  date: string;
+  entryDate: string;
+  weightKg: number;
+}
+
+/** Create/update payload for a weight entry. */
+export interface WeightEntryInput {
+  entryDate: string;
   weightKg: number;
 }
 
 export interface Targets {
-  calories: number;
+  bmr: number;
+  maintenanceKcal: number;
+  targetKcal: number;
   proteinG: number;
-  carbsG: number;
   fatG: number;
+  carbsG: number;
+  basis: TargetBasis;
 }
 
 export interface Food {

--- a/src/app/nutrition/services/nutrition.service.ts
+++ b/src/app/nutrition/services/nutrition.service.ts
@@ -1,16 +1,24 @@
-import {Injectable} from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {Observable} from 'rxjs';
 import {environment} from '../../../environments/environment';
-import {DaySummary, Food, MealEntry, Profile, Targets, WeightEntry} from '../models/nutrition.model';
+import {
+  DaySummary,
+  Food,
+  MealEntry,
+  Profile,
+  ProfileInput,
+  Targets,
+  WeightEntry,
+  WeightEntryInput
+} from '../models/nutrition.model';
 
 /**
  * HTTP access for the nutrition / calorie tracker feature.
  *
- * Endpoints mirror the backend `nutrition` module. Method bodies are kept
- * intentionally thin at the scaffold stage; the follow-up issues
- * (profile/weight/targets, food catalog, meal logging) flesh out the
- * payloads and add the remaining endpoints.
+ * Endpoints mirror the backend `nutrition` module. Profile, weight log and
+ * targets are wired up; the food catalog, meal logging and day summary
+ * endpoints are fleshed out by the follow-up issues.
  */
 @Injectable({
   providedIn: 'root'
@@ -19,10 +27,14 @@ export class NutritionService {
 
   private host = `${environment.apiUrl}/nutrition`;
 
-  constructor(private http: HttpClient) {}
+  private http = inject(HttpClient);
 
   getProfile(): Observable<Profile> {
     return this.http.get<Profile>(`${this.host}/profile`);
+  }
+
+  updateProfile(profile: ProfileInput): Observable<Profile> {
+    return this.http.put<Profile>(`${this.host}/profile`, profile);
   }
 
   getTargets(): Observable<Targets> {
@@ -31,6 +43,18 @@ export class NutritionService {
 
   getWeightEntries(): Observable<WeightEntry[]> {
     return this.http.get<WeightEntry[]>(`${this.host}/weight`);
+  }
+
+  addWeightEntry(entry: WeightEntryInput): Observable<WeightEntry> {
+    return this.http.post<WeightEntry>(`${this.host}/weight`, entry);
+  }
+
+  updateWeightEntry(id: string, entry: WeightEntryInput): Observable<WeightEntry> {
+    return this.http.put<WeightEntry>(`${this.host}/weight/${id}`, entry);
+  }
+
+  deleteWeightEntry(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.host}/weight/${id}`);
   }
 
   searchFoods(query: string): Observable<Food[]> {


### PR DESCRIPTION
Implements #140 (nutrition F2) — UI to log bodyweight, edit the profile, and view computed daily targets.

> **Note:** the F1 scaffold (#... `feat(nutrition): scaffold module, layout & routing`) had not been merged to `master`, so this branch is built on top of it and the PR includes that scaffold commit as well.

## What's included

### Weight log — `/nutrition/weight`
- Reactive form (de-DE date picker + weight) to add an entry.
- `MatTable` list sorted by date desc with edit & delete dialogs.
- `MatSnackBar` feedback on every mutation.

### Profile form — `/nutrition/profile`
- Sex, birth date, height, activity level (`MatSelect`), goal (`MatSelect`), protein per kg, fat % and an **optional manual basal-kcal field** that overrides the formula (with a hint).
- Loads the existing profile; treats a 404 as "no profile yet" and keeps sensible defaults.

### Targets card — `GET /nutrition/targets`
- Reusable component showing BMR, maintenance, target kcal and protein/fat/carb grams.
- Indicates whether the BMR came from the manual value or the Mifflin–St-Jeor formula (`basis`).
- Handles the "no profile / no weight yet" state gracefully.
- **Adding weight / editing the profile reloads the card live** (via `@ViewChild`).

### Service & models
- `updateProfile` (PUT) and weight `add`/`update`/`delete` (POST/PUT/DELETE).
- Models aligned with backend Marvin1912/backend#104: `Goal` = `CUT|MAINTAIN|BULK`, `WeightEntry.entryDate`, targets `{bmr, maintenanceKcal, targetKcal, proteinG, fatG, carbsG, basis}`.

## Acceptance criteria
- [x] Adding weight / editing profile updates the targets card.
- [x] `npm run build` passes.
- [x] `npm run lint` — new code is lint-clean (`inject()`, OnPush, self-closing tags). The two remaining `prefer-inject` findings on `nutrition-layout` are pre-existing baseline, identical to the other module layouts (`grocery-layout`, `plant-layout`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)