### PR TITLE
feat(nutrition): barcode scanning via OpenFoodFacts (frontend)

### DIFF
--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.css
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.css
@@ -13,6 +13,7 @@
 
   --c-g:  #a3e635;
   --c-n:  #2dd4bf;
+  --c-b:  #4da6ff;
   --c-e:  #fb7185;
 
   display: block;
@@ -73,7 +74,8 @@
 }
 
 .btn-add,
-.btn-scan {
+.btn-scan,
+.btn-barcode {
   height: 56px;
   border-radius: 8px !important;
   font-weight: 600 !important;
@@ -103,6 +105,17 @@
 }
 
 .btn-scan[disabled] { opacity: 0.55 !important; }
+
+.btn-barcode {
+  background: color-mix(in srgb, var(--c-b) 14%, transparent) !important;
+  border: 1px solid color-mix(in srgb, var(--c-b) 35%, transparent) !important;
+  color: var(--c-b) !important;
+}
+
+.btn-barcode:hover {
+  background: color-mix(in srgb, var(--c-b) 22%, transparent) !important;
+  box-shadow: 0 0 12px rgba(77, 166, 255, 0.25) !important;
+}
 
 .btn-scan mat-spinner { margin-right: 4px; }
 

--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.html
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.html
@@ -26,6 +26,10 @@
           }
           Foto
         </button>
+        <button mat-flat-button type="button" class="btn-barcode" (click)="openBarcodeDialog()">
+          <mat-icon>barcode_scanner</mat-icon>
+          Barcode
+        </button>
         <input #photoInput type="file" accept="image/*" capture="environment" hidden
                (change)="onPhotoSelected($event)" />
       </div>

--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.ts
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.ts
@@ -23,9 +23,10 @@ import {MatDialog} from '@angular/material/dialog';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {debounceTime, distinctUntilChanged, startWith, switchMap} from 'rxjs';
 import {NutritionService} from '../../services/nutrition.service';
-import {Food, FoodInput} from '../../models/nutrition.model';
+import {Food, FoodDraft, FoodInput} from '../../models/nutrition.model';
 import {FoodEditDialogComponent, FoodEditDialogData} from '../../dialogs/food-edit-dialog/food-edit-dialog.component';
 import {FoodDeleteDialogComponent} from '../../dialogs/food-delete-dialog/food-delete-dialog.component';
+import {BarcodeScanDialogComponent} from '../../dialogs/barcode-scan-dialog/barcode-scan-dialog.component';
 
 @Component({
   selector: 'app-nutrition-foods',
@@ -115,6 +116,15 @@ export class NutritionFoodsComponent implements OnInit {
           this.snackBar.open(msg, 'Schließen', {duration: 5000});
         }
       });
+    });
+  }
+
+  openBarcodeDialog(): void {
+    const ref = this.dialog.open(BarcodeScanDialogComponent);
+    ref.afterClosed().subscribe((draft: FoodDraft | undefined) => {
+      if (!draft) return;
+      // Same review-and-save flow as the photo scan, tagged as a BARCODE source.
+      this.openFoodDialog({food: null, prefill: draft, source: 'BARCODE'}, null);
     });
   }
 

