### PR TITLE
feat(nutrition): dashboard with weight & intake trend charts

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -36,6 +36,7 @@ import {NutritionProfileComponent} from './nutrition/components/nutrition-profil
 import {NutritionFoodsComponent} from './nutrition/components/nutrition-foods/nutrition-foods.component';
 import {NutritionDayComponent} from './nutrition/components/nutrition-day/nutrition-day.component';
 import {NutritionCanteenComponent} from './nutrition/components/nutrition-canteen/nutrition-canteen.component';
+import {NutritionDashboardComponent} from './nutrition/components/nutrition-dashboard/nutrition-dashboard.component';
 
 export const routes: Routes = [
   {path: '', component: HomeComponent},
@@ -110,6 +111,7 @@ export const routes: Routes = [
     component: NutritionLayoutComponent,
     children: [
       {path: '', component: NutritionHomeComponent, data: {home: '/'}},
+      {path: 'dashboard', component: NutritionDashboardComponent, data: {home: '/nutrition'}},
       {path: 'day', component: NutritionDayComponent, data: {home: '/nutrition'}},
       {path: 'canteen', component: NutritionCanteenComponent, data: {home: '/nutrition'}},
       {path: 'weight', component: NutritionWeightComponent, data: {home: '/nutrition'}},

--- a/src/app/nutrition/components/nutrition-dashboard/nutrition-dashboard.component.css
+++ b/src/app/nutrition/components/nutrition-dashboard/nutrition-dashboard.component.css
@@ -1,0 +1,221 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-w:  #a3e635;
+  --c-k:  #4da6ff;
+  --c-a:  #fbbf24;
+  --c-within: #2dd4bf;
+  --c-under:  #4da6ff;
+  --c-over:   #fb7185;
+
+  display: block;
+  height: 100%;
+  overflow-y: auto;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+}
+
+.dash {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem clamp(1rem, 6vw, 4rem);
+  max-width: 760px;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+/* ── Panels ──────────────────────────────────────── */
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem 1.1rem 1.1rem;
+}
+
+.panel__head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.9rem;
+}
+
+.panel__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.panel__dot--w { background: var(--c-w); box-shadow: 0 0 6px var(--c-w); }
+.panel__dot--k { background: var(--c-k); box-shadow: 0 0 6px var(--c-k); }
+.panel__dot--a { background: var(--c-a); box-shadow: 0 0 6px var(--c-a); }
+
+.panel__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+}
+
+.panel__stat {
+  margin-left: auto;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.delta {
+  margin-left: 0.25rem;
+  font-weight: 700;
+}
+
+.delta--up { color: var(--c-over); }
+.delta--down { color: var(--c-within); }
+
+/* ── Charts ──────────────────────────────────────── */
+.chart {
+  width: 100%;
+}
+
+.svg {
+  width: 100%;
+  height: 150px;
+  display: block;
+  overflow: visible;
+}
+
+.line--w {
+  fill: none;
+  stroke: var(--c-w);
+  stroke-width: 2;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+  filter: drop-shadow(0 0 3px color-mix(in srgb, var(--c-w) 55%, transparent));
+}
+
+.area--w {
+  fill: var(--c-w);
+  opacity: 0.10;
+  stroke: none;
+}
+
+.dot--w {
+  fill: var(--surface);
+  stroke: var(--c-w);
+  stroke-width: 1.5;
+}
+
+.bar { transition: opacity 0.2s; }
+.bar--within { fill: var(--c-within); }
+.bar--under  { fill: var(--c-under); opacity: 0.65; }
+.bar--over   { fill: var(--c-over); }
+
+.target-line {
+  stroke: var(--text-muted);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+  opacity: 0.7;
+}
+
+.axis {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.35rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.58rem;
+  color: var(--text-dim);
+}
+
+.legend {
+  display: flex;
+  gap: 0.9rem;
+  margin: 0.6rem 0 0;
+  font-size: 0.62rem;
+  color: var(--text-muted);
+}
+
+.legend__item {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.legend__item::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+}
+
+.legend__item--within::before { background: var(--c-within); }
+.legend__item--under::before  { background: var(--c-under); opacity: 0.65; }
+.legend__item--over::before   { background: var(--c-over); }
+
+/* ── Stats ───────────────────────────────────────── */
+.stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.85rem 0.5rem;
+  background: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+
+.stat__v {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--c-a);
+  font-variant-numeric: tabular-nums;
+}
+
+.stat__sub {
+  font-size: 0.8rem;
+  color: var(--text-dim);
+}
+
+.stat__u {
+  font-size: 0.6rem;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+  text-align: center;
+}
+
+/* ── States ──────────────────────────────────────── */
+.state {
+  display: flex;
+  justify-content: center;
+  padding: 3rem;
+}
+
+::ng-deep .state mat-spinner circle { stroke: var(--c-k) !important; }
+
+.empty {
+  margin: 0;
+  padding: 1.25rem;
+  text-align: center;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  background: var(--raised);
+  border: 1px dashed var(--border-mid);
+  border-radius: 10px;
+}

