### PR TITLE
feat(nutrition): canteen meal estimate UI

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -35,6 +35,7 @@ import {NutritionWeightComponent} from './nutrition/components/nutrition-weight/
 import {NutritionProfileComponent} from './nutrition/components/nutrition-profile/nutrition-profile.component';
 import {NutritionFoodsComponent} from './nutrition/components/nutrition-foods/nutrition-foods.component';
 import {NutritionDayComponent} from './nutrition/components/nutrition-day/nutrition-day.component';
+import {NutritionCanteenComponent} from './nutrition/components/nutrition-canteen/nutrition-canteen.component';
 
 export const routes: Routes = [
   {path: '', component: HomeComponent},
@@ -110,6 +111,7 @@ export const routes: Routes = [
     children: [
       {path: '', component: NutritionHomeComponent, data: {home: '/'}},
       {path: 'day', component: NutritionDayComponent, data: {home: '/nutrition'}},
+      {path: 'canteen', component: NutritionCanteenComponent, data: {home: '/nutrition'}},
       {path: 'weight', component: NutritionWeightComponent, data: {home: '/nutrition'}},
       {path: 'foods', component: NutritionFoodsComponent, data: {home: '/nutrition'}},
       {path: 'profile', component: NutritionProfileComponent, data: {home: '/nutrition'}}

--- a/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.css
+++ b/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.css
@@ -1,0 +1,177 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-g:  #a3e635;
+  --c-n:  #2dd4bf;
+  --c-b:  #4da6ff;
+
+  display: block;
+  height: 100%;
+  overflow-y: auto;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+}
+
+.canteen {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem clamp(1rem, 6vw, 4rem);
+  max-width: 760px;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+/* ── Panels ──────────────────────────────────────── */
+.panel__head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.panel__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--c-b);
+  box-shadow: 0 0 6px var(--c-b);
+}
+
+.panel__dot--n { background: var(--c-n); box-shadow: 0 0 6px var(--c-n); }
+
+.panel__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+}
+
+.lead {
+  margin: 0 0 1rem;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.field-full { width: 100%; }
+
+/* ── Buttons ─────────────────────────────────────── */
+.btn-estimate,
+.btn-log {
+  height: 48px;
+  border-radius: 8px !important;
+  font-weight: 600 !important;
+  margin-top: 0.5rem;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-estimate {
+  background: color-mix(in srgb, var(--c-b) 14%, transparent) !important;
+  border: 1px solid color-mix(in srgb, var(--c-b) 35%, transparent) !important;
+  color: var(--c-b) !important;
+}
+
+.btn-estimate:hover:not([disabled]) {
+  background: color-mix(in srgb, var(--c-b) 22%, transparent) !important;
+  box-shadow: 0 0 12px rgba(77, 166, 255, 0.25) !important;
+}
+
+.btn-log {
+  background: color-mix(in srgb, var(--c-g) 14%, transparent) !important;
+  border: 1px solid color-mix(in srgb, var(--c-g) 35%, transparent) !important;
+  color: var(--c-g) !important;
+}
+
+.btn-log:hover:not([disabled]) {
+  background: color-mix(in srgb, var(--c-g) 22%, transparent) !important;
+  box-shadow: 0 0 12px rgba(163, 230, 53, 0.25) !important;
+}
+
+.btn-estimate[disabled],
+.btn-log[disabled] { opacity: 0.55 !important; }
+
+.btn-estimate mat-spinner,
+.btn-log mat-spinner { margin-right: 4px; }
+
+::ng-deep .btn-estimate mat-spinner circle { stroke: var(--c-b) !important; }
+::ng-deep .btn-log mat-spinner circle { stroke: var(--c-g) !important; }
+
+/* ── Estimate grid ───────────────────────────────── */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.25rem 0.75rem;
+}
+
+@media (max-width: 420px) {
+  .grid { grid-template-columns: 1fr; }
+}
+
+.assumptions {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin: 0.25rem 0 1rem;
+  padding: 0.7rem 0.8rem;
+  background: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+
+.assumptions mat-icon {
+  flex-shrink: 0;
+  font-size: 1.05rem;
+  width: 1.05rem;
+  height: 1.05rem;
+  color: var(--c-n);
+}
+
+.log-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.field-date { flex: 1 1 180px; }
+.field-meal { flex: 1 1 180px; }
+
+/* ── Dark form fields ────────────────────────────── */
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__trailing {
+  border-color: var(--border-mid) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined:not(.mdc-text-field--disabled) .mdc-text-field__input,
+::ng-deep .mat-mdc-form-field .mat-mdc-select-value-text {
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-mdc-floating-label { color: var(--text-dim) !important; }
+
+::ng-deep .mat-mdc-form-field .mat-icon,
+::ng-deep .mat-mdc-form-field .mat-mdc-select-arrow,
+::ng-deep .mat-mdc-form-field .mat-datepicker-toggle { color: var(--text-dim) !important; }
+
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__trailing {
+  border-color: var(--c-b) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mat-mdc-floating-label { color: var(--c-b) !important; }

--- a/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.html
+++ b/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.html
@@ -1,0 +1,97 @@
+<div class="canteen">
+
+  <section class="panel">
+    <header class="panel__head">
+      <span class="panel__dot"></span>
+      <span class="panel__label">KANTINE</span>
+    </header>
+
+    <p class="lead">
+      Beschreibe dein Mittagessen in eigenen Worten – die KI schätzt Kalorien und Makros,
+      die du anpassen und als Eintrag speichern kannst.
+    </p>
+
+    <mat-form-field appearance="outline" class="field-full">
+      <mat-label>Beschreibung</mat-label>
+      <textarea matInput rows="3" [formControl]="description"
+                placeholder="z. B. Schnitzel mit Pommes und Salat, großer Teller"></textarea>
+    </mat-form-field>
+
+    <button mat-flat-button type="button" class="btn-estimate"
+            [disabled]="description.invalid || estimating" (click)="estimate()">
+      @if (estimating) {
+        <mat-spinner diameter="18" />
+      } @else {
+        <mat-icon>auto_awesome</mat-icon>
+      }
+      Schätzen
+    </button>
+  </section>
+
+  @if (hasEstimate) {
+    <section class="panel">
+      <header class="panel__head">
+        <span class="panel__dot panel__dot--n"></span>
+        <span class="panel__label">SCHÄTZUNG</span>
+      </header>
+
+      <form class="grid" [formGroup]="valuesForm">
+        <mat-form-field appearance="outline">
+          <mat-label>kcal</mat-label>
+          <input matInput type="number" step="1" formControlName="kcal" />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Protein (g)</mat-label>
+          <input matInput type="number" step="0.1" formControlName="proteinG" />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Kohlenhydrate (g)</mat-label>
+          <input matInput type="number" step="0.1" formControlName="carbsG" />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Fett (g)</mat-label>
+          <input matInput type="number" step="0.1" formControlName="fatG" />
+        </mat-form-field>
+      </form>
+
+      @if (assumptions) {
+        <p class="assumptions">
+          <mat-icon>info</mat-icon>
+          <span>{{ assumptions }}</span>
+        </p>
+      }
+
+      <div class="log-row">
+        <mat-form-field appearance="outline" class="field-date">
+          <mat-label>Datum</mat-label>
+          <input matInput [matDatepicker]="picker" [formControl]="date" />
+          <mat-datepicker-toggle matIconSuffix [for]="picker" />
+          <mat-datepicker #picker />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="field-meal">
+          <mat-label>Mahlzeit</mat-label>
+          <mat-select [formControl]="mealType">
+            @for (m of mealTypes; track m.value) {
+              <mat-option [value]="m.value">{{ m.label }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+      </div>
+
+      <button mat-flat-button type="button" class="btn-log"
+              [disabled]="valuesForm.invalid || logging" (click)="log()">
+        @if (logging) {
+          <mat-spinner diameter="18" />
+        } @else {
+          <mat-icon>add_task</mat-icon>
+        }
+        Eintragen
+      </button>
+    </section>
+  }
+
+</div>

--- a/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.ts
+++ b/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.ts
@@ -1,0 +1,139 @@
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit} from '@angular/core';
+import {FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
+import {MatFormField, MatLabel} from '@angular/material/form-field';
+import {MatInput} from '@angular/material/input';
+import {MatSelect} from '@angular/material/select';
+import {MatOption} from '@angular/material/core';
+import {MatDatepicker, MatDatepickerInput, MatDatepickerToggle} from '@angular/material/datepicker';
+import {MatButton} from '@angular/material/button';
+import {MatIcon} from '@angular/material/icon';
+import {MatProgressSpinner} from '@angular/material/progress-spinner';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {format} from 'date-fns';
+import {NutritionService} from '../../services/nutrition.service';
+import {AdHocEntryInput, MealEstimate, MealType} from '../../models/nutrition.model';
+
+const MEAL_TYPES: { value: MealType; label: string }[] = [
+  {value: 'BREAKFAST', label: 'Frühstück'},
+  {value: 'LUNCH', label: 'Mittagessen'},
+  {value: 'DINNER', label: 'Abendessen'},
+  {value: 'SNACK', label: 'Snack'}
+];
+
+@Component({
+  selector: 'app-nutrition-canteen',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ReactiveFormsModule,
+    MatFormField,
+    MatLabel,
+    MatInput,
+    MatSelect,
+    MatOption,
+    MatDatepicker,
+    MatDatepickerInput,
+    MatDatepickerToggle,
+    MatButton,
+    MatIcon,
+    MatProgressSpinner
+  ],
+  templateUrl: './nutrition-canteen.component.html',
+  styleUrl: './nutrition-canteen.component.css'
+})
+export class NutritionCanteenComponent implements OnInit {
+
+  readonly mealTypes = MEAL_TYPES;
+
+  description = new FormControl('', {nonNullable: true, validators: Validators.required});
+  mealType = new FormControl<MealType>('LUNCH', {nonNullable: true});
+  date = new FormControl<Date>(new Date(), {nonNullable: true});
+
+  /** Editable macro values; populated once an estimate arrives. */
+  valuesForm!: FormGroup;
+  assumptions = '';
+  estimating = false;
+  logging = false;
+  hasEstimate = false;
+
+  private fb = inject(FormBuilder);
+  private nutritionService = inject(NutritionService);
+  private snackBar = inject(MatSnackBar);
+  private cdr = inject(ChangeDetectorRef);
+
+  ngOnInit(): void {
+    this.valuesForm = this.fb.group({
+      kcal: [0, [Validators.required, Validators.min(0)]],
+      proteinG: [0, [Validators.required, Validators.min(0)]],
+      carbsG: [0, [Validators.required, Validators.min(0)]],
+      fatG: [0, [Validators.required, Validators.min(0)]]
+    });
+  }
+
+  estimate(): void {
+    if (this.description.invalid || this.estimating) return;
+    this.estimating = true;
+    this.cdr.markForCheck();
+
+    this.nutritionService.estimateMeal(this.description.value.trim()).subscribe({
+      next: (estimate: MealEstimate) => {
+        this.applyEstimate(estimate);
+        this.estimating = false;
+        this.hasEstimate = true;
+        this.cdr.markForCheck();
+      },
+      error: () => {
+        this.estimating = false;
+        this.cdr.markForCheck();
+        this.snackBar.open('Schätzung fehlgeschlagen', 'Schließen', {duration: 5000});
+      }
+    });
+  }
+
+  private applyEstimate(estimate: MealEstimate): void {
+    this.valuesForm.setValue({
+      kcal: Math.round(estimate.kcal),
+      proteinG: estimate.proteinG,
+      carbsG: estimate.carbsG,
+      fatG: estimate.fatG
+    });
+    this.assumptions = estimate.assumptions;
+  }
+
+  log(): void {
+    if (!this.hasEstimate || this.valuesForm.invalid || this.description.invalid || this.logging) return;
+    this.logging = true;
+    this.cdr.markForCheck();
+
+    const v = this.valuesForm.getRawValue();
+    const payload: AdHocEntryInput = {
+      mealType: this.mealType.value,
+      description: this.description.value.trim(),
+      kcal: Number(v.kcal),
+      proteinG: Number(v.proteinG),
+      carbsG: Number(v.carbsG),
+      fatG: Number(v.fatG)
+    };
+    const isoDate = format(this.date.value, 'yyyy-MM-dd');
+
+    this.nutritionService.addEntry(isoDate, payload).subscribe({
+      next: () => {
+        this.logging = false;
+        this.reset();
+        this.cdr.markForCheck();
+        this.snackBar.open('Als Eintrag gespeichert', 'OK', {duration: 3000});
+      },
+      error: () => {
+        this.logging = false;
+        this.cdr.markForCheck();
+        this.snackBar.open('Eintrag konnte nicht gespeichert werden', 'Schließen', {duration: 5000});
+      }
+    });
+  }
+
+  private reset(): void {
+    this.description.reset('');
+    this.assumptions = '';
+    this.hasEstimate = false;
+    this.valuesForm.reset({kcal: 0, proteinG: 0, carbsG: 0, fatG: 0});
+  }
+}

--- a/src/app/nutrition/components/nutrition-home/nutrition-home.component.css
+++ b/src/app/nutrition/components/nutrition-home/nutrition-home.component.css
@@ -9,9 +9,10 @@
   --text-dim:    #3d5470;
 
   --c-d:  #fbbf24;  --cg-d: rgba(251, 191,  36, 0.18);
+  --c-c:  #4da6ff;  --cg-c: rgba(77,  166, 255, 0.18);
   --c-w:  #a3e635;  --cg-w: rgba(163, 230,  53, 0.18);
   --c-f:  #2dd4bf;  --cg-f: rgba(45,  212, 191, 0.18);
-  --c-p:  #4da6ff;  --cg-p: rgba(77,  166, 255, 0.18);
+  --c-p:  #c084fc;  --cg-p: rgba(192, 132, 252, 0.18);
 
   display: block;
   height: 100%;
@@ -80,6 +81,7 @@
 .navcard:hover::before { opacity: 1; }
 
 .navcard--d { --cc: var(--c-d); --cc-glow: var(--cg-d); }
+.navcard--c { --cc: var(--c-c); --cc-glow: var(--cg-c); }
 .navcard--w { --cc: var(--c-w); --cc-glow: var(--cg-w); }
 .navcard--f { --cc: var(--c-f); --cc-glow: var(--cg-f); }
 .navcard--p { --cc: var(--c-p); --cc-glow: var(--cg-p); }
@@ -141,3 +143,4 @@
 .navcard:nth-child(2) { animation-delay: 0.12s; }
 .navcard:nth-child(3) { animation-delay: 0.19s; }
 .navcard:nth-child(4) { animation-delay: 0.26s; }
+.navcard:nth-child(5) { animation-delay: 0.33s; }

--- a/src/app/nutrition/components/nutrition-home/nutrition-home.component.html
+++ b/src/app/nutrition/components/nutrition-home/nutrition-home.component.html
@@ -17,6 +17,13 @@
       <span class="navcard__arrow" aria-hidden="true">↗</span>
     </a>
 
+    <a class="navcard navcard--c" routerLink="/nutrition/canteen">
+      <div class="navcard__mark">✦</div>
+      <h2 class="navcard__title">Kantine</h2>
+      <p class="navcard__sub">Mittagessen per KI schätzen</p>
+      <span class="navcard__arrow" aria-hidden="true">↗</span>
+    </a>
+
     <a class="navcard navcard--f" routerLink="/nutrition/foods">
       <div class="navcard__mark">⬡</div>
       <h2 class="navcard__title">Lebensmittel</h2>

--- a/src/app/nutrition/components/nutrition-layout/nutrition-layout.component.html
+++ b/src/app/nutrition/components/nutrition-layout/nutrition-layout.component.html
@@ -14,6 +14,9 @@
         <button mat-menu-item routerLink="/nutrition/day">
           <span>Tagebuch</span>
         </button>
+        <button mat-menu-item routerLink="/nutrition/canteen">
+          <span>Kantine</span>
+        </button>
         <button mat-menu-item routerLink="/nutrition/weight">
           <span>Gewicht</span>
         </button>


### PR DESCRIPTION
## Summary

Implements **#143** — estimate a canteen lunch from free text via Claude and log it as an ad-hoc entry.

- **Free-text input** → `POST /nutrition/estimate` (`{description}`).
- Shows the returned **estimate** (kcal + macros + assumptions note) with the macro values **editable** before logging.
- **"Eintragen"** logs it as an **ad-hoc** entry for the selected day + meal type (ad-hoc path of backend #107).
- **Loading** spinners on estimate/log and **error** states via `MatSnackBar`.

Builds on the day-log/ad-hoc entry path from #142 (`estimateMeal` + `addEntry` already added to the service there).

## Verification

- `npm run build` ✅
- `npm run lint` — no new errors in the added files.

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)