### PR TITLE
fix(nutrition): type Profile/WeightEntry id as number

### DIFF
--- a/src/app/nutrition/models/nutrition.model.ts
+++ b/src/app/nutrition/models/nutrition.model.ts
@@ -18,7 +18,7 @@ export type MealType = 'BREAKFAST' | 'LUNCH' | 'DINNER' | 'SNACK';
 export type TargetBasis = 'BASAL_KCAL' | 'MIFFLIN_ST_JEOR';
 
 export interface Profile {
-  id: string;
+  id: number;
   sex: Sex;
   birthDate: string;
   heightCm: number;
@@ -35,7 +35,7 @@ export interface Profile {
 export type ProfileInput = Omit<Profile, 'id'>;
 
 export interface WeightEntry {
-  id: string;
+  id: number;
   entryDate: string;
   weightKg: number;
 }

--- a/src/app/nutrition/services/nutrition.service.ts
+++ b/src/app/nutrition/services/nutrition.service.ts
@@ -54,11 +54,11 @@ export class NutritionService {
     return this.http.post<WeightEntry>(`${this.host}/weight`, entry);
   }
 
-  updateWeightEntry(id: string, entry: WeightEntryInput): Observable<WeightEntry> {
+  updateWeightEntry(id: number, entry: WeightEntryInput): Observable<WeightEntry> {
     return this.http.put<WeightEntry>(`${this.host}/weight/${id}`, entry);
   }
 
-  deleteWeightEntry(id: string): Observable<void> {
+  deleteWeightEntry(id: number): Observable<void> {
     return this.http.delete<void>(`${this.host}/weight/${id}`);
   }
 


### PR DESCRIPTION
## Summary
`Profile.id` and `WeightEntry.id` were typed `string`, but the backend uses `Long` (serialized as a JSON number). It worked only because IDs are string-interpolated into URLs; the types were misleading and could mask bugs (e.g. strict equality). (`Food`/`MealEntry` correctly use UUID strings and are unchanged.)

## Changes
- `Profile.id` and `WeightEntry.id` are now `number`.
- `updateWeightEntry` / `deleteWeightEntry` signatures take `id: number`.

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)