### PR TITLE
fix(nutrition): flatten dialog->HTTP subscribes with switchMap

### DIFF
--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
@@ -11,6 +11,7 @@ import {MatIcon} from '@angular/material/icon';
 import {MatProgressSpinner} from '@angular/material/progress-spinner';
 import {MatDialog} from '@angular/material/dialog';
 import {MatSnackBar} from '@angular/material/snack-bar';
+import {EMPTY, switchMap} from 'rxjs';
 import {format} from 'date-fns';
 import {NutritionService} from '../../services/nutrition.service';
 import {DaySummary, FoodEntryInput, MealEntry, MealEntryUpdate, MealType} from '../../models/nutrition.model';
@@ -154,46 +155,46 @@ export class NutritionDayComponent implements OnInit {
   openAddDialog(mealType?: MealType): void {
     const data: AddDayEntryDialogData = {mealType};
     const ref = this.dialog.open(AddDayEntryDialogComponent, {data});
-    ref.afterClosed().subscribe((result: FoodEntryInput | undefined) => {
-      if (!result) return;
-      this.nutritionService.addEntry(this.isoDate, result).subscribe({
-        next: () => {
-          this.load();
-          this.snackBar.open('Eintrag hinzugefügt', 'OK', {duration: 3000});
-        },
-        error: () => this.snackBar.open('Eintrag konnte nicht gespeichert werden', 'Schließen', {duration: 5000})
-      });
+    ref.afterClosed().pipe(
+      switchMap((result: FoodEntryInput | undefined) => result ? this.nutritionService.addEntry(this.isoDate, result) : EMPTY),
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe({
+      next: () => {
+        this.load();
+        this.snackBar.open('Eintrag hinzugefügt', 'OK', {duration: 3000});
+      },
+      error: () => this.snackBar.open('Eintrag konnte nicht gespeichert werden', 'Schließen', {duration: 5000})
     });
   }
 
   openEditDialog(entry: MealEntry): void {
     const ref = this.dialog.open(EntryEditDialogComponent, {data: entry});
-    ref.afterClosed().subscribe((update: MealEntryUpdate | undefined) => {
-      if (!update) return;
-      this.nutritionService.updateEntry(entry.id, update).subscribe({
-        next: () => {
-          this.load();
-          this.snackBar.open('Eintrag aktualisiert', 'OK', {duration: 3000});
-        },
-        error: () => this.snackBar.open('Eintrag konnte nicht aktualisiert werden', 'Schließen', {duration: 5000})
-      });
+    ref.afterClosed().pipe(
+      switchMap((update: MealEntryUpdate | undefined) => update ? this.nutritionService.updateEntry(entry.id, update) : EMPTY),
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe({
+      next: () => {
+        this.load();
+        this.snackBar.open('Eintrag aktualisiert', 'OK', {duration: 3000});
+      },
+      error: () => this.snackBar.open('Eintrag konnte nicht aktualisiert werden', 'Schließen', {duration: 5000})
     });
   }
 
   openDeleteDialog(entry: MealEntry): void {
     const ref = this.dialog.open(EntryDeleteDialogComponent, {data: {label: this.entryName(entry)}});
-    ref.afterClosed().subscribe(result => {
-      if (result !== 'confirmed') return;
-      this.nutritionService.deleteEntry(entry.id).subscribe({
-        next: () => {
-          this.load();
-          this.snackBar.open('Eintrag gelöscht', 'OK', {duration: 3000});
-        },
-        error: err => {
-          const msg = err.status === 404 ? 'Eintrag nicht gefunden' : 'Eintrag konnte nicht gelöscht werden';
-          this.snackBar.open(msg, 'Schließen', {duration: 5000});
-        }
-      });
+    ref.afterClosed().pipe(
+      switchMap(result => result === 'confirmed' ? this.nutritionService.deleteEntry(entry.id) : EMPTY),
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe({
+      next: () => {
+        this.load();
+        this.snackBar.open('Eintrag gelöscht', 'OK', {duration: 3000});
+      },
+      error: err => {
+        const msg = err.status === 404 ? 'Eintrag nicht gefunden' : 'Eintrag konnte nicht gelöscht werden';
+        this.snackBar.open(msg, 'Schließen', {duration: 5000});
+      }
     });
   }
 }

--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.ts
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.ts
@@ -22,7 +22,7 @@ import {MatIcon} from '@angular/material/icon';
 import {MatProgressSpinner} from '@angular/material/progress-spinner';
 import {MatDialog} from '@angular/material/dialog';
 import {MatSnackBar} from '@angular/material/snack-bar';
-import {debounceTime, distinctUntilChanged, startWith, switchMap} from 'rxjs';
+import {debounceTime, distinctUntilChanged, EMPTY, startWith, switchMap} from 'rxjs';
 import {NutritionService} from '../../services/nutrition.service';
 import {Food, FoodDraft, FoodInput} from '../../models/nutrition.model';
 import {FoodEditDialogComponent, FoodEditDialogData} from '../../dialogs/food-edit-dialog/food-edit-dialog.component';
@@ -106,25 +106,25 @@ export class NutritionFoodsComponent implements OnInit {
 
   openDeleteDialog(food: Food): void {
     const ref = this.dialog.open(FoodDeleteDialogComponent, {data: {name: food.name}});
-    ref.afterClosed().subscribe(result => {
-      if (result !== 'confirmed') return;
-      this.nutritionService.deleteFood(food.id).subscribe({
-        next: () => {
-          this.foods.data = this.foods.data.filter(f => f.id !== food.id);
-          this.cdr.markForCheck();
-          this.snackBar.open('Lebensmittel gelöscht', 'OK', {duration: 3000});
-        },
-        error: err => {
-          const msg = err.status === 404 ? 'Lebensmittel nicht gefunden' : 'Lebensmittel konnte nicht gelöscht werden';
-          this.snackBar.open(msg, 'Schließen', {duration: 5000});
-        }
-      });
+    ref.afterClosed().pipe(
+      switchMap(result => result === 'confirmed' ? this.nutritionService.deleteFood(food.id) : EMPTY),
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe({
+      next: () => {
+        this.foods.data = this.foods.data.filter(f => f.id !== food.id);
+        this.cdr.markForCheck();
+        this.snackBar.open('Lebensmittel gelöscht', 'OK', {duration: 3000});
+      },
+      error: err => {
+        const msg = err.status === 404 ? 'Lebensmittel nicht gefunden' : 'Lebensmittel konnte nicht gelöscht werden';
+        this.snackBar.open(msg, 'Schließen', {duration: 5000});
+      }
     });
   }
 
   openBarcodeDialog(): void {
     const ref = this.dialog.open(BarcodeScanDialogComponent);
-    ref.afterClosed().subscribe((draft: FoodDraft | undefined) => {
+    ref.afterClosed().pipe(takeUntilDestroyed(this.destroyRef)).subscribe((draft: FoodDraft | undefined) => {
       if (!draft) return;
       // Same review-and-save flow as the photo scan, tagged as a BARCODE source.
       this.openFoodDialog({food: null, prefill: draft, source: 'BARCODE'}, null);
@@ -161,37 +161,26 @@ export class NutritionFoodsComponent implements OnInit {
 
   private openFoodDialog(data: FoodEditDialogData, existing: Food | null): void {
     const ref = this.dialog.open(FoodEditDialogComponent, {data});
-    ref.afterClosed().subscribe((result: FoodInput | undefined) => {
-      if (!result) return;
-      if (existing) {
-        this.update(existing.id, result);
-      } else {
-        this.create(result);
-      }
-    });
-  }
-
-  private create(input: FoodInput): void {
-    this.nutritionService.createFood(input).subscribe({
-      next: () => {
-        this.reload();
-        this.snackBar.open('Lebensmittel gespeichert', 'OK', {duration: 3000});
-      },
-      error: () => {
-        this.snackBar.open('Lebensmittel konnte nicht gespeichert werden', 'Schließen', {duration: 5000});
-      }
-    });
-  }
-
-  private update(id: string, input: FoodInput): void {
-    this.nutritionService.updateFood(id, input).subscribe({
+    ref.afterClosed().pipe(
+      switchMap((result: FoodInput | undefined) => {
+        if (!result) return EMPTY;
+        return existing ? this.nutritionService.updateFood(existing.id, result) : this.nutritionService.createFood(result);
+      }),
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe({
       next: updated => {
-        this.foods.data = this.foods.data.map(f => f.id === updated.id ? updated : f);
-        this.cdr.markForCheck();
-        this.snackBar.open('Lebensmittel aktualisiert', 'OK', {duration: 3000});
+        if (existing) {
+          this.foods.data = this.foods.data.map(f => f.id === updated.id ? updated : f);
+          this.cdr.markForCheck();
+          this.snackBar.open('Lebensmittel aktualisiert', 'OK', {duration: 3000});
+        } else {
+          this.reload();
+          this.snackBar.open('Lebensmittel gespeichert', 'OK', {duration: 3000});
+        }
       },
       error: () => {
-        this.snackBar.open('Lebensmittel konnte nicht aktualisiert werden', 'Schließen', {duration: 5000});
+        const msg = existing ? 'Lebensmittel konnte nicht aktualisiert werden' : 'Lebensmittel konnte nicht gespeichert werden';
+        this.snackBar.open(msg, 'Schließen', {duration: 5000});
       }
     });
   }

--- a/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.ts
+++ b/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.ts
@@ -1,4 +1,5 @@
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit, ViewChild} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, inject, OnInit, ViewChild} from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {DatePipe, DecimalPipe} from '@angular/common';
 import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
 import {
@@ -21,6 +22,7 @@ import {MatButton, MatIconButton} from '@angular/material/button';
 import {MatIcon} from '@angular/material/icon';
 import {MatDialog} from '@angular/material/dialog';
 import {MatSnackBar} from '@angular/material/snack-bar';
+import {EMPTY, switchMap} from 'rxjs';
 import {format} from 'date-fns';
 import {NutritionService} from '../../services/nutrition.service';
 import {WeightEntry, WeightEntryInput} from '../../models/nutrition.model';
@@ -73,6 +75,7 @@ export class NutritionWeightComponent implements OnInit {
   private dialog = inject(MatDialog);
   private snackBar = inject(MatSnackBar);
   private cdr = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
 
   ngOnInit(): void {
     this.form = this.fb.group({
@@ -116,38 +119,38 @@ export class NutritionWeightComponent implements OnInit {
 
   openEditDialog(entry: WeightEntry): void {
     const ref = this.dialog.open(WeightEditDialogComponent, {data: entry});
-    ref.afterClosed().subscribe((result: WeightEntryInput | undefined) => {
-      if (!result) return;
-      this.nutritionService.updateWeightEntry(entry.id, result).subscribe({
-        next: updated => {
-          this.entries.data = this.sortDesc(this.entries.data.map(e => e.id === updated.id ? updated : e));
-          this.targetsCard?.reload();
-          this.cdr.markForCheck();
-          this.snackBar.open('Gewicht aktualisiert', 'OK', {duration: 3000});
-        },
-        error: () => {
-          this.snackBar.open('Gewicht konnte nicht aktualisiert werden', 'Schließen', {duration: 5000});
-        }
-      });
+    ref.afterClosed().pipe(
+      switchMap((result: WeightEntryInput | undefined) => result ? this.nutritionService.updateWeightEntry(entry.id, result) : EMPTY),
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe({
+      next: updated => {
+        this.entries.data = this.sortDesc(this.entries.data.map(e => e.id === updated.id ? updated : e));
+        this.targetsCard?.reload();
+        this.cdr.markForCheck();
+        this.snackBar.open('Gewicht aktualisiert', 'OK', {duration: 3000});
+      },
+      error: () => {
+        this.snackBar.open('Gewicht konnte nicht aktualisiert werden', 'Schließen', {duration: 5000});
+      }
     });
   }
 
   openDeleteDialog(entry: WeightEntry): void {
     const ref = this.dialog.open(WeightDeleteDialogComponent);
-    ref.afterClosed().subscribe(result => {
-      if (result !== 'confirmed') return;
-      this.nutritionService.deleteWeightEntry(entry.id).subscribe({
-        next: () => {
-          this.entries.data = this.entries.data.filter(e => e.id !== entry.id);
-          this.targetsCard?.reload();
-          this.cdr.markForCheck();
-          this.snackBar.open('Gewicht gelöscht', 'OK', {duration: 3000});
-        },
-        error: err => {
-          const msg = err.status === 404 ? 'Eintrag nicht gefunden' : 'Gewicht konnte nicht gelöscht werden';
-          this.snackBar.open(msg, 'Schließen', {duration: 5000});
-        }
-      });
+    ref.afterClosed().pipe(
+      switchMap(result => result === 'confirmed' ? this.nutritionService.deleteWeightEntry(entry.id) : EMPTY),
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe({
+      next: () => {
+        this.entries.data = this.entries.data.filter(e => e.id !== entry.id);
+        this.targetsCard?.reload();
+        this.cdr.markForCheck();
+        this.snackBar.open('Gewicht gelöscht', 'OK', {duration: 3000});
+      },
+      error: err => {
+        const msg = err.status === 404 ? 'Eintrag nicht gefunden' : 'Gewicht konnte nicht gelöscht werden';
+        this.snackBar.open(msg, 'Schließen', {duration: 5000});
+      }
     });
   }
 }


### PR DESCRIPTION
## Summary
- Replaces nested `afterClosed().subscribe(...)` -> service `.subscribe(...)` patterns with a single `switchMap` pipeline in `nutrition-day`, `nutrition-weight` and `nutrition-foods` components
- Adds `takeUntilDestroyed(this.destroyRef)` to these flattened streams so they can't fire after the component is destroyed

Closes #163

## Test plan
- [x] `npm run build` succeeds