### PR TITLE
fix(nutrition): handle errors when loading weight entries

### DIFF
--- a/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.ts
+++ b/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.ts
@@ -86,9 +86,14 @@ export class NutritionWeightComponent implements OnInit {
   }
 
   private loadEntries(): void {
-    this.nutritionService.getWeightEntries().subscribe(entries => {
-      this.entries.data = this.sortDesc(entries);
-      this.cdr.markForCheck();
+    this.nutritionService.getWeightEntries().subscribe({
+      next: entries => {
+        this.entries.data = this.sortDesc(entries);
+        this.cdr.markForCheck();
+      },
+      error: () => {
+        this.snackBar.open('Gewichtseinträge konnten nicht geladen werden', 'Schließen', {duration: 5000});
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- `getProfile` already had an error branch; `getWeightEntries` in `nutrition-weight.component.ts` did not. Adds an error branch with a snackbar message, mirroring the pattern used elsewhere in the module.

Closes #164

## Test plan
- [x] `npm run build` succeeds