### PR TITLE
feat(nutrition): daily meal log & day summary UI

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -34,6 +34,7 @@ import {NutritionHomeComponent} from './nutrition/components/nutrition-home/nutr
 import {NutritionWeightComponent} from './nutrition/components/nutrition-weight/nutrition-weight.component';
 import {NutritionProfileComponent} from './nutrition/components/nutrition-profile/nutrition-profile.component';
 import {NutritionFoodsComponent} from './nutrition/components/nutrition-foods/nutrition-foods.component';
+import {NutritionDayComponent} from './nutrition/components/nutrition-day/nutrition-day.component';
 
 export const routes: Routes = [
   {path: '', component: HomeComponent},
@@ -108,6 +109,7 @@ export const routes: Routes = [
     component: NutritionLayoutComponent,
     children: [
       {path: '', component: NutritionHomeComponent, data: {home: '/'}},
+      {path: 'day', component: NutritionDayComponent, data: {home: '/nutrition'}},
       {path: 'weight', component: NutritionWeightComponent, data: {home: '/nutrition'}},
       {path: 'foods', component: NutritionFoodsComponent, data: {home: '/nutrition'}},
       {path: 'profile', component: NutritionProfileComponent, data: {home: '/nutrition'}}

--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.css
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.css
@@ -1,0 +1,260 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-kcal: #a3e635;
+  --c-p:    #2dd4bf;
+  --c-c:    #4da6ff;
+  --c-f:    #fb7185;
+
+  display: block;
+  height: 100%;
+  overflow-y: auto;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+}
+
+.day {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem clamp(1rem, 6vw, 4rem);
+  max-width: 760px;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+/* ── Panels ──────────────────────────────────────── */
+.panel__head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.panel__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--c-kcal);
+  box-shadow: 0 0 6px var(--c-kcal);
+}
+
+.panel__dot--n { background: var(--c-p); box-shadow: 0 0 6px var(--c-p); }
+
+.panel__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+}
+
+/* ── Toolbar ─────────────────────────────────────── */
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.field-date { flex: 1 1 200px; }
+
+.btn-add {
+  height: 56px;
+  border-radius: 8px !important;
+  font-weight: 600 !important;
+  background: color-mix(in srgb, var(--c-kcal) 14%, transparent) !important;
+  border: 1px solid color-mix(in srgb, var(--c-kcal) 35%, transparent) !important;
+  color: var(--c-kcal) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-add:hover {
+  background: color-mix(in srgb, var(--c-kcal) 22%, transparent) !important;
+  box-shadow: 0 0 12px rgba(163, 230, 53, 0.25) !important;
+}
+
+/* ── Summary bars ────────────────────────────────── */
+.bars {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem 1.1rem;
+}
+
+.bar--kcal { --bc: var(--c-kcal); }
+.bar--p    { --bc: var(--c-p); }
+.bar--c    { --bc: var(--c-c); }
+.bar--f    { --bc: var(--c-f); }
+
+.bar__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 0.3rem;
+}
+
+.bar__name {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.bar__nums {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.bar__track {
+  height: 7px;
+  border-radius: 4px;
+  background: var(--raised);
+  overflow: hidden;
+}
+
+.bar__fill {
+  height: 100%;
+  border-radius: 4px;
+  background: var(--bc);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--bc) 50%, transparent);
+  transition: width 0.4s ease;
+}
+
+.bar__rem {
+  display: block;
+  margin-top: 0.25rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+}
+
+/* ── Meal groups ─────────────────────────────────── */
+.meal__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 0.5rem;
+}
+
+.meal__title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.meal__kcal {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  color: var(--c-kcal);
+}
+
+.entries {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.entry {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.7rem 0.9rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.entry:last-child { border-bottom: none; }
+
+.entry__main {
+  flex: 1;
+  min-width: 0;
+}
+
+.entry__name {
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.entry__meta {
+  display: block;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.62rem;
+  color: var(--text-dim);
+  letter-spacing: 0.02em;
+}
+
+.entry__actions {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.btn-edit { color: var(--text-dim); transition: color 0.2s; }
+.btn-edit:hover { color: var(--c-kcal); }
+.btn-del { color: var(--text-dim); transition: color 0.2s; }
+.btn-del:hover { color: var(--c-f); }
+
+/* ── States ──────────────────────────────────────── */
+.state {
+  display: flex;
+  justify-content: center;
+  padding: 2rem;
+}
+
+::ng-deep .state mat-spinner circle { stroke: var(--c-p) !important; }
+
+.empty {
+  margin: 0;
+  padding: 1.5rem;
+  text-align: center;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  background: var(--surface);
+  border: 1px dashed var(--border-mid);
+  border-radius: 12px;
+}
+
+/* ── Dark form fields ────────────────────────────── */
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__trailing {
+  border-color: var(--border-mid) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined:not(.mdc-text-field--disabled) .mdc-text-field__input {
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-mdc-floating-label { color: var(--text-dim) !important; }
+
+::ng-deep .mat-mdc-form-field .mat-icon,
+::ng-deep .mat-mdc-form-field .mat-datepicker-toggle { color: var(--text-dim) !important; }
+
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__trailing {
+  border-color: var(--c-kcal) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mat-mdc-floating-label { color: var(--c-kcal) !important; }

--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.html
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.html
@@ -1,0 +1,104 @@
+<div class="day">
+
+  <section class="panel">
+    <header class="panel__head">
+      <span class="panel__dot"></span>
+      <span class="panel__label">TAGEBUCH</span>
+    </header>
+
+    <div class="toolbar">
+      <mat-form-field appearance="outline" class="field-date">
+        <mat-label>Datum</mat-label>
+        <input matInput [matDatepicker]="picker" [formControl]="date" />
+        <mat-datepicker-toggle matIconSuffix [for]="picker" />
+        <mat-datepicker #picker />
+      </mat-form-field>
+
+      <button mat-flat-button type="button" class="btn-add" (click)="openAddDialog()">
+        <mat-icon>add</mat-icon>
+        Essen
+      </button>
+    </div>
+  </section>
+
+  @if (loading) {
+    <div class="state">
+      <mat-spinner diameter="32" />
+    </div>
+  } @else if (unavailable) {
+    <p class="empty">{{ unavailable }}</p>
+  } @else if (summary) {
+
+    <section class="panel summary">
+      <header class="panel__head">
+        <span class="panel__dot panel__dot--n"></span>
+        <span class="panel__label">ÜBERSICHT</span>
+      </header>
+
+      <div class="bars">
+        @for (b of bars; track b.label) {
+          <div class="bar bar--{{ b.cls }}">
+            <div class="bar__top">
+              <span class="bar__name">{{ b.label }}</span>
+              <span class="bar__nums">
+                {{ b.consumed | number:'1.0-0':'de' }} / {{ b.target | number:'1.0-0':'de' }} {{ b.unit }}
+              </span>
+            </div>
+            <div class="bar__track">
+              <div class="bar__fill" [style.width.%]="b.pct"></div>
+            </div>
+            <span class="bar__rem">
+              @if (b.remaining > 0) {
+                noch {{ b.remaining | number:'1.0-0':'de' }} {{ b.unit }}
+              } @else {
+                {{ -b.remaining | number:'1.0-0':'de' }} {{ b.unit }} über Ziel
+              }
+            </span>
+          </div>
+        }
+      </div>
+    </section>
+
+    @if (hasEntries) {
+      @for (group of groups; track group.type) {
+        <section class="panel meal">
+          <header class="meal__head">
+            <span class="meal__title">{{ group.label }}</span>
+            <span class="meal__kcal">{{ group.kcal | number:'1.0-0':'de' }} kcal</span>
+          </header>
+
+          <ul class="entries">
+            @for (entry of group.entries; track entry.id) {
+              <li class="entry">
+                <div class="entry__main">
+                  <span class="entry__name">{{ entryName(entry) }}</span>
+                  <span class="entry__meta">
+                    @if (entry.quantityG !== null) {
+                      {{ entry.quantityG | number:'1.0-0':'de' }} g ·
+                    }
+                    {{ entry.kcal | number:'1.0-0':'de' }} kcal ·
+                    P {{ entry.proteinG | number:'1.0-1':'de' }} ·
+                    KH {{ entry.carbsG | number:'1.0-1':'de' }} ·
+                    F {{ entry.fatG | number:'1.0-1':'de' }}
+                  </span>
+                </div>
+                <div class="entry__actions">
+                  <button mat-icon-button class="btn-edit" (click)="openEditDialog(entry)">
+                    <mat-icon>edit</mat-icon>
+                  </button>
+                  <button mat-icon-button class="btn-del" (click)="openDeleteDialog(entry)">
+                    <mat-icon>delete</mat-icon>
+                  </button>
+                </div>
+              </li>
+            }
+          </ul>
+        </section>
+      }
+    } @else {
+      <p class="empty">Noch nichts erfasst. Füge dein erstes Essen hinzu.</p>
+    }
+
+  }
+
+</div>

--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
@@ -1,0 +1,193 @@
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit} from '@angular/core';
+import {DecimalPipe} from '@angular/common';
+import {HttpErrorResponse} from '@angular/common/http';
+import {FormControl, ReactiveFormsModule} from '@angular/forms';
+import {MatFormField, MatLabel} from '@angular/material/form-field';
+import {MatInput} from '@angular/material/input';
+import {MatDatepicker, MatDatepickerInput, MatDatepickerToggle} from '@angular/material/datepicker';
+import {MatButton, MatIconButton} from '@angular/material/button';
+import {MatIcon} from '@angular/material/icon';
+import {MatProgressSpinner} from '@angular/material/progress-spinner';
+import {MatDialog} from '@angular/material/dialog';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {format} from 'date-fns';
+import {NutritionService} from '../../services/nutrition.service';
+import {DaySummary, FoodEntryInput, MealEntry, MealEntryUpdate, MealType} from '../../models/nutrition.model';
+import {
+  AddDayEntryDialogComponent,
+  AddDayEntryDialogData
+} from '../../dialogs/add-day-entry-dialog/add-day-entry-dialog.component';
+import {EntryEditDialogComponent} from '../../dialogs/entry-edit-dialog/entry-edit-dialog.component';
+import {EntryDeleteDialogComponent} from '../../dialogs/entry-delete-dialog/entry-delete-dialog.component';
+
+interface MealGroup {
+  type: MealType;
+  label: string;
+  entries: MealEntry[];
+  kcal: number;
+}
+
+interface MacroBar {
+  label: string;
+  unit: string;
+  consumed: number;
+  target: number;
+  remaining: number;
+  pct: number;
+  cls: string;
+}
+
+const MEAL_GROUPS: { type: MealType; label: string }[] = [
+  {type: 'BREAKFAST', label: 'Frühstück'},
+  {type: 'LUNCH', label: 'Mittagessen'},
+  {type: 'DINNER', label: 'Abendessen'},
+  {type: 'SNACK', label: 'Snack'}
+];
+
+@Component({
+  selector: 'app-nutrition-day',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ReactiveFormsModule,
+    DecimalPipe,
+    MatFormField,
+    MatLabel,
+    MatInput,
+    MatDatepicker,
+    MatDatepickerInput,
+    MatDatepickerToggle,
+    MatButton,
+    MatIconButton,
+    MatIcon,
+    MatProgressSpinner
+  ],
+  templateUrl: './nutrition-day.component.html',
+  styleUrl: './nutrition-day.component.css'
+})
+export class NutritionDayComponent implements OnInit {
+
+  date = new FormControl<Date>(new Date(), {nonNullable: true});
+  summary: DaySummary | null = null;
+  loading = false;
+  /** Set when the day summary cannot be loaded (e.g. no targets yet). */
+  unavailable: string | null = null;
+
+  private nutritionService = inject(NutritionService);
+  private dialog = inject(MatDialog);
+  private snackBar = inject(MatSnackBar);
+  private cdr = inject(ChangeDetectorRef);
+
+  ngOnInit(): void {
+    this.date.valueChanges.subscribe(() => this.load());
+    this.load();
+  }
+
+  private get isoDate(): string {
+    return format(this.date.value, 'yyyy-MM-dd');
+  }
+
+  private load(): void {
+    this.loading = true;
+    this.unavailable = null;
+    this.cdr.markForCheck();
+
+    this.nutritionService.getDaySummary(this.isoDate).subscribe({
+      next: summary => {
+        this.summary = summary;
+        this.loading = false;
+        this.cdr.markForCheck();
+      },
+      error: (err: HttpErrorResponse) => {
+        this.summary = null;
+        this.loading = false;
+        this.unavailable = err.status >= 400 && err.status < 500
+          ? 'Keine Tagesübersicht verfügbar. Bitte zuerst ein Profil und einen Gewichtseintrag erfassen.'
+          : 'Tagesübersicht konnte nicht geladen werden.';
+        this.cdr.markForCheck();
+      }
+    });
+  }
+
+  get groups(): MealGroup[] {
+    const entries = this.summary?.entries ?? [];
+    return MEAL_GROUPS.map(g => {
+      const groupEntries = entries.filter(e => e.mealType === g.type);
+      return {
+        type: g.type,
+        label: g.label,
+        entries: groupEntries,
+        kcal: groupEntries.reduce((sum, e) => sum + e.kcal, 0)
+      };
+    }).filter(g => g.entries.length > 0);
+  }
+
+  get hasEntries(): boolean {
+    return (this.summary?.entries.length ?? 0) > 0;
+  }
+
+  get bars(): MacroBar[] {
+    if (!this.summary) return [];
+    const {totals, targets, remaining} = this.summary;
+    return [
+      this.bar('Kalorien', 'kcal', totals.kcal, targets.targetKcal, remaining.kcal, 'kcal'),
+      this.bar('Protein', 'g', totals.proteinG, targets.proteinG, remaining.proteinG, 'p'),
+      this.bar('Kohlenhydrate', 'g', totals.carbsG, targets.carbsG, remaining.carbsG, 'c'),
+      this.bar('Fett', 'g', totals.fatG, targets.fatG, remaining.fatG, 'f')
+    ];
+  }
+
+  private bar(label: string, unit: string, consumed: number, target: number, remaining: number, cls: string): MacroBar {
+    const pct = target > 0 ? Math.min(100, Math.round(consumed / target * 100)) : 0;
+    return {label, unit, consumed, target, remaining, pct, cls};
+  }
+
+  entryName(entry: MealEntry): string {
+    return entry.description ?? entry.foodName ?? 'Eintrag';
+  }
+
+  openAddDialog(mealType?: MealType): void {
+    const data: AddDayEntryDialogData = {mealType};
+    const ref = this.dialog.open(AddDayEntryDialogComponent, {data});
+    ref.afterClosed().subscribe((result: FoodEntryInput | undefined) => {
+      if (!result) return;
+      this.nutritionService.addEntry(this.isoDate, result).subscribe({
+        next: () => {
+          this.load();
+          this.snackBar.open('Eintrag hinzugefügt', 'OK', {duration: 3000});
+        },
+        error: () => this.snackBar.open('Eintrag konnte nicht gespeichert werden', 'Schließen', {duration: 5000})
+      });
+    });
+  }
+
+  openEditDialog(entry: MealEntry): void {
+    const ref = this.dialog.open(EntryEditDialogComponent, {data: entry});
+    ref.afterClosed().subscribe((update: MealEntryUpdate | undefined) => {
+      if (!update) return;
+      this.nutritionService.updateEntry(entry.id, update).subscribe({
+        next: () => {
+          this.load();
+          this.snackBar.open('Eintrag aktualisiert', 'OK', {duration: 3000});
+        },
+        error: () => this.snackBar.open('Eintrag konnte nicht aktualisiert werden', 'Schließen', {duration: 5000})
+      });
+    });
+  }
+
+  openDeleteDialog(entry: MealEntry): void {
+    const ref = this.dialog.open(EntryDeleteDialogComponent, {data: {label: this.entryName(entry)}});
+    ref.afterClosed().subscribe(result => {
+      if (result !== 'confirmed') return;
+      this.nutritionService.deleteEntry(entry.id).subscribe({
+        next: () => {
+          this.load();
+          this.snackBar.open('Eintrag gelöscht', 'OK', {duration: 3000});
+        },
+        error: err => {
+          const msg = err.status === 404 ? 'Eintrag nicht gefunden' : 'Eintrag konnte nicht gelöscht werden';
+          this.snackBar.open(msg, 'Schließen', {duration: 5000});
+        }
+      });
+    });
+  }
+}

--- a/src/app/nutrition/components/nutrition-home/nutrition-home.component.css
+++ b/src/app/nutrition/components/nutrition-home/nutrition-home.component.css
@@ -8,6 +8,7 @@
   --text-muted:  #7a93b0;
   --text-dim:    #3d5470;
 
+  --c-d:  #fbbf24;  --cg-d: rgba(251, 191,  36, 0.18);
   --c-w:  #a3e635;  --cg-w: rgba(163, 230,  53, 0.18);
   --c-f:  #2dd4bf;  --cg-f: rgba(45,  212, 191, 0.18);
   --c-p:  #4da6ff;  --cg-p: rgba(77,  166, 255, 0.18);
@@ -78,6 +79,7 @@
 
 .navcard:hover::before { opacity: 1; }
 
+.navcard--d { --cc: var(--c-d); --cc-glow: var(--cg-d); }
 .navcard--w { --cc: var(--c-w); --cc-glow: var(--cg-w); }
 .navcard--f { --cc: var(--c-f); --cc-glow: var(--cg-f); }
 .navcard--p { --cc: var(--c-p); --cc-glow: var(--cg-p); }
@@ -138,3 +140,4 @@
 .navcard:nth-child(1) { animation-delay: 0.05s; }
 .navcard:nth-child(2) { animation-delay: 0.12s; }
 .navcard:nth-child(3) { animation-delay: 0.19s; }
+.navcard:nth-child(4) { animation-delay: 0.26s; }

--- a/src/app/nutrition/components/nutrition-home/nutrition-home.component.html
+++ b/src/app/nutrition/components/nutrition-home/nutrition-home.component.html
@@ -3,6 +3,13 @@
   <app-targets-card />
 
   <div class="navgrid">
+    <a class="navcard navcard--d" routerLink="/nutrition/day">
+      <div class="navcard__mark">▤</div>
+      <h2 class="navcard__title">Tagebuch</h2>
+      <p class="navcard__sub">Essen erfassen & Tagesbilanz</p>
+      <span class="navcard__arrow" aria-hidden="true">↗</span>
+    </a>
+
     <a class="navcard navcard--w" routerLink="/nutrition/weight">
       <div class="navcard__mark">⚖</div>
       <h2 class="navcard__title">Gewicht</h2>

--- a/src/app/nutrition/components/nutrition-layout/nutrition-layout.component.html
+++ b/src/app/nutrition/components/nutrition-layout/nutrition-layout.component.html
@@ -11,6 +11,9 @@
         <button mat-menu-item routerLink="/nutrition">
           <span>Home</span>
         </button>
+        <button mat-menu-item routerLink="/nutrition/day">
+          <span>Tagebuch</span>
+        </button>
         <button mat-menu-item routerLink="/nutrition/weight">
           <span>Gewicht</span>
         </button>

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.css
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.css
@@ -1,0 +1,187 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+  --c-g:         #a3e635;
+  --c-n:         #2dd4bf;
+  --c-b:         #4da6ff;
+  --c-e:         #fb7185;
+}
+
+::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+  min-width: 340px !important;
+}
+
+::ng-deep .mat-mdc-dialog-title {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
+  color: var(--text) !important;
+  letter-spacing: 0.03em;
+}
+
+::ng-deep .mat-mdc-dialog-content {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.9rem !important;
+  overflow: visible !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions {
+  gap: 10px;
+  padding-bottom: 16px !important;
+  justify-content: center !important;
+}
+
+.entry-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.5rem;
+}
+
+.field-full { width: 100%; }
+
+/* ── Autocomplete options ────────────────────────── */
+.opt-name { font-weight: 600; }
+
+.opt-brand {
+  margin-left: 0.4rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.opt-kcal {
+  display: block;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  color: var(--text-dim);
+}
+
+/* ── Live macros ─────────────────────────────────── */
+.macros {
+  margin-top: 0.25rem;
+  padding: 0.75rem;
+  background: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+
+.macros__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.macros__grid {
+  margin-top: 0.5rem;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5rem;
+}
+
+.macro {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.4rem 0.25rem;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--mc) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--mc) 25%, transparent);
+}
+
+.macro--kcal { --mc: var(--c-g); }
+.macro--p    { --mc: var(--c-n); }
+.macro--c    { --mc: var(--c-b); }
+.macro--f    { --mc: var(--c-e); }
+
+.macro__v {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--mc);
+  font-variant-numeric: tabular-nums;
+}
+
+.macro__u {
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+}
+
+/* ── Dark theme form fields ──────────────────────── */
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__trailing {
+  border-color: var(--border-mid) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined:not(.mdc-text-field--disabled) .mdc-text-field__input {
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-mdc-floating-label,
+::ng-deep .mat-mdc-form-field .mat-mdc-select-value-text,
+::ng-deep .mat-mdc-form-field .mat-mdc-select-min-line {
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-mdc-floating-label { color: var(--text-dim) !important; }
+
+::ng-deep .mat-mdc-form-field .mat-icon,
+::ng-deep .mat-mdc-form-field .mat-mdc-select-arrow {
+  color: var(--text-dim) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__trailing {
+  border-color: var(--c-g) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mat-mdc-floating-label { color: var(--c-g) !important; }
+
+/* ── Buttons ─────────────────────────────────────── */
+.btn-confirm {
+  background: rgba(45, 212, 191, 0.10) !important;
+  border: 1px solid rgba(45, 212, 191, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-n) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-confirm:hover:not([disabled]) {
+  background: rgba(45, 212, 191, 0.18) !important;
+  box-shadow: 0 0 12px rgba(45, 212, 191, 0.25) !important;
+}
+
+.btn-confirm[disabled] { opacity: 0.4 !important; }
+
+.btn-confirm mat-icon { color: var(--c-n) !important; }
+
+.btn-cancel {
+  background: rgba(251, 113, 133, 0.10) !important;
+  border: 1px solid rgba(251, 113, 133, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-e) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-cancel:hover {
+  background: rgba(251, 113, 133, 0.18) !important;
+  box-shadow: 0 0 12px rgba(251, 113, 133, 0.25) !important;
+}
+
+.btn-cancel mat-icon { color: var(--c-e) !important; }

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.html
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.html
@@ -1,0 +1,72 @@
+<h2 mat-dialog-title>Essen hinzufügen</h2>
+
+<mat-dialog-content>
+  <form class="entry-form" [formGroup]="form">
+    <mat-form-field appearance="outline" class="field-full">
+      <mat-label>Mahlzeit</mat-label>
+      <mat-select formControlName="mealType">
+        @for (m of mealTypes; track m.value) {
+          <mat-option [value]="m.value">{{ m.label }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="field-full">
+      <mat-label>Lebensmittel</mat-label>
+      <mat-icon matSuffix>search</mat-icon>
+      <input matInput autocomplete="off" formControlName="foodSearch"
+             [matAutocomplete]="auto" placeholder="Suchen…" />
+      <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayFood"
+                        (optionSelected)="onFoodSelected($event)">
+        @for (food of results; track food.id) {
+          <mat-option [value]="food">
+            <span class="opt-name">{{ food.name }}</span>
+            @if (food.brand) {
+              <span class="opt-brand">{{ food.brand }}</span>
+            }
+            <span class="opt-kcal">{{ food.kcalPer100 | number:'1.0-0':'de' }} kcal / 100 g</span>
+          </mat-option>
+        }
+      </mat-autocomplete>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="field-full">
+      <mat-label>Menge</mat-label>
+      <input matInput type="number" step="1" formControlName="quantityG" />
+      <span matSuffix>g</span>
+    </mat-form-field>
+
+    @if (selected) {
+      <div class="macros">
+        <span class="macros__label">Für {{ quantityG.value || 0 }} g</span>
+        <div class="macros__grid">
+          <div class="macro macro--kcal">
+            <span class="macro__v">{{ scaled(selected.kcalPer100) | number:'1.0-0':'de' }}</span>
+            <span class="macro__u">kcal</span>
+          </div>
+          <div class="macro macro--p">
+            <span class="macro__v">{{ scaled(selected.proteinPer100) | number:'1.0-1':'de' }}</span>
+            <span class="macro__u">P</span>
+          </div>
+          <div class="macro macro--c">
+            <span class="macro__v">{{ scaled(selected.carbsPer100) | number:'1.0-1':'de' }}</span>
+            <span class="macro__u">KH</span>
+          </div>
+          <div class="macro macro--f">
+            <span class="macro__v">{{ scaled(selected.fatPer100) | number:'1.0-1':'de' }}</span>
+            <span class="macro__u">F</span>
+          </div>
+        </div>
+      </div>
+    }
+  </form>
+</mat-dialog-content>
+
+<mat-dialog-actions align="center">
+  <button mat-mini-fab class="btn-confirm" [disabled]="!canSave" (click)="save()">
+    <mat-icon>check_circle</mat-icon>
+  </button>
+  <button mat-mini-fab mat-dialog-close class="btn-cancel">
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-dialog-actions>

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.ts
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.ts
@@ -1,0 +1,113 @@
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit} from '@angular/core';
+import {DecimalPipe} from '@angular/common';
+import {FormControl, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
+import {MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MatFormField, MatLabel, MatSuffix} from '@angular/material/form-field';
+import {MatInput} from '@angular/material/input';
+import {MatSelect} from '@angular/material/select';
+import {MatOption} from '@angular/material/core';
+import {MatAutocomplete, MatAutocompleteSelectedEvent, MatAutocompleteTrigger} from '@angular/material/autocomplete';
+import {MatIcon} from '@angular/material/icon';
+import {MatMiniFabButton} from '@angular/material/button';
+import {debounceTime, distinctUntilChanged, startWith, switchMap} from 'rxjs';
+import {NutritionService} from '../../services/nutrition.service';
+import {Food, FoodEntryInput, MealType} from '../../models/nutrition.model';
+
+/** Optional defaults for the add-entry dialog (e.g. the meal type tapped). */
+export interface AddDayEntryDialogData {
+  mealType?: MealType;
+}
+
+const MEAL_TYPES: { value: MealType; label: string }[] = [
+  {value: 'BREAKFAST', label: 'Frühstück'},
+  {value: 'LUNCH', label: 'Mittagessen'},
+  {value: 'DINNER', label: 'Abendessen'},
+  {value: 'SNACK', label: 'Snack'}
+];
+
+@Component({
+  selector: 'app-add-day-entry-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ReactiveFormsModule,
+    DecimalPipe,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatFormField,
+    MatLabel,
+    MatSuffix,
+    MatInput,
+    MatSelect,
+    MatOption,
+    MatAutocomplete,
+    MatAutocompleteTrigger,
+    MatIcon,
+    MatMiniFabButton
+  ],
+  templateUrl: './add-day-entry-dialog.component.html',
+  styleUrl: './add-day-entry-dialog.component.css'
+})
+export class AddDayEntryDialogComponent implements OnInit {
+
+  private nutritionService = inject(NutritionService);
+  private dialogRef = inject(MatDialogRef<AddDayEntryDialogComponent>);
+  private cdr = inject(ChangeDetectorRef);
+  private data = inject<AddDayEntryDialogData>(MAT_DIALOG_DATA, {optional: true});
+
+  readonly mealTypes = MEAL_TYPES;
+
+  mealType = new FormControl<MealType>(this.data?.mealType ?? 'LUNCH', {nonNullable: true});
+  foodSearch = new FormControl<string | Food>('', {nonNullable: true});
+  quantityG = new FormControl<number | null>(null, [Validators.required, Validators.min(0)]);
+  form = new FormGroup({mealType: this.mealType, foodSearch: this.foodSearch, quantityG: this.quantityG});
+
+  results: Food[] = [];
+  selected: Food | null = null;
+
+  ngOnInit(): void {
+    this.foodSearch.valueChanges.pipe(
+      startWith(this.foodSearch.value),
+      // Once a food is picked the control holds a Food object; skip searching then.
+      debounceTime(300),
+      distinctUntilChanged(),
+      switchMap(value => this.nutritionService.searchFoods(typeof value === 'string' ? value.trim() : ''))
+    ).subscribe(foods => {
+      this.results = foods;
+      this.cdr.markForCheck();
+    });
+  }
+
+  displayFood(food: Food | string | null): string {
+    return food && typeof food !== 'string' ? food.name : (food ?? '');
+  }
+
+  onFoodSelected(event: MatAutocompleteSelectedEvent): void {
+    this.selected = event.option.value as Food;
+    if (this.quantityG.value == null && this.selected.defaultServingG != null) {
+      this.quantityG.setValue(this.selected.defaultServingG);
+    }
+    this.cdr.markForCheck();
+  }
+
+  /** Macro value for the current portion, scaled from the per-100 g figure. */
+  scaled(per100: number): number {
+    const qty = Number(this.quantityG.value);
+    if (!this.selected || !qty) return 0;
+    return per100 * qty / 100;
+  }
+
+  get canSave(): boolean {
+    return !!this.selected && this.quantityG.valid && Number(this.quantityG.value) > 0;
+  }
+
+  save(): void {
+    if (!this.canSave || !this.selected) return;
+    const result: FoodEntryInput = {
+      mealType: this.mealType.value,
+      foodId: this.selected.id,
+      quantityG: Number(this.quantityG.value)
+    };
+    this.dialogRef.close(result);
+  }
+}

--- a/src/app/nutrition/dialogs/entry-delete-dialog/entry-delete-dialog.component.css
+++ b/src/app/nutrition/dialogs/entry-delete-dialog/entry-delete-dialog.component.css
@@ -1,0 +1,69 @@
+:host {
+  --surface:     #0c1018;
+  --border-mid:  rgba(255, 255, 255, 0.13);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --c-n:         #2dd4bf;
+  --c-e:         #fb7185;
+}
+
+::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-dialog-title {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
+  color: var(--text) !important;
+  letter-spacing: 0.03em;
+}
+
+::ng-deep .mat-mdc-dialog-content {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.9rem !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions {
+  gap: 10px;
+  padding-bottom: 16px !important;
+  justify-content: center !important;
+}
+
+.btn-confirm {
+  background: rgba(45, 212, 191, 0.10) !important;
+  border: 1px solid rgba(45, 212, 191, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-n) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-confirm:hover {
+  background: rgba(45, 212, 191, 0.18) !important;
+  box-shadow: 0 0 12px rgba(45, 212, 191, 0.25) !important;
+}
+
+.btn-confirm mat-icon {
+  color: var(--c-n) !important;
+}
+
+.btn-cancel {
+  background: rgba(251, 113, 133, 0.10) !important;
+  border: 1px solid rgba(251, 113, 133, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-e) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-cancel:hover {
+  background: rgba(251, 113, 133, 0.18) !important;
+  box-shadow: 0 0 12px rgba(251, 113, 133, 0.25) !important;
+}
+
+.btn-cancel mat-icon {
+  color: var(--c-e) !important;
+}

--- a/src/app/nutrition/dialogs/entry-delete-dialog/entry-delete-dialog.component.html
+++ b/src/app/nutrition/dialogs/entry-delete-dialog/entry-delete-dialog.component.html
@@ -1,0 +1,14 @@
+<h2 mat-dialog-title>Eintrag löschen</h2>
+
+<mat-dialog-content>
+  <span>«{{ label }}» wirklich löschen?</span>
+</mat-dialog-content>
+
+<mat-dialog-actions align="center">
+  <button mat-mini-fab class="btn-confirm" (click)="confirm()">
+    <mat-icon>check_circle</mat-icon>
+  </button>
+  <button mat-mini-fab mat-dialog-close class="btn-cancel">
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-dialog-actions>

--- a/src/app/nutrition/dialogs/entry-delete-dialog/entry-delete-dialog.component.ts
+++ b/src/app/nutrition/dialogs/entry-delete-dialog/entry-delete-dialog.component.ts
@@ -1,0 +1,28 @@
+import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MatIcon} from '@angular/material/icon';
+import {MatMiniFabButton} from '@angular/material/button';
+
+@Component({
+  selector: 'app-entry-delete-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatIcon,
+    MatMiniFabButton
+  ],
+  templateUrl: './entry-delete-dialog.component.html',
+  styleUrl: './entry-delete-dialog.component.css'
+})
+export class EntryDeleteDialogComponent {
+
+  private dialogRef = inject(MatDialogRef<EntryDeleteDialogComponent>);
+  label = inject<{label: string}>(MAT_DIALOG_DATA).label;
+
+  confirm() {
+    this.dialogRef.close('confirmed');
+  }
+}

--- a/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.css
+++ b/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.css
@@ -1,0 +1,117 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --surface:     #0c1018;
+  --border-mid:  rgba(255, 255, 255, 0.13);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+  --c-g:         #a3e635;
+  --c-n:         #2dd4bf;
+  --c-e:         #fb7185;
+}
+
+::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+  min-width: 340px !important;
+}
+
+::ng-deep .mat-mdc-dialog-title {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
+  color: var(--text) !important;
+  letter-spacing: 0.03em;
+}
+
+::ng-deep .mat-mdc-dialog-content {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.9rem !important;
+  overflow: visible !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions {
+  gap: 10px;
+  padding-bottom: 16px !important;
+  justify-content: center !important;
+}
+
+.entry-label {
+  margin: 0.25rem 0 0.5rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.field-full { width: 100%; }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.25rem 0.75rem;
+}
+
+@media (max-width: 420px) {
+  .grid { grid-template-columns: 1fr; }
+}
+
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__trailing {
+  border-color: var(--border-mid) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined:not(.mdc-text-field--disabled) .mdc-text-field__input {
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-mdc-floating-label { color: var(--text-dim) !important; }
+
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__trailing {
+  border-color: var(--c-g) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mat-mdc-floating-label { color: var(--c-g) !important; }
+
+.btn-confirm {
+  background: rgba(45, 212, 191, 0.10) !important;
+  border: 1px solid rgba(45, 212, 191, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-n) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-confirm:hover:not([disabled]) {
+  background: rgba(45, 212, 191, 0.18) !important;
+  box-shadow: 0 0 12px rgba(45, 212, 191, 0.25) !important;
+}
+
+.btn-confirm[disabled] { opacity: 0.4 !important; }
+
+.btn-confirm mat-icon { color: var(--c-n) !important; }
+
+.btn-cancel {
+  background: rgba(251, 113, 133, 0.10) !important;
+  border: 1px solid rgba(251, 113, 133, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-e) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-cancel:hover {
+  background: rgba(251, 113, 133, 0.18) !important;
+  box-shadow: 0 0 12px rgba(251, 113, 133, 0.25) !important;
+}
+
+.btn-cancel mat-icon { color: var(--c-e) !important; }

--- a/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.html
+++ b/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.html
@@ -1,0 +1,51 @@
+<h2 mat-dialog-title>Eintrag bearbeiten</h2>
+
+<mat-dialog-content>
+  <p class="entry-label">{{ label }}</p>
+
+  <form class="edit-form" [formGroup]="form">
+    @if (isAdHoc) {
+      <mat-form-field appearance="outline" class="field-full">
+        <mat-label>Beschreibung</mat-label>
+        <input matInput formControlName="description" />
+      </mat-form-field>
+
+      <div class="grid">
+        <mat-form-field appearance="outline">
+          <mat-label>kcal</mat-label>
+          <input matInput type="number" step="1" formControlName="kcal" />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Protein (g)</mat-label>
+          <input matInput type="number" step="0.1" formControlName="proteinG" />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Kohlenhydrate (g)</mat-label>
+          <input matInput type="number" step="0.1" formControlName="carbsG" />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Fett (g)</mat-label>
+          <input matInput type="number" step="0.1" formControlName="fatG" />
+        </mat-form-field>
+      </div>
+    } @else {
+      <mat-form-field appearance="outline" class="field-full">
+        <mat-label>Menge</mat-label>
+        <input matInput type="number" step="1" formControlName="quantityG" />
+        <span matSuffix>g</span>
+      </mat-form-field>
+    }
+  </form>
+</mat-dialog-content>
+
+<mat-dialog-actions align="center">
+  <button mat-mini-fab class="btn-confirm" [disabled]="form.invalid" (click)="save()">
+    <mat-icon>check_circle</mat-icon>
+  </button>
+  <button mat-mini-fab mat-dialog-close class="btn-cancel">
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-dialog-actions>

--- a/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.ts
+++ b/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.ts
@@ -1,0 +1,73 @@
+import {ChangeDetectionStrategy, Component, inject, OnInit} from '@angular/core';
+import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
+import {MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MatFormField, MatLabel, MatSuffix} from '@angular/material/form-field';
+import {MatInput} from '@angular/material/input';
+import {MatIcon} from '@angular/material/icon';
+import {MatMiniFabButton} from '@angular/material/button';
+import {MealEntry, MealEntryUpdate} from '../../models/nutrition.model';
+
+/**
+ * Edit a logged entry. Food-based entries edit only the portion (`quantityG`);
+ * the backend re-snapshots the macros. Ad-hoc entries edit the values directly.
+ */
+@Component({
+  selector: 'app-entry-edit-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ReactiveFormsModule,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatFormField,
+    MatLabel,
+    MatSuffix,
+    MatInput,
+    MatIcon,
+    MatMiniFabButton
+  ],
+  templateUrl: './entry-edit-dialog.component.html',
+  styleUrl: './entry-edit-dialog.component.css'
+})
+export class EntryEditDialogComponent implements OnInit {
+
+  private fb = inject(FormBuilder);
+  private dialogRef = inject(MatDialogRef<EntryEditDialogComponent>);
+  private entry = inject<MealEntry>(MAT_DIALOG_DATA);
+
+  form!: FormGroup;
+  /** Ad-hoc entries have no food reference and edit their macro values. */
+  readonly isAdHoc = this.entry.foodId == null;
+  readonly label = this.entry.description ?? this.entry.foodName ?? 'Eintrag';
+
+  ngOnInit(): void {
+    if (this.isAdHoc) {
+      this.form = this.fb.group({
+        description: [this.entry.description ?? '', Validators.required],
+        kcal: [this.entry.kcal, [Validators.required, Validators.min(0)]],
+        proteinG: [this.entry.proteinG, [Validators.required, Validators.min(0)]],
+        carbsG: [this.entry.carbsG, [Validators.required, Validators.min(0)]],
+        fatG: [this.entry.fatG, [Validators.required, Validators.min(0)]]
+      });
+    } else {
+      this.form = this.fb.group({
+        quantityG: [this.entry.quantityG, [Validators.required, Validators.min(0)]]
+      });
+    }
+  }
+
+  save(): void {
+    if (this.form.invalid) return;
+    const v = this.form.getRawValue();
+    const update: MealEntryUpdate = this.isAdHoc
+      ? {
+        description: v.description.trim(),
+        kcal: Number(v.kcal),
+        proteinG: Number(v.proteinG),
+        carbsG: Number(v.carbsG),
+        fatG: Number(v.fatG)
+      }
+      : {quantityG: Number(v.quantityG)};
+    this.dialogRef.close(update);
+  }
+}

--- a/src/app/nutrition/models/nutrition.model.ts
+++ b/src/app/nutrition/models/nutrition.model.ts
@@ -88,25 +88,77 @@ export interface FoodDraft {
   servingG: number | null;
 }
 
-export interface MealEntry {
-  id: string;
-  date: string;
-  mealType: MealType;
-  foodId: string;
-  foodName: string;
-  amountG: number;
-  calories: number;
+/** A set of macro values (used for day totals and remaining-vs-target). */
+export interface Macros {
+  kcal: number;
   proteinG: number;
   carbsG: number;
   fatG: number;
 }
 
+/**
+ * A logged meal entry. Either references a stored food (`foodId` + `quantityG`)
+ * or is ad-hoc (`description` + supplied macros, e.g. a canteen estimate). The
+ * macro values are snapshotted at log time so historical totals stay stable.
+ */
+export interface MealEntry {
+  id: string;
+  entryDate: string;
+  mealType: MealType;
+  foodId: string | null;
+  /** Name of the referenced food, when the backend resolves it for display. */
+  foodName: string | null;
+  /** Free-text label for ad-hoc entries (null for food-based entries). */
+  description: string | null;
+  /** Portion in grams for food-based entries (null for ad-hoc). */
+  quantityG: number | null;
+  kcal: number;
+  proteinG: number;
+  carbsG: number;
+  fatG: number;
+}
+
+/** Log a stored food eaten in a given portion (POST /days/{date}/entries). */
+export interface FoodEntryInput {
+  mealType: MealType;
+  foodId: string;
+  quantityG: number;
+}
+
+/** Log an ad-hoc entry with supplied macros, e.g. a canteen estimate. */
+export interface AdHocEntryInput {
+  mealType: MealType;
+  description: string;
+  kcal: number;
+  proteinG: number;
+  carbsG: number;
+  fatG: number;
+}
+
+export type MealEntryInput = FoodEntryInput | AdHocEntryInput;
+
+/** Edit payload for PUT /entries/{id}: a new portion, or new ad-hoc values. */
+export type MealEntryUpdate =
+  | { quantityG: number }
+  | { description: string; kcal: number; proteinG: number; carbsG: number; fatG: number };
+
 export interface DaySummary {
   date: string;
+  entries: MealEntry[];
+  totals: Macros;
   targets: Targets;
-  consumedCalories: number;
-  consumedProteinG: number;
-  consumedCarbsG: number;
-  consumedFatG: number;
-  meals: MealEntry[];
+  remaining: Macros;
+}
+
+/**
+ * Rough macro estimate for a free-text meal description, produced by Claude
+ * (POST /nutrition/estimate). Directly usable as an ad-hoc entry payload.
+ */
+export interface MealEstimate {
+  kcal: number;
+  proteinG: number;
+  carbsG: number;
+  fatG: number;
+  /** Short note on the assumptions made (portion size, ingredients, …). */
+  assumptions: string;
 }

--- a/src/app/nutrition/services/nutrition.service.ts
+++ b/src/app/nutrition/services/nutrition.service.ts
@@ -8,6 +8,9 @@ import {
   FoodDraft,
   FoodInput,
   MealEntry,
+  MealEntryInput,
+  MealEntryUpdate,
+  MealEstimate,
   Profile,
   ProfileInput,
   Targets,
@@ -94,11 +97,27 @@ export class NutritionService {
     return this.http.get<FoodDraft>(`${this.host}/foods/barcode/${ean}`);
   }
 
-  getMeals(date: string): Observable<MealEntry[]> {
-    return this.http.get<MealEntry[]>(`${this.host}/meals`, {params: {date}});
-  }
-
+  /** Day summary: logged entries, totals, targets and remaining amounts. */
   getDaySummary(date: string): Observable<DaySummary> {
     return this.http.get<DaySummary>(`${this.host}/days/${date}`);
+  }
+
+  /** Log a meal entry on a day, either food-based or ad-hoc. */
+  addEntry(date: string, entry: MealEntryInput): Observable<MealEntry> {
+    return this.http.post<MealEntry>(`${this.host}/days/${date}/entries`, entry);
+  }
+
+  /** Edit an entry's portion (food-based) or values (ad-hoc). */
+  updateEntry(id: string, update: MealEntryUpdate): Observable<MealEntry> {
+    return this.http.put<MealEntry>(`${this.host}/entries/${id}`, update);
+  }
+
+  deleteEntry(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.host}/entries/${id}`);
+  }
+
+  /** Estimate macros for a free-text meal description via Claude. */
+  estimateMeal(description: string): Observable<MealEstimate> {
+    return this.http.post<MealEstimate>(`${this.host}/estimate`, {description});
   }
 }


### PR DESCRIPTION
## Summary

Implements **#142** — the daily meal log and day summary for the nutrition module.

- **Date picker** (de-DE) selecting the day, defaults to today; switching reloads the day.
- **Add-food-to-day dialog**: meal type `MatSelect`, food-search autocomplete (reuses `searchFoods`), quantity in grams, with **live computed macros** for the portion.
- **Per-day entries** grouped by meal type, each with edit (portion for food entries / values for ad-hoc) and delete.
- **Summary panel**: totals vs. targets with progress bars and remaining amounts (kcal, protein, carbs, fat) from `GET /nutrition/days/{date}`.
- Adding/editing/removing entries reloads the day so the summary updates immediately.

## Model/service alignment

Aligned `MealEntry`/`DaySummary` and `NutritionService` with backend **#107**: `POST /nutrition/days/{date}/entries` (food or ad-hoc), `PUT`/`DELETE /nutrition/entries/{id}`, `GET /nutrition/days/{date}` (`{entries, totals, targets, remaining}`). Also added `estimateMeal` + `MealEstimate` to unblock the canteen estimator (#143).

## Verification

- `npm run build` ✅
- `npm run lint` — no new errors in the added files (repo has a pre-existing warning/error baseline).

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)