### PR TITLE
feat(nutrition): send optional portion hint with meal estimate

### DIFF
--- a/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.html
+++ b/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.html
@@ -17,6 +17,13 @@
                 placeholder="z. B. Schnitzel mit Pommes und Salat, großer Teller"></textarea>
     </mat-form-field>
 
+    <mat-form-field appearance="outline" class="field-full">
+      <mat-label>Portionsgröße (optional)</mat-label>
+      <input matInput [formControl]="portionHint"
+             placeholder="z. B. großer Teller, ca. 350 g" />
+      <mat-hint>Hilft der KI, die Menge besser einzuschätzen.</mat-hint>
+    </mat-form-field>
+
     <button mat-flat-button type="button" class="btn-estimate"
             [disabled]="description.invalid || estimating" (click)="estimate()">
       @if (estimating) {

--- a/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.ts
+++ b/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.ts
@@ -1,6 +1,6 @@
 import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit} from '@angular/core';
 import {FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
-import {MatFormField, MatLabel} from '@angular/material/form-field';
+import {MatFormField, MatHint, MatLabel} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
 import {MatSelect} from '@angular/material/select';
 import {MatOption} from '@angular/material/core';
@@ -27,6 +27,7 @@ const MEAL_TYPES: { value: MealType; label: string }[] = [
     ReactiveFormsModule,
     MatFormField,
     MatLabel,
+    MatHint,
     MatInput,
     MatSelect,
     MatOption,
@@ -45,6 +46,8 @@ export class NutritionCanteenComponent implements OnInit {
   readonly mealTypes = MEAL_TYPES;
 
   description = new FormControl('', {nonNullable: true, validators: Validators.required});
+  /** Optional hint on portion size to sharpen the estimate. */
+  portionHint = new FormControl('', {nonNullable: true});
   mealType = new FormControl<MealType>('LUNCH', {nonNullable: true});
   date = new FormControl<Date>(new Date(), {nonNullable: true});
 
@@ -74,7 +77,8 @@ export class NutritionCanteenComponent implements OnInit {
     this.estimating = true;
     this.cdr.markForCheck();
 
-    this.nutritionService.estimateMeal(this.description.value.trim()).subscribe({
+    const hint = this.portionHint.value.trim();
+    this.nutritionService.estimateMeal(this.description.value.trim(), hint || undefined).subscribe({
       next: (estimate: MealEstimate) => {
         this.applyEstimate(estimate);
         this.estimating = false;
@@ -132,6 +136,7 @@ export class NutritionCanteenComponent implements OnInit {
 
   private reset(): void {
     this.description.reset('');
+    this.portionHint.reset('');
     this.assumptions = '';
     this.hasEstimate = false;
     this.valuesForm.reset({kcal: 0, proteinG: 0, carbsG: 0, fatG: 0});

--- a/src/app/nutrition/services/nutrition.service.ts
+++ b/src/app/nutrition/services/nutrition.service.ts
@@ -116,8 +116,15 @@ export class NutritionService {
     return this.http.delete<void>(`${this.host}/entries/${id}`);
   }
 
-  /** Estimate macros for a free-text meal description via Claude. */
-  estimateMeal(description: string): Observable<MealEstimate> {
-    return this.http.post<MealEstimate>(`${this.host}/estimate`, {description});
+  /**
+   * Estimate macros for a free-text meal description via Claude. An optional
+   * portion hint (e.g. "großer Teller", "ca. 350 g") improves accuracy.
+   */
+  estimateMeal(description: string, portionHint?: string): Observable<MealEstimate> {
+    const body: { description: string; portionHint?: string } = {description};
+    if (portionHint) {
+      body.portionHint = portionHint;
+    }
+    return this.http.post<MealEstimate>(`${this.host}/estimate`, body);
   }
 }


### PR DESCRIPTION
## Summary
The backend `POST /nutrition/estimate` accepts an optional `portionHint` to improve estimate accuracy, but the frontend never sent it and the canteen UI had no field for it — a dead capability on the client.

## Changes
- `estimateMeal(description, portionHint?)` now includes `portionHint` in the request body when provided.
- Added an optional "Portionsgröße" input to `NutritionCanteenComponent`, passed through on estimate and cleared on reset.

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)