--- a/src/app/nutrition/components/nutrition-dashboard/nutrition-dashboard.component.html
+++ b/src/app/nutrition/components/nutrition-dashboard/nutrition-dashboard.component.html
@@ -1,0 +1,113 @@
+<div class="dash">
+
+  @if (loading) {
+    <div class="state">
+      <mat-spinner diameter="32" />
+    </div>
+  } @else {
+
+    <!-- ── Weight trend ───────────────────────────── -->
+    <section class="panel">
+      <header class="panel__head">
+        <span class="panel__dot panel__dot--w"></span>
+        <span class="panel__label">GEWICHTSVERLAUF</span>
+        @if (latestWeight !== null) {
+          <span class="panel__stat">
+            {{ latestWeight | number:'1.1-1':'de' }} kg
+            @if (weightDelta !== null) {
+              <span class="delta" [class.delta--up]="weightDelta > 0" [class.delta--down]="weightDelta < 0">
+                {{ weightDelta > 0 ? '+' : '' }}{{ weightDelta | number:'1.1-1':'de' }}
+              </span>
+            }
+          </span>
+        }
+      </header>
+
+      @if (hasWeight) {
+        <div class="chart">
+          <svg [attr.viewBox]="'0 0 ' + vbW + ' ' + vbH" preserveAspectRatio="none" class="svg">
+            <polygon class="area area--w" [attr.points]="weightArea" />
+            <polyline class="line line--w" [attr.points]="weightLine" />
+            @for (p of weightPoints; track p.label + p.x) {
+              <circle class="dot dot--w" [attr.cx]="p.x" [attr.cy]="p.y" r="2.4" />
+            }
+          </svg>
+        </div>
+        <div class="axis">
+          <span>{{ weightPoints[0].label }}</span>
+          <span>{{ weightPoints[weightPoints.length - 1].label }}</span>
+        </div>
+      } @else {
+        <p class="empty">Noch keine Gewichtseinträge.</p>
+      }
+    </section>
+
+    <!-- ── Intake vs. target ──────────────────────── -->
+    <section class="panel">
+      <header class="panel__head">
+        <span class="panel__dot panel__dot--k"></span>
+        <span class="panel__label">KALORIEN ({{ intakeDays.length }} TAGE)</span>
+        @if (intakeTargetKcal !== null) {
+          <span class="panel__stat">Ziel {{ intakeTargetKcal | number:'1.0-0':'de' }} kcal</span>
+        }
+      </header>
+
+      @if (hasIntake) {
+        <div class="chart">
+          <svg [attr.viewBox]="'0 0 ' + vbW + ' ' + vbH" class="svg">
+            @for (d of intakeDays; track d.date) {
+              <rect class="bar bar--{{ d.state }}"
+                    [attr.x]="d.x" [attr.y]="d.y" [attr.width]="barWidth" [attr.height]="d.h" rx="1.5" />
+            }
+            @if (intakeTargetY !== null) {
+              <line class="target-line"
+                    [attr.x1]="axisX1" [attr.x2]="axisX2" [attr.y1]="intakeTargetY" [attr.y2]="intakeTargetY" />
+            }
+          </svg>
+        </div>
+        <div class="axis">
+          <span>{{ intakeDays[0].label }}</span>
+          <span>{{ intakeDays[intakeDays.length - 1].label }}</span>
+        </div>
+        <p class="legend">
+          <span class="legend__item legend__item--within">im Ziel</span>
+          <span class="legend__item legend__item--under">darunter</span>
+          <span class="legend__item legend__item--over">darüber</span>
+        </p>
+      } @else {
+        <p class="empty">Noch keine erfassten Tage.</p>
+      }
+    </section>
+
+    <!-- ── Adherence summary ──────────────────────── -->
+    <section class="panel">
+      <header class="panel__head">
+        <span class="panel__dot panel__dot--a"></span>
+        <span class="panel__label">BILANZ</span>
+      </header>
+
+      <div class="stats">
+        <div class="stat">
+          <span class="stat__v">
+            @if (avgKcal !== null) {
+              {{ avgKcal | number:'1.0-0':'de' }}
+            } @else {
+              –
+            }
+          </span>
+          <span class="stat__u">Ø kcal / Tag</span>
+        </div>
+        <div class="stat">
+          <span class="stat__v">{{ daysOnTarget }}<span class="stat__sub">/{{ daysWithData }}</span></span>
+          <span class="stat__u">Tage im Ziel</span>
+        </div>
+        <div class="stat">
+          <span class="stat__v">{{ daysWithData }}</span>
+          <span class="stat__u">Tage erfasst</span>
+        </div>
+      </div>
+    </section>
+
+  }
+
+</div>