--- a/src/app/nutrition/dialogs/barcode-scan-dialog/barcode-scan-dialog.component.css
+++ b/src/app/nutrition/dialogs/barcode-scan-dialog/barcode-scan-dialog.component.css
@@ -1,0 +1,173 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+  --c-g:         #a3e635;
+  --c-n:         #2dd4bf;
+  --c-e:         #fb7185;
+}
+
+::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+  min-width: 320px !important;
+}
+
+::ng-deep .mat-mdc-dialog-title {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
+  color: var(--text) !important;
+  letter-spacing: 0.03em;
+}
+
+::ng-deep .mat-mdc-dialog-content {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.9rem !important;
+  overflow: visible !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions {
+  gap: 10px;
+  padding-bottom: 16px !important;
+  justify-content: center !important;
+}
+
+.scan-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding-top: 0.5rem;
+}
+
+/* ── Camera viewport ─────────────────────────────── */
+.viewport {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  background: #000;
+  border: 1px solid var(--border-mid);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.viewport--off { display: none; }
+
+.viewport__video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.viewport__frame {
+  position: absolute;
+  inset: 22% 12%;
+  border: 2px solid var(--c-n);
+  border-radius: 8px;
+  box-shadow: 0 0 0 100vmax rgba(0, 0, 0, 0.25);
+  pointer-events: none;
+}
+
+.viewport__overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(6, 8, 14, 0.6);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  color: var(--c-n);
+  text-transform: uppercase;
+}
+
+.hint {
+  margin: 0;
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--text-dim);
+}
+
+.msg {
+  margin: 0;
+  text-align: center;
+  font-size: 0.78rem;
+  color: var(--c-e);
+}
+
+/* ── Manual entry ────────────────────────────────── */
+.manual {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.manual__field { flex: 1 1 auto; }
+
+.btn-lookup {
+  height: 56px;
+  background: color-mix(in srgb, var(--c-n) 14%, transparent) !important;
+  border: 1px solid color-mix(in srgb, var(--c-n) 35%, transparent) !important;
+  border-radius: 8px !important;
+  color: var(--c-n) !important;
+  font-weight: 600 !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-lookup:hover:not([disabled]) {
+  background: color-mix(in srgb, var(--c-n) 22%, transparent) !important;
+  box-shadow: 0 0 12px rgba(45, 212, 191, 0.25) !important;
+}
+
+.btn-lookup[disabled] { opacity: 0.45 !important; }
+
+/* ── Dark form field ─────────────────────────────── */
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__trailing {
+  border-color: var(--border-mid) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined:not(.mdc-text-field--disabled) .mdc-text-field__input {
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-mdc-floating-label {
+  color: var(--text-dim) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__trailing {
+  border-color: var(--c-n) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mat-mdc-floating-label {
+  color: var(--c-n) !important;
+}
+
+/* ── Cancel button ───────────────────────────────── */
+.btn-cancel {
+  background: rgba(251, 113, 133, 0.10) !important;
+  border: 1px solid rgba(251, 113, 133, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-e) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-cancel:hover {
+  background: rgba(251, 113, 133, 0.18) !important;
+  box-shadow: 0 0 12px rgba(251, 113, 133, 0.25) !important;
+}
+
+.btn-cancel mat-icon { color: var(--c-e) !important; }

--- a/src/app/nutrition/dialogs/barcode-scan-dialog/barcode-scan-dialog.component.html
+++ b/src/app/nutrition/dialogs/barcode-scan-dialog/barcode-scan-dialog.component.html
@@ -1,0 +1,40 @@
+<h2 mat-dialog-title>Barcode scannen</h2>
+
+<mat-dialog-content>
+  <div class="scan-body">
+
+    @if (cameraSupported) {
+      <div class="viewport" [class.viewport--off]="!cameraActive">
+        <video #video class="viewport__video" muted playsinline></video>
+        <div class="viewport__frame" aria-hidden="true"></div>
+        @if (looking) {
+          <div class="viewport__overlay">Suche…</div>
+        }
+      </div>
+    }
+
+    @if (message) {
+      <p class="msg">{{ message }}</p>
+    } @else if (cameraActive) {
+      <p class="hint">Barcode vor die Kamera halten.</p>
+    }
+
+    <form class="manual" (ngSubmit)="lookupManual()">
+      <mat-form-field appearance="outline" class="manual__field">
+        <mat-label>Barcode (EAN)</mat-label>
+        <input matInput inputmode="numeric" autocomplete="off" [formControl]="manualEan" />
+      </mat-form-field>
+      <button mat-flat-button type="submit" class="btn-lookup" [disabled]="looking">
+        <mat-icon>search</mat-icon>
+        Suchen
+      </button>
+    </form>
+
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions align="center">
+  <button mat-mini-fab mat-dialog-close class="btn-cancel" aria-label="Abbrechen">
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-dialog-actions>

--- a/src/app/nutrition/dialogs/barcode-scan-dialog/barcode-scan-dialog.component.ts
+++ b/src/app/nutrition/dialogs/barcode-scan-dialog/barcode-scan-dialog.component.ts
@@ -1,0 +1,167 @@
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  inject,
+  OnDestroy,
+  ViewChild
+} from '@angular/core';
+import {FormControl, ReactiveFormsModule, Validators} from '@angular/forms';
+import {MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MatFormField, MatLabel} from '@angular/material/form-field';
+import {MatInput} from '@angular/material/input';
+import {MatIcon} from '@angular/material/icon';
+import {MatButton, MatMiniFabButton} from '@angular/material/button';
+import {NutritionService} from '../../services/nutrition.service';
+
+/**
+ * Minimal shape of the native BarcodeDetector API (not yet in lib.dom).
+ * Used for live camera scanning where the browser supports it.
+ */
+interface DetectedBarcode {
+  rawValue: string;
+}
+
+interface BarcodeDetectorLike {
+  detect(source: CanvasImageSource): Promise<DetectedBarcode[]>;
+}
+
+type BarcodeDetectorCtor = new (options?: {formats: string[]}) => BarcodeDetectorLike;
+
+/** Valid EAN/UPC: 8–14 digits (matches the backend's format guard). */
+const EAN_PATTERN = /^\d{8,14}$/;
+
+/**
+ * Resolve a packaged food by barcode. Where the browser exposes BarcodeDetector
+ * the camera is scanned live; otherwise (or in addition) the user can type the
+ * EAN. On a hit the dialog closes with the EAN, which the foods view looks up
+ * and prefills as a BARCODE-sourced food.
+ */
+@Component({
+  selector: 'app-barcode-scan-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ReactiveFormsModule,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatFormField,
+    MatLabel,
+    MatInput,
+    MatIcon,
+    MatButton,
+    MatMiniFabButton
+  ],
+  templateUrl: './barcode-scan-dialog.component.html',
+  styleUrl: './barcode-scan-dialog.component.css'
+})
+export class BarcodeScanDialogComponent implements AfterViewInit, OnDestroy {
+
+  @ViewChild('video') videoRef?: ElementRef<HTMLVideoElement>;
+
+  manualEan = new FormControl('', {nonNullable: true, validators: [Validators.pattern(EAN_PATTERN)]});
+
+  /** Whether this browser can scan via the camera at all. */
+  cameraSupported = typeof window !== 'undefined' && 'BarcodeDetector' in window;
+  cameraActive = false;
+  looking = false;
+  message = '';
+
+  private dialogRef = inject(MatDialogRef<BarcodeScanDialogComponent>);
+  private service = inject(NutritionService);
+  private cdr = inject(ChangeDetectorRef);
+
+  private stream?: MediaStream;
+  private detector?: BarcodeDetectorLike;
+  private timer?: ReturnType<typeof setInterval>;
+  private detecting = false;
+  private handled = false;
+
+  ngAfterViewInit(): void {
+    if (this.cameraSupported) {
+      void this.startCamera();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.stopCamera();
+  }
+
+  private async startCamera(): Promise<void> {
+    try {
+      const Ctor = (window as unknown as {BarcodeDetector: BarcodeDetectorCtor}).BarcodeDetector;
+      this.detector = new Ctor({formats: ['ean_13', 'ean_8', 'upc_a', 'upc_e']});
+      this.stream = await navigator.mediaDevices.getUserMedia({video: {facingMode: 'environment'}});
+      const video = this.videoRef?.nativeElement;
+      if (!video) return;
+      video.srcObject = this.stream;
+      await video.play();
+      this.cameraActive = true;
+      this.message = '';
+      this.cdr.markForCheck();
+      this.timer = setInterval(() => void this.scanFrame(), 400);
+    } catch {
+      this.cameraActive = false;
+      this.message = 'Kamera nicht verfügbar – Barcode bitte eingeben.';
+      this.cdr.markForCheck();
+    }
+  }
+
+  private async scanFrame(): Promise<void> {
+    const video = this.videoRef?.nativeElement;
+    if (!this.detector || !video || this.detecting || this.handled) return;
+    this.detecting = true;
+    try {
+      const codes = await this.detector.detect(video);
+      const hit = codes.map(c => c.rawValue).find(v => EAN_PATTERN.test(v));
+      if (hit) this.onEan(hit);
+    } catch {
+      // Transient decode failures are expected between frames; ignore.
+    } finally {
+      this.detecting = false;
+    }
+  }
+
+  lookupManual(): void {
+    const ean = this.manualEan.value.trim();
+    if (!EAN_PATTERN.test(ean)) {
+      this.manualEan.markAsTouched();
+      return;
+    }
+    this.onEan(ean);
+  }
+
+  private onEan(ean: string): void {
+    if (this.handled) return;
+    this.handled = true;
+    this.stopCamera();
+    this.looking = true;
+    this.message = '';
+    this.cdr.markForCheck();
+    this.service.getFoodByBarcode(ean).subscribe({
+      next: draft => this.dialogRef.close(draft),
+      error: err => {
+        this.looking = false;
+        this.message = err.status === 404
+          ? `Kein Treffer für ${ean}.`
+          : 'Barcode-Suche fehlgeschlagen.';
+        // Allow another attempt.
+        this.handled = false;
+        if (this.cameraSupported) void this.startCamera();
+        this.cdr.markForCheck();
+      }
+    });
+  }
+
+  private stopCamera(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+    this.stream?.getTracks().forEach(track => track.stop());
+    this.stream = undefined;
+    this.cameraActive = false;
+  }
+}

--- a/src/app/nutrition/services/nutrition.service.ts
+++ b/src/app/nutrition/services/nutrition.service.ts
@@ -85,6 +85,15 @@ export class NutritionService {
     return this.http.post<FoodDraft>(`${this.host}/foods/scan-label`, formData);
   }
 
+  /**
+   * Look up a packaged food by its EAN/UPC barcode via OpenFoodFacts. Returns a
+   * transient draft food (not persisted); the user reviews and saves it. A 404
+   * means the barcode is unknown to OpenFoodFacts.
+   */
+  getFoodByBarcode(ean: string): Observable<FoodDraft> {
+    return this.http.get<FoodDraft>(`${this.host}/foods/barcode/${ean}`);
+  }
+
   getMeals(date: string): Observable<MealEntry[]> {
     return this.http.get<MealEntry[]>(`${this.host}/meals`, {params: {date}});
   }


### PR DESCRIPTION
## Summary

Implements the **frontend** half of barcode scanning — the deliverable that was left unchecked when [backend #109](https://github.com/Marvin1912/backend/issues/109) was closed (the backend `GET /nutrition/foods/barcode/{ean}` endpoint is already live).

A new **Barcode** button in the food catalog (`/nutrition/foods`) opens a scanner dialog that resolves a packaged food by its EAN/UPC and prefills the existing add-food form with `source=BARCODE`, reusing the same review-and-save flow as the photo label scan.

## Details

- **Camera-based scanning** via the native `BarcodeDetector` API where supported (EAN-13/8, UPC-A/E), with a live camera preview and scan frame.
- **Graceful fallback**: on browsers without `BarcodeDetector` or when camera access is denied, the dialog shows a manual EAN entry (8–14 digits, matching the backend's format guard) — so the lookup path always works.
- `NutritionService.getFoodByBarcode(ean)` → `GET /nutrition/foods/barcode/{ean}` returns a transient `FoodDraft` (never persisted); the user confirms and saves via the existing food CRUD endpoint.
- A `404` (unknown barcode) keeps the scanner open for another attempt rather than dismissing it.
- The camera `MediaStream` and detection interval are torn down on dialog close (`ngOnDestroy`).

## Acceptance criteria (#109 frontend box)

- [x] Barcode scanner in the food module → calls the lookup → prefills/saves a Food with `source=BARCODE`.
- [x] `npm run build` passes; new files are lint-clean.

## Notes / caveats

- `BarcodeDetector` is well-supported on Chromium/Android but absent on Firefox and iOS Safari — hence the manual-entry fallback. A heavier JS barcode lib could be added later if broader live-scan coverage is needed.
- The live camera + OpenFoodFacts path is hard to exercise in headless CI; the manual-entry path is the deterministic one to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)