### PR TITLE
fix(nutrition): handle null targets/remaining in day view

### DIFF
--- a/src/app/nutrition/components/nutrition-dashboard/nutrition-dashboard.component.ts
+++ b/src/app/nutrition/components/nutrition-dashboard/nutrition-dashboard.component.ts
@@ -141,7 +141,7 @@ export class NutritionDashboardComponent implements OnInit {
 
   // ── Intake ─────────────────────────────────────────
   private buildIntakeChart(dates: string[], days: (DaySummary | null)[]): void {
-    const target = days.find(d => d?.targets)?.targets.targetKcal ?? null;
+    const target = days.find(d => d?.targets)?.targets?.targetKcal ?? null;
     this.intakeTargetKcal = target;
 
     const consumed = days.map(d => d?.totals.kcal ?? 0);
@@ -156,7 +156,7 @@ export class NutritionDashboardComponent implements OnInit {
     this.intakeDays = dates.map((date, i) => {
       const summary = days[i];
       const kcal = summary?.totals.kcal ?? 0;
-      const dayTarget = summary?.targets.targetKcal ?? target ?? 0;
+      const dayTarget = summary?.targets?.targetKcal ?? target ?? 0;
       const h = innerH * (kcal / this.intakeMax);
       const x = PAD_L + slot * i + (slot - this.barWidth) / 2;
       const y = PAD_T + innerH - h;

--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.html
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.html
@@ -29,6 +29,7 @@
     <p class="empty">{{ unavailable }}</p>
   } @else if (summary) {
 
+    @if (hasTargets) {
     <section class="panel summary">
       <header class="panel__head">
         <span class="panel__dot panel__dot--n"></span>
@@ -58,6 +59,9 @@
         }
       </div>
     </section>
+    } @else {
+      <p class="empty">Tagesziele nicht verfügbar. Bitte zuerst ein Profil und einen Gewichtseintrag erfassen.</p>
+    }
 
     @if (hasEntries) {
       @for (group of groups; track group.type) {

--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
@@ -125,8 +125,12 @@ export class NutritionDayComponent implements OnInit {
     return (this.summary?.entries.length ?? 0) > 0;
   }
 
+  get hasTargets(): boolean {
+    return !!this.summary?.targets && !!this.summary?.remaining;
+  }
+
   get bars(): MacroBar[] {
-    if (!this.summary) return [];
+    if (!this.summary?.targets || !this.summary?.remaining) return [];
     const {totals, targets, remaining} = this.summary;
     return [
       this.bar('Kalorien', 'kcal', totals.kcal, targets.targetKcal, remaining.kcal, 'kcal'),

--- a/src/app/nutrition/models/nutrition.model.ts
+++ b/src/app/nutrition/models/nutrition.model.ts
@@ -146,8 +146,10 @@ export interface DaySummary {
   date: string;
   entries: MealEntry[];
   totals: Macros;
-  targets: Targets;
-  remaining: Macros;
+  /** Null when no profile/weight exists yet (backend returns 200 with null). */
+  targets: Targets | null;
+  /** Null when no profile/weight exists yet (backend returns 200 with null). */
+  remaining: Macros | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
`GET /nutrition/days/{date}` returns **200 OK with `targets: null` and `remaining: null`** when no profile/weight exists, but the frontend typed them as non-null and `NutritionDayComponent.bars` dereferenced them unconditionally — crashing the Tagebuch tab as soon as a day loaded without a profile/weight.

## Changes
- `DaySummary.targets` / `remaining` are now `Targets | null` / `Macros | null`.
- `bars` returns `[]` when targets/remaining are missing; new `hasTargets` getter.
- Template guards the ÜBERSICHT section on `hasTargets` and renders a "Tagesziele nicht verfügbar" empty state otherwise.
- Fixed a latent unguarded `targets` access in the dashboard's intake chart surfaced by the nullable typing.

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)