--- a/src/app/nutrition/components/nutrition-dashboard/nutrition-dashboard.component.ts
+++ b/src/app/nutrition/components/nutrition-dashboard/nutrition-dashboard.component.ts
@@ -1,0 +1,200 @@
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit} from '@angular/core';
+import {DecimalPipe} from '@angular/common';
+import {MatProgressSpinner} from '@angular/material/progress-spinner';
+import {catchError, forkJoin, of} from 'rxjs';
+import {format, parseISO, subDays} from 'date-fns';
+import {NutritionService} from '../../services/nutrition.service';
+import {DaySummary, WeightEntry} from '../../models/nutrition.model';
+
+/** SVG view-box geometry shared by the inline charts. */
+const VB_W = 320;
+const VB_H = 140;
+const PAD_L = 6;
+const PAD_R = 6;
+const PAD_T = 12;
+const PAD_B = 20;
+
+/** Days of intake history to load for the trend chart. */
+const INTAKE_DAYS = 14;
+
+/** A day's consumed kcal against its target, for the intake chart. */
+interface IntakeDay {
+  date: string;
+  label: string;
+  consumed: number;
+  target: number;
+  x: number;
+  /** Bar top (consumed) and bar height in view-box units. */
+  y: number;
+  h: number;
+  /** within | under | over target */
+  state: 'within' | 'under' | 'over';
+}
+
+interface WeightPoint {
+  x: number;
+  y: number;
+  weightKg: number;
+  label: string;
+}
+
+@Component({
+  selector: 'app-nutrition-dashboard',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [DecimalPipe, MatProgressSpinner],
+  templateUrl: './nutrition-dashboard.component.html',
+  styleUrl: './nutrition-dashboard.component.css'
+})
+export class NutritionDashboardComponent implements OnInit {
+
+  readonly vbW = VB_W;
+  readonly vbH = VB_H;
+  readonly axisX1 = PAD_L;
+  readonly axisX2 = VB_W - PAD_R;
+  readonly baselineY = VB_H - PAD_B;
+
+  loading = true;
+
+  // ── Weight chart ──
+  weightPoints: WeightPoint[] = [];
+  weightLine = '';
+  weightArea = '';
+  weightMin = 0;
+  weightMax = 0;
+  latestWeight: number | null = null;
+  weightDelta: number | null = null;
+
+  // ── Intake chart ──
+  intakeDays: IntakeDay[] = [];
+  intakeTargetY: number | null = null;
+  intakeTargetKcal: number | null = null;
+  intakeMax = 0;
+  barWidth = 0;
+
+  // ── Adherence ──
+  avgKcal: number | null = null;
+  daysOnTarget = 0;
+  daysWithData = 0;
+
+  private nutritionService = inject(NutritionService);
+  private cdr = inject(ChangeDetectorRef);
+
+  ngOnInit(): void {
+    const today = new Date();
+    const dates = Array.from({length: INTAKE_DAYS}, (_, i) =>
+      format(subDays(today, INTAKE_DAYS - 1 - i), 'yyyy-MM-dd'));
+
+    forkJoin({
+      weights: this.nutritionService.getWeightEntries().pipe(catchError(() => of([] as WeightEntry[]))),
+      // A day without targets/entries 4xx's; treat it as "no data" rather than failing all.
+      days: forkJoin(dates.map(d =>
+        this.nutritionService.getDaySummary(d).pipe(catchError(() => of(null)))))
+    }).subscribe(({weights, days}) => {
+      this.buildWeightChart(weights);
+      this.buildIntakeChart(dates, days);
+      this.loading = false;
+      this.cdr.markForCheck();
+    });
+  }
+
+  get hasWeight(): boolean {
+    return this.weightPoints.length > 0;
+  }
+
+  get hasIntake(): boolean {
+    return this.intakeDays.length > 0;
+  }
+
+  // ── Weight ─────────────────────────────────────────
+  private buildWeightChart(entries: WeightEntry[]): void {
+    const sorted = [...entries].sort((a, b) => a.entryDate.localeCompare(b.entryDate));
+    if (sorted.length === 0) return;
+
+    const values = sorted.map(e => e.weightKg);
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    // Pad the range so a flat line doesn't sit on the axis.
+    const span = max - min || 1;
+    this.weightMin = min - span * 0.1;
+    this.weightMax = max + span * 0.1;
+
+    const innerW = VB_W - PAD_L - PAD_R;
+    const innerH = VB_H - PAD_T - PAD_B;
+    const stepX = sorted.length > 1 ? innerW / (sorted.length - 1) : 0;
+
+    this.weightPoints = sorted.map((e, i) => {
+      const x = PAD_L + (sorted.length > 1 ? stepX * i : innerW / 2);
+      const t = (e.weightKg - this.weightMin) / (this.weightMax - this.weightMin);
+      const y = PAD_T + innerH * (1 - t);
+      return {x, y, weightKg: e.weightKg, label: format(parseISO(e.entryDate), 'dd.MM.')};
+    });
+
+    this.weightLine = this.weightPoints.map(p => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');
+    const first = this.weightPoints[0];
+    const last = this.weightPoints[this.weightPoints.length - 1];
+    this.weightArea =
+      `${first.x.toFixed(1)},${(VB_H - PAD_B).toFixed(1)} ${this.weightLine} ${last.x.toFixed(1)},${(VB_H - PAD_B).toFixed(1)}`;
+
+    this.latestWeight = last.weightKg;
+    this.weightDelta = sorted.length > 1 ? last.weightKg - first.weightKg : null;
+  }
+
+  // ── Intake ─────────────────────────────────────────
+  private buildIntakeChart(dates: string[], days: (DaySummary | null)[]): void {
+    const target = days.find(d => d?.targets)?.targets.targetKcal ?? null;
+    this.intakeTargetKcal = target;
+
+    const consumed = days.map(d => d?.totals.kcal ?? 0);
+    const maxConsumed = Math.max(0, ...consumed);
+    this.intakeMax = Math.max(maxConsumed, (target ?? 0) * 1.1, 1);
+
+    const innerW = VB_W - PAD_L - PAD_R;
+    const innerH = VB_H - PAD_T - PAD_B;
+    const slot = innerW / dates.length;
+    this.barWidth = slot * 0.6;
+
+    this.intakeDays = dates.map((date, i) => {
+      const summary = days[i];
+      const kcal = summary?.totals.kcal ?? 0;
+      const dayTarget = summary?.targets.targetKcal ?? target ?? 0;
+      const h = innerH * (kcal / this.intakeMax);
+      const x = PAD_L + slot * i + (slot - this.barWidth) / 2;
+      const y = PAD_T + innerH - h;
+      return {
+        date,
+        label: format(parseISO(date), 'dd.MM.'),
+        consumed: kcal,
+        target: dayTarget,
+        x,
+        y,
+        h,
+        state: this.targetState(kcal, dayTarget)
+      };
+    });
+
+    if (target != null) {
+      this.intakeTargetY = PAD_T + innerH * (1 - target / this.intakeMax);
+    }
+
+    this.buildAdherence(target);
+  }
+
+  private targetState(kcal: number, target: number): 'within' | 'under' | 'over' {
+    if (!target || kcal === 0) return 'under';
+    if (kcal > target * 1.1) return 'over';
+    if (kcal < target * 0.9) return 'under';
+    return 'within';
+  }
+
+  private buildAdherence(target: number | null): void {
+    const withData = this.intakeDays.filter(d => d.consumed > 0);
+    this.daysWithData = withData.length;
+    if (withData.length === 0) {
+      this.avgKcal = null;
+      this.daysOnTarget = 0;
+      return;
+    }
+    this.avgKcal = withData.reduce((sum, d) => sum + d.consumed, 0) / withData.length;
+    this.daysOnTarget = target == null ? 0 : withData.filter(d => d.state === 'within').length;
+  }
+}

--- a/src/app/nutrition/components/nutrition-home/nutrition-home.component.css
+++ b/src/app/nutrition/components/nutrition-home/nutrition-home.component.css
@@ -8,6 +8,7 @@
   --text-muted:  #7a93b0;
   --text-dim:    #3d5470;
 
+  --c-b:  #f472b6;  --cg-b: rgba(244, 114, 182, 0.18);
   --c-d:  #fbbf24;  --cg-d: rgba(251, 191,  36, 0.18);
   --c-c:  #4da6ff;  --cg-c: rgba(77,  166, 255, 0.18);
   --c-w:  #a3e635;  --cg-w: rgba(163, 230,  53, 0.18);
@@ -80,6 +81,7 @@
 
 .navcard:hover::before { opacity: 1; }
 
+.navcard--b { --cc: var(--c-b); --cc-glow: var(--cg-b); }
 .navcard--d { --cc: var(--c-d); --cc-glow: var(--cg-d); }
 .navcard--c { --cc: var(--c-c); --cc-glow: var(--cg-c); }
 .navcard--w { --cc: var(--c-w); --cc-glow: var(--cg-w); }
@@ -144,3 +146,4 @@
 .navcard:nth-child(3) { animation-delay: 0.19s; }
 .navcard:nth-child(4) { animation-delay: 0.26s; }
 .navcard:nth-child(5) { animation-delay: 0.33s; }
+.navcard:nth-child(6) { animation-delay: 0.40s; }

--- a/src/app/nutrition/components/nutrition-home/nutrition-home.component.html
+++ b/src/app/nutrition/components/nutrition-home/nutrition-home.component.html
@@ -3,6 +3,13 @@
   <app-targets-card />
 
   <div class="navgrid">
+    <a class="navcard navcard--b" routerLink="/nutrition/dashboard">
+      <div class="navcard__mark">◔</div>
+      <h2 class="navcard__title">Dashboard</h2>
+      <p class="navcard__sub">Trends & Bilanz</p>
+      <span class="navcard__arrow" aria-hidden="true">↗</span>
+    </a>
+
     <a class="navcard navcard--d" routerLink="/nutrition/day">
       <div class="navcard__mark">▤</div>
       <h2 class="navcard__title">Tagebuch</h2>

--- a/src/app/nutrition/components/nutrition-layout/nutrition-layout.component.html
+++ b/src/app/nutrition/components/nutrition-layout/nutrition-layout.component.html
@@ -11,6 +11,9 @@
         <button mat-menu-item routerLink="/nutrition">
           <span>Home</span>
         </button>
+        <button mat-menu-item routerLink="/nutrition/dashboard">
+          <span>Dashboard</span>
+        </button>
         <button mat-menu-item routerLink="/nutrition/day">
           <span>Tagebuch</span>
         </button>


### PR DESCRIPTION
## Summary

Implements **#144** — a dashboard for the nutrition module at `/nutrition/dashboard`.

- **Weight-over-time** line chart from `/nutrition/weight` (with latest weight + delta).
- **Intake-vs-target** chart for the last 14 days: a bar per day coloured by within / under / over target, with a dashed target reference line.
- **Adherence summary**: average kcal per logged day, days on target, and days logged.

## Implementation notes

- **Charting:** rather than add a heavy dependency, the charts are hand-rolled **inline SVG**. This keeps the bundle lean, avoids an Angular 20 peer-dependency conflict, and matches the module's custom dark theme. Easy to swap for `ngx-charts`/Chart.js later if richer interactivity is wanted.
- **Aggregation:** per-day intake is gathered client-side via `forkJoin` over the existing `GET /nutrition/days/{date}` (last 14 days), so **no new backend endpoint is required**. Days without targets/entries are tolerated with a per-request `catchError`.

## Verification

- `npm run build` ✅ (no warnings)
- `npm run lint` — no new errors in the added files.

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)