### PR TITLE
fix(nutrition): apply takeUntilDestroyed to valueChanges subscriptions

### DIFF
--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
@@ -1,4 +1,5 @@
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, inject, OnInit} from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {DecimalPipe} from '@angular/common';
 import {HttpErrorResponse} from '@angular/common/http';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
@@ -76,9 +77,10 @@ export class NutritionDayComponent implements OnInit {
   private dialog = inject(MatDialog);
   private snackBar = inject(MatSnackBar);
   private cdr = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
 
   ngOnInit(): void {
-    this.date.valueChanges.subscribe(() => this.load());
+    this.date.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.load());
     this.load();
   }
 

--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.ts
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.ts
@@ -1,4 +1,5 @@
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit, ViewChild} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, inject, OnInit, ViewChild} from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {DecimalPipe} from '@angular/common';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
 import {
@@ -73,13 +74,15 @@ export class NutritionFoodsComponent implements OnInit {
   private dialog = inject(MatDialog);
   private snackBar = inject(MatSnackBar);
   private cdr = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
 
   ngOnInit(): void {
     this.search.valueChanges.pipe(
       startWith(this.search.value),
       debounceTime(300),
       distinctUntilChanged(),
-      switchMap(query => this.nutritionService.searchFoods(query.trim()))
+      switchMap(query => this.nutritionService.searchFoods(query.trim())),
+      takeUntilDestroyed(this.destroyRef)
     ).subscribe(foods => {
       this.foods.data = foods;
       this.cdr.markForCheck();

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.ts
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.ts
@@ -1,4 +1,5 @@
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, inject, OnInit} from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {DecimalPipe} from '@angular/common';
 import {FormControl, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
 import {MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
@@ -53,6 +54,7 @@ export class AddDayEntryDialogComponent implements OnInit {
   private nutritionService = inject(NutritionService);
   private dialogRef = inject(MatDialogRef<AddDayEntryDialogComponent>);
   private cdr = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
   private data = inject<AddDayEntryDialogData>(MAT_DIALOG_DATA, {optional: true});
 
   readonly mealTypes = MEAL_TYPES;
@@ -71,7 +73,8 @@ export class AddDayEntryDialogComponent implements OnInit {
       // Once a food is picked the control holds a Food object; skip searching then.
       debounceTime(300),
       distinctUntilChanged(),
-      switchMap(value => this.nutritionService.searchFoods(typeof value === 'string' ? value.trim() : ''))
+      switchMap(value => this.nutritionService.searchFoods(typeof value === 'string' ? value.trim() : '')),
+      takeUntilDestroyed(this.destroyRef)
     ).subscribe(foods => {
       this.results = foods;
       this.cdr.markForCheck();


### PR DESCRIPTION
## Summary
- Adds `takeUntilDestroyed(this.destroyRef)` to the long-lived `valueChanges` subscriptions that never complete on their own:
  - `date.valueChanges` in `nutrition-day.component.ts`
  - the foods search pipe in `nutrition-foods.component.ts`
  - the food search autocomplete pipe in `add-day-entry-dialog.component.ts`

Closes #162

## Test plan
- [x] `npm run build` succeeds