### PR TITLE
feat(nutrition): food catalog + photo label scan UI

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -33,6 +33,7 @@ import {NutritionLayoutComponent} from './nutrition/components/nutrition-layout/
 import {NutritionHomeComponent} from './nutrition/components/nutrition-home/nutrition-home.component';
 import {NutritionWeightComponent} from './nutrition/components/nutrition-weight/nutrition-weight.component';
 import {NutritionProfileComponent} from './nutrition/components/nutrition-profile/nutrition-profile.component';
+import {NutritionFoodsComponent} from './nutrition/components/nutrition-foods/nutrition-foods.component';
 
 export const routes: Routes = [
   {path: '', component: HomeComponent},
@@ -108,6 +109,7 @@ export const routes: Routes = [
     children: [
       {path: '', component: NutritionHomeComponent, data: {home: '/'}},
       {path: 'weight', component: NutritionWeightComponent, data: {home: '/nutrition'}},
+      {path: 'foods', component: NutritionFoodsComponent, data: {home: '/nutrition'}},
       {path: 'profile', component: NutritionProfileComponent, data: {home: '/nutrition'}}
     ]
   }

--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.css
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.css
@@ -1,0 +1,230 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-g:  #a3e635;
+  --c-n:  #2dd4bf;
+  --c-e:  #fb7185;
+
+  display: block;
+  height: 100%;
+  overflow-y: auto;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+}
+
+.foods {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem clamp(1rem, 6vw, 4rem);
+  max-width: 760px;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+/* ── Panels ──────────────────────────────────────── */
+.panel__head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.panel__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--c-g);
+  box-shadow: 0 0 6px var(--c-g);
+}
+
+.panel__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+}
+
+/* ── Toolbar ─────────────────────────────────────── */
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.field-search { flex: 1 1 220px; }
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.btn-add,
+.btn-scan {
+  height: 56px;
+  border-radius: 8px !important;
+  font-weight: 600 !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-add {
+  background: color-mix(in srgb, var(--c-g) 14%, transparent) !important;
+  border: 1px solid color-mix(in srgb, var(--c-g) 35%, transparent) !important;
+  color: var(--c-g) !important;
+}
+
+.btn-add:hover {
+  background: color-mix(in srgb, var(--c-g) 22%, transparent) !important;
+  box-shadow: 0 0 12px rgba(163, 230, 53, 0.25) !important;
+}
+
+.btn-scan {
+  background: color-mix(in srgb, var(--c-n) 14%, transparent) !important;
+  border: 1px solid color-mix(in srgb, var(--c-n) 35%, transparent) !important;
+  color: var(--c-n) !important;
+}
+
+.btn-scan:hover:not([disabled]) {
+  background: color-mix(in srgb, var(--c-n) 22%, transparent) !important;
+  box-shadow: 0 0 12px rgba(45, 212, 191, 0.25) !important;
+}
+
+.btn-scan[disabled] { opacity: 0.55 !important; }
+
+.btn-scan mat-spinner { margin-right: 4px; }
+
+::ng-deep .btn-scan mat-spinner circle { stroke: var(--c-n) !important; }
+
+/* ── Table ───────────────────────────────────────── */
+.table-container {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  background: transparent !important;
+}
+
+.col-header {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.6rem !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.12em !important;
+  text-transform: uppercase !important;
+  color: var(--text-dim) !important;
+  background: var(--raised) !important;
+  border-bottom: 1px solid var(--border-mid) !important;
+  height: 36px !important;
+  padding: 0 12px !important;
+}
+
+::ng-deep .mat-mdc-header-row {
+  background: var(--raised) !important;
+}
+
+::ng-deep .mat-mdc-cell {
+  font-size: 0.85rem !important;
+  color: var(--text) !important;
+  background: transparent !important;
+  border-bottom: 1px solid var(--border) !important;
+  padding: 0 12px !important;
+}
+
+.col-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.food-name { display: block; }
+
+.food-brand {
+  display: block;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+.col-actions {
+  width: 96px;
+  text-align: right;
+  padding-right: 8px !important;
+  white-space: nowrap;
+}
+
+.btn-edit {
+  color: var(--text-dim);
+  transition: color 0.2s;
+}
+
+.btn-edit:hover { color: var(--c-g); }
+
+.btn-del {
+  color: var(--text-dim);
+  transition: color 0.2s;
+}
+
+.btn-del:hover { color: var(--c-e); }
+
+.hint {
+  margin: 0.6rem 0 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+}
+
+/* ── Empty ───────────────────────────────────────── */
+.empty {
+  margin: 0;
+  padding: 1.5rem;
+  text-align: center;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  background: var(--surface);
+  border: 1px dashed var(--border-mid);
+  border-radius: 12px;
+}
+
+/* ── Dark form fields ────────────────────────────── */
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__trailing {
+  border-color: var(--border-mid) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined:not(.mdc-text-field--disabled) .mdc-text-field__input {
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-mdc-floating-label {
+  color: var(--text-dim) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-icon {
+  color: var(--text-dim) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__trailing {
+  border-color: var(--c-g) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mat-mdc-floating-label {
+  color: var(--c-g) !important;
+}

--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.html
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.html
@@ -1,0 +1,99 @@
+<div class="foods">
+
+  <section class="panel">
+    <header class="panel__head">
+      <span class="panel__dot"></span>
+      <span class="panel__label">LEBENSMITTEL</span>
+    </header>
+
+    <div class="toolbar">
+      <mat-form-field appearance="outline" class="field-search">
+        <mat-label>Suchen</mat-label>
+        <mat-icon matPrefix>search</mat-icon>
+        <input matInput autocomplete="off" [formControl]="search" />
+      </mat-form-field>
+
+      <div class="actions">
+        <button mat-flat-button type="button" class="btn-add" (click)="openAddDialog()">
+          <mat-icon>add</mat-icon>
+          Neu
+        </button>
+        <button mat-flat-button type="button" class="btn-scan" [disabled]="scanning" (click)="triggerPhoto()">
+          @if (scanning) {
+            <mat-spinner diameter="18" />
+          } @else {
+            <mat-icon>photo_camera</mat-icon>
+          }
+          Foto
+        </button>
+        <input #photoInput type="file" accept="image/*" capture="environment" hidden
+               (change)="onPhotoSelected($event)" />
+      </div>
+    </div>
+  </section>
+
+  <section class="panel">
+    @if (foods.data.length) {
+      <div class="table-container">
+        <table mat-table [dataSource]="foods">
+
+          <ng-container matColumnDef="name">
+            <th *matHeaderCellDef mat-header-cell class="col-header">Name</th>
+            <td *matCellDef="let food" mat-cell>
+              <span class="food-name">{{ food.name }}</span>
+              @if (food.brand) {
+                <span class="food-brand">{{ food.brand }}</span>
+              }
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="kcal">
+            <th *matHeaderCellDef mat-header-cell class="col-header col-num">kcal</th>
+            <td *matCellDef="let food" mat-cell class="col-num">{{ food.kcalPer100 | number:'1.0-0':'de' }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="protein">
+            <th *matHeaderCellDef mat-header-cell class="col-header col-num">P</th>
+            <td *matCellDef="let food" mat-cell class="col-num">{{ food.proteinPer100 | number:'1.0-1':'de' }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="carbs">
+            <th *matHeaderCellDef mat-header-cell class="col-header col-num">KH</th>
+            <td *matCellDef="let food" mat-cell class="col-num">{{ food.carbsPer100 | number:'1.0-1':'de' }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="fat">
+            <th *matHeaderCellDef mat-header-cell class="col-header col-num">F</th>
+            <td *matCellDef="let food" mat-cell class="col-num">{{ food.fatPer100 | number:'1.0-1':'de' }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="actions">
+            <th *matHeaderCellDef mat-header-cell class="col-header"></th>
+            <td *matCellDef="let food" mat-cell class="col-actions">
+              <button mat-icon-button class="btn-edit" (click)="openEditDialog(food)">
+                <mat-icon>edit</mat-icon>
+              </button>
+              <button mat-icon-button class="btn-del" (click)="openDeleteDialog(food)">
+                <mat-icon>delete</mat-icon>
+              </button>
+            </td>
+          </ng-container>
+
+          <tr *matHeaderRowDef="columnsToDisplay" mat-header-row></tr>
+          <tr *matRowDef="let food; columns: columnsToDisplay;" mat-row></tr>
+
+        </table>
+      </div>
+      <p class="hint">Werte je 100 g · P Protein · KH Kohlenhydrate · F Fett</p>
+    } @else {
+      <p class="empty">
+        @if (searchTerm) {
+          Keine Treffer für «{{ searchTerm }}».
+        } @else {
+          Noch keine Lebensmittel. Lege eins manuell an oder scanne ein Etikett.
+        }
+      </p>
+    }
+  </section>
+
+</div>

--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.ts
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.ts
@@ -1,0 +1,185 @@
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit, ViewChild} from '@angular/core';
+import {DecimalPipe} from '@angular/common';
+import {FormControl, ReactiveFormsModule} from '@angular/forms';
+import {
+  MatCell,
+  MatCellDef,
+  MatColumnDef,
+  MatHeaderCell,
+  MatHeaderCellDef,
+  MatHeaderRow,
+  MatHeaderRowDef,
+  MatRow,
+  MatRowDef,
+  MatTable,
+  MatTableDataSource
+} from '@angular/material/table';
+import {MatFormField, MatLabel, MatPrefix} from '@angular/material/form-field';
+import {MatInput} from '@angular/material/input';
+import {MatButton, MatIconButton} from '@angular/material/button';
+import {MatIcon} from '@angular/material/icon';
+import {MatProgressSpinner} from '@angular/material/progress-spinner';
+import {MatDialog} from '@angular/material/dialog';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {debounceTime, distinctUntilChanged, startWith, switchMap} from 'rxjs';
+import {NutritionService} from '../../services/nutrition.service';
+import {Food, FoodInput} from '../../models/nutrition.model';
+import {FoodEditDialogComponent, FoodEditDialogData} from '../../dialogs/food-edit-dialog/food-edit-dialog.component';
+import {FoodDeleteDialogComponent} from '../../dialogs/food-delete-dialog/food-delete-dialog.component';
+
+@Component({
+  selector: 'app-nutrition-foods',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ReactiveFormsModule,
+    DecimalPipe,
+    MatTable,
+    MatColumnDef,
+    MatHeaderCell,
+    MatHeaderCellDef,
+    MatCellDef,
+    MatCell,
+    MatHeaderRow,
+    MatHeaderRowDef,
+    MatRow,
+    MatRowDef,
+    MatFormField,
+    MatLabel,
+    MatPrefix,
+    MatInput,
+    MatButton,
+    MatIconButton,
+    MatIcon,
+    MatProgressSpinner
+  ],
+  templateUrl: './nutrition-foods.component.html',
+  styleUrl: './nutrition-foods.component.css'
+})
+export class NutritionFoodsComponent implements OnInit {
+
+  @ViewChild('photoInput') photoInput!: { nativeElement: HTMLInputElement };
+
+  search = new FormControl('', {nonNullable: true});
+  foods = new MatTableDataSource<Food>();
+  columnsToDisplay = ['name', 'kcal', 'protein', 'carbs', 'fat', 'actions'];
+  scanning = false;
+
+  get searchTerm(): string {
+    return this.search.value.trim();
+  }
+
+  private nutritionService = inject(NutritionService);
+  private dialog = inject(MatDialog);
+  private snackBar = inject(MatSnackBar);
+  private cdr = inject(ChangeDetectorRef);
+
+  ngOnInit(): void {
+    this.search.valueChanges.pipe(
+      startWith(this.search.value),
+      debounceTime(300),
+      distinctUntilChanged(),
+      switchMap(query => this.nutritionService.searchFoods(query.trim()))
+    ).subscribe(foods => {
+      this.foods.data = foods;
+      this.cdr.markForCheck();
+    });
+  }
+
+  private reload(): void {
+    this.nutritionService.searchFoods(this.search.value.trim()).subscribe(foods => {
+      this.foods.data = foods;
+      this.cdr.markForCheck();
+    });
+  }
+
+  openAddDialog(): void {
+    this.openFoodDialog({food: null, source: 'MANUAL'}, null);
+  }
+
+  openEditDialog(food: Food): void {
+    this.openFoodDialog({food, source: food.source}, food);
+  }
+
+  openDeleteDialog(food: Food): void {
+    const ref = this.dialog.open(FoodDeleteDialogComponent, {data: {name: food.name}});
+    ref.afterClosed().subscribe(result => {
+      if (result !== 'confirmed') return;
+      this.nutritionService.deleteFood(food.id).subscribe({
+        next: () => {
+          this.foods.data = this.foods.data.filter(f => f.id !== food.id);
+          this.cdr.markForCheck();
+          this.snackBar.open('Lebensmittel gelöscht', 'OK', {duration: 3000});
+        },
+        error: err => {
+          const msg = err.status === 404 ? 'Lebensmittel nicht gefunden' : 'Lebensmittel konnte nicht gelöscht werden';
+          this.snackBar.open(msg, 'Schließen', {duration: 5000});
+        }
+      });
+    });
+  }
+
+  triggerPhoto(): void {
+    this.photoInput.nativeElement.click();
+  }
+
+  onPhotoSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    // Reset so re-selecting the same file fires the change event again.
+    input.value = '';
+    if (!file) return;
+
+    this.scanning = true;
+    this.nutritionService.scanLabel(file).subscribe({
+      next: draft => {
+        this.scanning = false;
+        this.cdr.markForCheck();
+        // Prefill the add form with the parsed values; the user reviews and saves
+        // as a PHOTO-sourced food. The image itself is not stored.
+        this.openFoodDialog({food: null, prefill: draft, source: 'PHOTO'}, null);
+      },
+      error: () => {
+        this.scanning = false;
+        this.cdr.markForCheck();
+        this.snackBar.open('Etikett konnte nicht gelesen werden', 'Schließen', {duration: 5000});
+      }
+    });
+  }
+
+  private openFoodDialog(data: FoodEditDialogData, existing: Food | null): void {
+    const ref = this.dialog.open(FoodEditDialogComponent, {data});
+    ref.afterClosed().subscribe((result: FoodInput | undefined) => {
+      if (!result) return;
+      if (existing) {
+        this.update(existing.id, result);
+      } else {
+        this.create(result);
+      }
+    });
+  }
+
+  private create(input: FoodInput): void {
+    this.nutritionService.createFood(input).subscribe({
+      next: () => {
+        this.reload();
+        this.snackBar.open('Lebensmittel gespeichert', 'OK', {duration: 3000});
+      },
+      error: () => {
+        this.snackBar.open('Lebensmittel konnte nicht gespeichert werden', 'Schließen', {duration: 5000});
+      }
+    });
+  }
+
+  private update(id: string, input: FoodInput): void {
+    this.nutritionService.updateFood(id, input).subscribe({
+      next: updated => {
+        this.foods.data = this.foods.data.map(f => f.id === updated.id ? updated : f);
+        this.cdr.markForCheck();
+        this.snackBar.open('Lebensmittel aktualisiert', 'OK', {duration: 3000});
+      },
+      error: () => {
+        this.snackBar.open('Lebensmittel konnte nicht aktualisiert werden', 'Schließen', {duration: 5000});
+      }
+    });
+  }
+}

--- a/src/app/nutrition/components/nutrition-home/nutrition-home.component.css
+++ b/src/app/nutrition/components/nutrition-home/nutrition-home.component.css
@@ -9,6 +9,7 @@
   --text-dim:    #3d5470;
 
   --c-w:  #a3e635;  --cg-w: rgba(163, 230,  53, 0.18);
+  --c-f:  #2dd4bf;  --cg-f: rgba(45,  212, 191, 0.18);
   --c-p:  #4da6ff;  --cg-p: rgba(77,  166, 255, 0.18);
 
   display: block;
@@ -78,6 +79,7 @@
 .navcard:hover::before { opacity: 1; }
 
 .navcard--w { --cc: var(--c-w); --cc-glow: var(--cg-w); }
+.navcard--f { --cc: var(--c-f); --cc-glow: var(--cg-f); }
 .navcard--p { --cc: var(--c-p); --cc-glow: var(--cg-p); }
 
 .navcard__mark {
@@ -135,3 +137,4 @@
 
 .navcard:nth-child(1) { animation-delay: 0.05s; }
 .navcard:nth-child(2) { animation-delay: 0.12s; }
+.navcard:nth-child(3) { animation-delay: 0.19s; }

--- a/src/app/nutrition/components/nutrition-home/nutrition-home.component.html
+++ b/src/app/nutrition/components/nutrition-home/nutrition-home.component.html
@@ -10,6 +10,13 @@
       <span class="navcard__arrow" aria-hidden="true">↗</span>
     </a>
 
+    <a class="navcard navcard--f" routerLink="/nutrition/foods">
+      <div class="navcard__mark">⬡</div>
+      <h2 class="navcard__title">Lebensmittel</h2>
+      <p class="navcard__sub">Katalog & Etikett scannen</p>
+      <span class="navcard__arrow" aria-hidden="true">↗</span>
+    </a>
+
     <a class="navcard navcard--p" routerLink="/nutrition/profile">
       <div class="navcard__mark">☰</div>
       <h2 class="navcard__title">Profil</h2>

--- a/src/app/nutrition/components/nutrition-layout/nutrition-layout.component.html
+++ b/src/app/nutrition/components/nutrition-layout/nutrition-layout.component.html
@@ -14,6 +14,9 @@
         <button mat-menu-item routerLink="/nutrition/weight">
           <span>Gewicht</span>
         </button>
+        <button mat-menu-item routerLink="/nutrition/foods">
+          <span>Lebensmittel</span>
+        </button>
         <button mat-menu-item routerLink="/nutrition/profile">
           <span>Profil</span>
         </button>

--- a/src/app/nutrition/dialogs/food-delete-dialog/food-delete-dialog.component.css
+++ b/src/app/nutrition/dialogs/food-delete-dialog/food-delete-dialog.component.css
@@ -1,0 +1,69 @@
+:host {
+  --surface:     #0c1018;
+  --border-mid:  rgba(255, 255, 255, 0.13);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --c-n:         #2dd4bf;
+  --c-e:         #fb7185;
+}
+
+::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-dialog-title {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
+  color: var(--text) !important;
+  letter-spacing: 0.03em;
+}
+
+::ng-deep .mat-mdc-dialog-content {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.9rem !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions {
+  gap: 10px;
+  padding-bottom: 16px !important;
+  justify-content: center !important;
+}
+
+.btn-confirm {
+  background: rgba(45, 212, 191, 0.10) !important;
+  border: 1px solid rgba(45, 212, 191, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-n) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-confirm:hover {
+  background: rgba(45, 212, 191, 0.18) !important;
+  box-shadow: 0 0 12px rgba(45, 212, 191, 0.25) !important;
+}
+
+.btn-confirm mat-icon {
+  color: var(--c-n) !important;
+}
+
+.btn-cancel {
+  background: rgba(251, 113, 133, 0.10) !important;
+  border: 1px solid rgba(251, 113, 133, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-e) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-cancel:hover {
+  background: rgba(251, 113, 133, 0.18) !important;
+  box-shadow: 0 0 12px rgba(251, 113, 133, 0.25) !important;
+}
+
+.btn-cancel mat-icon {
+  color: var(--c-e) !important;
+}

--- a/src/app/nutrition/dialogs/food-delete-dialog/food-delete-dialog.component.html
+++ b/src/app/nutrition/dialogs/food-delete-dialog/food-delete-dialog.component.html
@@ -1,0 +1,14 @@
+<h2 mat-dialog-title>Lebensmittel löschen</h2>
+
+<mat-dialog-content>
+  <span>«{{ foodName }}» wirklich löschen?</span>
+</mat-dialog-content>
+
+<mat-dialog-actions align="center">
+  <button mat-mini-fab class="btn-confirm" (click)="confirm()">
+    <mat-icon>check_circle</mat-icon>
+  </button>
+  <button mat-mini-fab mat-dialog-close class="btn-cancel">
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-dialog-actions>

--- a/src/app/nutrition/dialogs/food-delete-dialog/food-delete-dialog.component.ts
+++ b/src/app/nutrition/dialogs/food-delete-dialog/food-delete-dialog.component.ts
@@ -1,0 +1,28 @@
+import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MatIcon} from '@angular/material/icon';
+import {MatMiniFabButton} from '@angular/material/button';
+
+@Component({
+  selector: 'app-food-delete-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatIcon,
+    MatMiniFabButton
+  ],
+  templateUrl: './food-delete-dialog.component.html',
+  styleUrl: './food-delete-dialog.component.css'
+})
+export class FoodDeleteDialogComponent {
+
+  private dialogRef = inject(MatDialogRef<FoodDeleteDialogComponent>);
+  foodName = inject<{name: string}>(MAT_DIALOG_DATA).name;
+
+  confirm() {
+    this.dialogRef.close('confirmed');
+  }
+}

--- a/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.css
+++ b/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.css
@@ -1,0 +1,123 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+  --c-g:         #a3e635;
+  --c-n:         #2dd4bf;
+  --c-e:         #fb7185;
+}
+
+::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+  min-width: 340px !important;
+}
+
+::ng-deep .mat-mdc-dialog-title {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
+  color: var(--text) !important;
+  letter-spacing: 0.03em;
+}
+
+::ng-deep .mat-mdc-dialog-content {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.9rem !important;
+  overflow: visible !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions {
+  gap: 10px;
+  padding-bottom: 16px !important;
+  justify-content: center !important;
+}
+
+/* Form layout */
+.edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.5rem;
+}
+
+.field-full { width: 100%; }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.25rem 0.75rem;
+}
+
+@media (max-width: 420px) {
+  .grid { grid-template-columns: 1fr; }
+}
+
+/* Dark theme form fields */
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__trailing {
+  border-color: var(--border-mid) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined:not(.mdc-text-field--disabled) .mdc-text-field__input {
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-mdc-floating-label {
+  color: var(--text-dim) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__trailing {
+  border-color: var(--c-g) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mat-mdc-floating-label {
+  color: var(--c-g) !important;
+}
+
+/* Buttons */
+.btn-confirm {
+  background: rgba(45, 212, 191, 0.10) !important;
+  border: 1px solid rgba(45, 212, 191, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-n) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-confirm:hover:not([disabled]) {
+  background: rgba(45, 212, 191, 0.18) !important;
+  box-shadow: 0 0 12px rgba(45, 212, 191, 0.25) !important;
+}
+
+.btn-confirm[disabled] {
+  opacity: 0.4 !important;
+}
+
+.btn-confirm mat-icon { color: var(--c-n) !important; }
+
+.btn-cancel {
+  background: rgba(251, 113, 133, 0.10) !important;
+  border: 1px solid rgba(251, 113, 133, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-e) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-cancel:hover {
+  background: rgba(251, 113, 133, 0.18) !important;
+  box-shadow: 0 0 12px rgba(251, 113, 133, 0.25) !important;
+}
+
+.btn-cancel mat-icon { color: var(--c-e) !important; }

--- a/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.html
+++ b/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.html
@@ -1,0 +1,56 @@
+<h2 mat-dialog-title>{{ title }}</h2>
+
+<mat-dialog-content>
+  <form class="edit-form" [formGroup]="form">
+    <mat-form-field appearance="outline" class="field-full">
+      <mat-label>Name</mat-label>
+      <input matInput formControlName="name" />
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="field-full">
+      <mat-label>Marke</mat-label>
+      <input matInput formControlName="brand" />
+    </mat-form-field>
+
+    <div class="grid">
+      <mat-form-field appearance="outline">
+        <mat-label>kcal / 100 g</mat-label>
+        <input matInput type="number" step="1" formControlName="kcalPer100" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Protein (g)</mat-label>
+        <input matInput type="number" step="0.1" formControlName="proteinPer100" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Kohlenhydrate (g)</mat-label>
+        <input matInput type="number" step="0.1" formControlName="carbsPer100" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Fett (g)</mat-label>
+        <input matInput type="number" step="0.1" formControlName="fatPer100" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Ballaststoffe (g)</mat-label>
+        <input matInput type="number" step="0.1" formControlName="fiberPer100" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Portion (g)</mat-label>
+        <input matInput type="number" step="1" formControlName="defaultServingG" />
+      </mat-form-field>
+    </div>
+  </form>
+</mat-dialog-content>
+
+<mat-dialog-actions align="center">
+  <button mat-mini-fab class="btn-confirm" [disabled]="form.invalid" (click)="save()">
+    <mat-icon>check_circle</mat-icon>
+  </button>
+  <button mat-mini-fab mat-dialog-close class="btn-cancel">
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-dialog-actions>

--- a/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.ts
+++ b/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.ts
@@ -1,0 +1,86 @@
+import {ChangeDetectionStrategy, Component, inject, OnInit} from '@angular/core';
+import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
+import {MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MatFormField, MatLabel} from '@angular/material/form-field';
+import {MatInput} from '@angular/material/input';
+import {MatIcon} from '@angular/material/icon';
+import {MatMiniFabButton} from '@angular/material/button';
+import {Food, FoodDraft, FoodInput, FoodSource} from '../../models/nutrition.model';
+
+/**
+ * Add/edit form for a food. Used for manual entry, editing an existing food, and
+ * reviewing a draft parsed from a label photo. The `source` from the dialog data
+ * is carried through to the saved payload (e.g. `PHOTO` for scanned drafts).
+ */
+export interface FoodEditDialogData {
+  /** Existing food to edit, or null when adding a new one. */
+  food: Food | null;
+  /** Optional values parsed from a label photo to prefill an add form. */
+  prefill?: FoodDraft;
+  /** Source recorded on save. */
+  source: FoodSource;
+}
+
+@Component({
+  selector: 'app-food-edit-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ReactiveFormsModule,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatFormField,
+    MatLabel,
+    MatInput,
+    MatIcon,
+    MatMiniFabButton
+  ],
+  templateUrl: './food-edit-dialog.component.html',
+  styleUrl: './food-edit-dialog.component.css'
+})
+export class FoodEditDialogComponent implements OnInit {
+
+  private fb = inject(FormBuilder);
+  private dialogRef = inject(MatDialogRef<FoodEditDialogComponent>);
+  private data = inject<FoodEditDialogData>(MAT_DIALOG_DATA);
+
+  form!: FormGroup;
+  title = this.data.food ? 'Lebensmittel bearbeiten' : 'Lebensmittel hinzufügen';
+
+  ngOnInit(): void {
+    const source = this.data.food ?? this.data.prefill;
+    this.form = this.fb.group({
+      name: [source?.name ?? '', Validators.required],
+      brand: [source?.brand ?? ''],
+      kcalPer100: [source?.kcalPer100 ?? null, [Validators.required, Validators.min(0)]],
+      proteinPer100: [source?.proteinPer100 ?? null, [Validators.required, Validators.min(0)]],
+      carbsPer100: [source?.carbsPer100 ?? null, [Validators.required, Validators.min(0)]],
+      fatPer100: [source?.fatPer100 ?? null, [Validators.required, Validators.min(0)]],
+      fiberPer100: [source?.fiberPer100 ?? null, Validators.min(0)],
+      defaultServingG: [this.servingFrom(source), Validators.min(0)]
+    });
+  }
+
+  /** Stored foods expose `defaultServingG`; label drafts expose `servingG`. */
+  private servingFrom(source: Food | FoodDraft | undefined): number | null {
+    if (!source) return null;
+    return 'defaultServingG' in source ? source.defaultServingG : source.servingG;
+  }
+
+  save(): void {
+    if (this.form.invalid) return;
+    const v = this.form.getRawValue();
+    const result: FoodInput = {
+      name: v.name.trim(),
+      brand: v.brand?.trim() ? v.brand.trim() : null,
+      kcalPer100: Number(v.kcalPer100),
+      proteinPer100: Number(v.proteinPer100),
+      carbsPer100: Number(v.carbsPer100),
+      fatPer100: Number(v.fatPer100),
+      fiberPer100: v.fiberPer100 != null && v.fiberPer100 !== '' ? Number(v.fiberPer100) : null,
+      defaultServingG: v.defaultServingG != null && v.defaultServingG !== '' ? Number(v.defaultServingG) : null,
+      source: this.data.source
+    };
+    this.dialogRef.close(result);
+  }
+}

--- a/src/app/nutrition/models/nutrition.model.ts
+++ b/src/app/nutrition/models/nutrition.model.ts
@@ -53,14 +53,39 @@ export interface Targets {
   basis: TargetBasis;
 }
 
+/** Where a food's macro values originated. */
+export type FoodSource = 'MANUAL' | 'PHOTO' | 'ESTIMATE' | 'BARCODE';
+
 export interface Food {
   id: string;
   name: string;
   brand: string | null;
-  caloriesPer100g: number;
-  proteinPer100g: number;
-  carbsPer100g: number;
-  fatPer100g: number;
+  kcalPer100: number;
+  proteinPer100: number;
+  carbsPer100: number;
+  fatPer100: number;
+  fiberPer100: number | null;
+  defaultServingG: number | null;
+  source: FoodSource;
+}
+
+/** Create/update payload for a food (no audit/id fields). */
+export type FoodInput = Omit<Food, 'id'>;
+
+/**
+ * Transient food parsed from a nutrition-label photo (POST /nutrition/foods/scan-label).
+ * Not persisted — the user reviews it and saves via the food CRUD endpoint.
+ * Note the per-serving size is `servingG` here vs `defaultServingG` on a stored food.
+ */
+export interface FoodDraft {
+  name: string;
+  brand: string | null;
+  kcalPer100: number;
+  proteinPer100: number;
+  carbsPer100: number;
+  fatPer100: number;
+  fiberPer100: number | null;
+  servingG: number | null;
 }
 
 export interface MealEntry {

--- a/src/app/nutrition/services/nutrition.service.ts
+++ b/src/app/nutrition/services/nutrition.service.ts
@@ -5,6 +5,8 @@ import {environment} from '../../../environments/environment';
 import {
   DaySummary,
   Food,
+  FoodDraft,
+  FoodInput,
   MealEntry,
   Profile,
   ProfileInput,
@@ -59,6 +61,28 @@ export class NutritionService {
 
   searchFoods(query: string): Observable<Food[]> {
     return this.http.get<Food[]>(`${this.host}/foods`, {params: {q: query}});
+  }
+
+  createFood(food: FoodInput): Observable<Food> {
+    return this.http.post<Food>(`${this.host}/foods`, food);
+  }
+
+  updateFood(id: string, food: FoodInput): Observable<Food> {
+    return this.http.put<Food>(`${this.host}/foods/${id}`, food);
+  }
+
+  deleteFood(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.host}/foods/${id}`);
+  }
+
+  /**
+   * Upload a nutrition-label photo for parsing. The image is only used for this
+   * request and is not stored; the backend returns a transient draft food.
+   */
+  scanLabel(file: File): Observable<FoodDraft> {
+    const formData = new FormData();
+    formData.append('file', file);
+    return this.http.post<FoodDraft>(`${this.host}/foods/scan-label`, formData);
   }
 
   getMeals(date: string): Observable<MealEntry[]> {


### PR DESCRIPTION
## Summary

Implements the food catalog UI plus the photo nutrition-label scan flow (issue #141, F4).

- **Food list** (`/nutrition/foods`): debounced searchable `MatTable` of foods with per-100g macros (kcal · P · KH · F), plus add / edit / delete dialogs.
- **Add via photo**: a `capture="environment"` file input opens the camera on mobile. On select, the image is posted as `FormData` to `POST /nutrition/foods/scan-label`; the returned draft prefills the add-food form for review, and saving creates a food with `source=PHOTO`.
- The captured image is used **only** for the scan request — it is not uploaded for storage or kept (matches backend #106).
- Loading (inline spinner on the *Foto* button) + error states for the scan call via `MatSnackBar`.
- Aligned the `Food` model with the backend contract (`kcalPer100`, `proteinPer100`, `carbsPer100`, `fatPer100`, `fiberPer100`, `defaultServingG`, `source`) and added `FoodInput` / `FoodDraft`.
- Wired up the route, the nutrition layout menu item and a home dashboard nav card.

## Acceptance criteria

- [x] Scanning a label prefills the food form; saving creates a food with `source=PHOTO`.
- [x] Manual add / edit / delete works.
- [x] `npm run build` passes; new files are lint-clean (`eslint`).

## Notes

- Backend dependencies: Marvin1912/backend#105 (food CRUD), Marvin1912/backend#106 (label scan).
- Pre-existing lint errors in scaffold files (`nutrition-layout.component.ts`, legacy modules) are unrelated and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)