### PR TITLE
perf(nutrition): load dashboard intake history with a single request

### DIFF
--- a/src/app/nutrition/components/nutrition-dashboard/nutrition-dashboard.component.ts
+++ b/src/app/nutrition/components/nutrition-dashboard/nutrition-dashboard.component.ts
@@ -86,9 +86,8 @@ export class NutritionDashboardComponent implements OnInit {
 
     forkJoin({
       weights: this.nutritionService.getWeightEntries().pipe(catchError(() => of([] as WeightEntry[]))),
-      // A day without targets/entries 4xx's; treat it as "no data" rather than failing all.
-      days: forkJoin(dates.map(d =>
-        this.nutritionService.getDaySummary(d).pipe(catchError(() => of(null)))))
+      days: this.nutritionService.getDaySummaries(dates[0], dates[dates.length - 1])
+        .pipe(catchError(() => of([] as DaySummary[])))
     }).subscribe(({weights, days}) => {
       this.buildWeightChart(weights);
       this.buildIntakeChart(dates, days);
@@ -140,11 +139,12 @@ export class NutritionDashboardComponent implements OnInit {
   }
 
   // ── Intake ─────────────────────────────────────────
-  private buildIntakeChart(dates: string[], days: (DaySummary | null)[]): void {
-    const target = days.find(d => d?.targets)?.targets?.targetKcal ?? null;
+  private buildIntakeChart(dates: string[], days: DaySummary[]): void {
+    const byDate = new Map(days.map(d => [d.date, d]));
+    const target = days.find(d => d.targets)?.targets?.targetKcal ?? null;
     this.intakeTargetKcal = target;
 
-    const consumed = days.map(d => d?.totals.kcal ?? 0);
+    const consumed = dates.map(date => byDate.get(date)?.totals.kcal ?? 0);
     const maxConsumed = Math.max(0, ...consumed);
     this.intakeMax = Math.max(maxConsumed, (target ?? 0) * 1.1, 1);
 
@@ -154,7 +154,7 @@ export class NutritionDashboardComponent implements OnInit {
     this.barWidth = slot * 0.6;
 
     this.intakeDays = dates.map((date, i) => {
-      const summary = days[i];
+      const summary = byDate.get(date);
       const kcal = summary?.totals.kcal ?? 0;
       const dayTarget = summary?.targets?.targetKcal ?? target ?? 0;
       const h = innerH * (kcal / this.intakeMax);

--- a/src/app/nutrition/services/nutrition.service.ts
+++ b/src/app/nutrition/services/nutrition.service.ts
@@ -102,6 +102,11 @@ export class NutritionService {
     return this.http.get<DaySummary>(`${this.host}/days/${date}`);
   }
 
+  /** Day summaries for every date in [from, to] (inclusive), in a single request. */
+  getDaySummaries(from: string, to: string): Observable<DaySummary[]> {
+    return this.http.get<DaySummary[]>(`${this.host}/days`, {params: {from, to}});
+  }
+
   /** Log a meal entry on a day, either food-based or ad-hoc. */
   addEntry(date: string, entry: MealEntryInput): Observable<MealEntry> {
     return this.http.post<MealEntry>(`${this.host}/days/${date}/entries`, entry);


### PR DESCRIPTION
## Summary
- `NutritionDashboardComponent` previously fired 14 separate `getDaySummary` requests (plus one for weights) via `forkJoin` to build the intake chart.
- Adds `NutritionService.getDaySummaries(from, to)` calling the new backend `GET /nutrition/days?from=&to=` range endpoint (Marvin1912/backend#160), and uses it in the dashboard to load the 14-day intake history in a single request.
- Behaviour/visuals unchanged — intake chart is built from the same `DaySummary[]` shape, now keyed by date instead of by array index.

Closes #169

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run lint` shows no new issues in changed files