### PR TITLE
fix(nutrition): align TargetBasis with backend enum strings

### DIFF
--- a/src/app/nutrition/components/targets-card/targets-card.component.html
+++ b/src/app/nutrition/components/targets-card/targets-card.component.html
@@ -46,10 +46,10 @@
       </div>
     </div>
 
-    <div class="basis" [class.basis--manual]="targets.basis === 'MANUAL'">
-      <mat-icon>{{ targets.basis === 'MANUAL' ? 'tune' : 'functions' }}</mat-icon>
+    <div class="basis" [class.basis--manual]="targets.basis === 'BASAL_KCAL'">
+      <mat-icon>{{ targets.basis === 'BASAL_KCAL' ? 'tune' : 'functions' }}</mat-icon>
       <span>
-        {{ targets.basis === 'MANUAL'
+        {{ targets.basis === 'BASAL_KCAL'
           ? 'BMR aus manuellem Wert'
           : 'BMR aus Mifflin–St-Jeor-Formel' }}
       </span>

--- a/src/app/nutrition/models/nutrition.model.ts
+++ b/src/app/nutrition/models/nutrition.model.ts
@@ -11,8 +11,11 @@ export type Goal = 'CUT' | 'MAINTAIN' | 'BULK';
 
 export type MealType = 'BREAKFAST' | 'LUNCH' | 'DINNER' | 'SNACK';
 
-/** Whether the BMR used for the targets came from the manual value or the formula. */
-export type TargetBasis = 'MANUAL' | 'FORMULA';
+/**
+ * Whether the BMR used for the targets came from a manual basal value
+ * (`BASAL_KCAL`) or the Mifflin–St Jeor formula (`MIFFLIN_ST_JEOR`).
+ */
+export type TargetBasis = 'BASAL_KCAL' | 'MIFFLIN_ST_JEOR';
 
 export interface Profile {
   id: string;


### PR DESCRIPTION
## Summary
The backend emits `basis` values `BASAL_KCAL` / `MIFFLIN_ST_JEOR`, but the frontend `TargetBasis` type and the targets-card template expected `MANUAL` / `FORMULA`. As a result the manual-BMR indicator never triggered — the card always showed "BMR aus Mifflin–St-Jeor-Formel" with the `functions` icon and `basis--manual` styling never applied, even when a manual `basalKcal` was set.

## Changes
- `TargetBasis` is now `'BASAL_KCAL' | 'MIFFLIN_ST_JEOR'`.
- Targets-card template compares against `BASAL_KCAL` for the manual case.

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)