### PR TITLE
feat(nutrition): allow changing meal type when editing an entry

### DIFF
--- a/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.html
+++ b/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.html
@@ -4,6 +4,15 @@
   <p class="entry-label">{{ label }}</p>
 
   <form class="edit-form" [formGroup]="form">
+    <mat-form-field appearance="outline" class="field-full">
+      <mat-label>Mahlzeit</mat-label>
+      <mat-select formControlName="mealType">
+        @for (m of mealTypes; track m.value) {
+          <mat-option [value]="m.value">{{ m.label }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
     @if (isAdHoc) {
       <mat-form-field appearance="outline" class="field-full">
         <mat-label>Beschreibung</mat-label>

--- a/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.ts
+++ b/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.ts
@@ -3,13 +3,23 @@ import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/
 import {MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
 import {MatFormField, MatLabel, MatSuffix} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
+import {MatSelect} from '@angular/material/select';
+import {MatOption} from '@angular/material/core';
 import {MatIcon} from '@angular/material/icon';
 import {MatMiniFabButton} from '@angular/material/button';
-import {MealEntry, MealEntryUpdate} from '../../models/nutrition.model';
+import {MealEntry, MealEntryUpdate, MealType} from '../../models/nutrition.model';
+
+const MEAL_TYPES: { value: MealType; label: string }[] = [
+  {value: 'BREAKFAST', label: 'Frühstück'},
+  {value: 'LUNCH', label: 'Mittagessen'},
+  {value: 'DINNER', label: 'Abendessen'},
+  {value: 'SNACK', label: 'Snack'}
+];
 
 /**
  * Edit a logged entry. Food-based entries edit only the portion (`quantityG`);
  * the backend re-snapshots the macros. Ad-hoc entries edit the values directly.
+ * The meal type can always be changed regardless of entry kind.
  */
 @Component({
   selector: 'app-entry-edit-dialog',
@@ -23,6 +33,8 @@ import {MealEntry, MealEntryUpdate} from '../../models/nutrition.model';
     MatLabel,
     MatSuffix,
     MatInput,
+    MatSelect,
+    MatOption,
     MatIcon,
     MatMiniFabButton
   ],
@@ -35,6 +47,8 @@ export class EntryEditDialogComponent implements OnInit {
   private dialogRef = inject(MatDialogRef<EntryEditDialogComponent>);
   private entry = inject<MealEntry>(MAT_DIALOG_DATA);
 
+  readonly mealTypes = MEAL_TYPES;
+
   form!: FormGroup;
   /** Ad-hoc entries have no food reference and edit their macro values. */
   readonly isAdHoc = this.entry.foodId == null;
@@ -43,6 +57,7 @@ export class EntryEditDialogComponent implements OnInit {
   ngOnInit(): void {
     if (this.isAdHoc) {
       this.form = this.fb.group({
+        mealType: [this.entry.mealType, Validators.required],
         description: [this.entry.description ?? '', Validators.required],
         kcal: [this.entry.kcal, [Validators.required, Validators.min(0)]],
         proteinG: [this.entry.proteinG, [Validators.required, Validators.min(0)]],
@@ -51,6 +66,7 @@ export class EntryEditDialogComponent implements OnInit {
       });
     } else {
       this.form = this.fb.group({
+        mealType: [this.entry.mealType, Validators.required],
         quantityG: [this.entry.quantityG, [Validators.required, Validators.min(0)]]
       });
     }
@@ -61,13 +77,14 @@ export class EntryEditDialogComponent implements OnInit {
     const v = this.form.getRawValue();
     const update: MealEntryUpdate = this.isAdHoc
       ? {
+        mealType: v.mealType,
         description: v.description.trim(),
         kcal: Number(v.kcal),
         proteinG: Number(v.proteinG),
         carbsG: Number(v.carbsG),
         fatG: Number(v.fatG)
       }
-      : {quantityG: Number(v.quantityG)};
+      : {mealType: v.mealType, quantityG: Number(v.quantityG)};
     this.dialogRef.close(update);
   }
 }

--- a/src/app/nutrition/models/nutrition.model.ts
+++ b/src/app/nutrition/models/nutrition.model.ts
@@ -140,10 +140,10 @@ export interface AdHocEntryInput {
 
 export type MealEntryInput = FoodEntryInput | AdHocEntryInput;
 
-/** Edit payload for PUT /entries/{id}: a new portion, or new ad-hoc values. */
+/** Edit payload for PUT /entries/{id}: a new portion, or new ad-hoc values; the meal type can always be changed. */
 export type MealEntryUpdate =
-  | { quantityG: number }
-  | { description: string; kcal: number; proteinG: number; carbsG: number; fatG: number };
+  | { mealType?: MealType; quantityG: number }
+  | { mealType?: MealType; description: string; kcal: number; proteinG: number; carbsG: number; fatG: number };
 
 export interface DaySummary {
   date: string;


### PR DESCRIPTION
## Summary
- `MealEntryUpdate` now has an optional `mealType` field, matching the backend's `UpdateMealEntryRequest`.
- The entry-edit dialog gets a "Mahlzeit" select (same options/labels as the add-entry dialog) for both food-based and ad-hoc entries, pre-filled with the entry's current meal type.
- A logged entry can now be moved between meals (e.g. Lunch → Dinner) without deleting and re-adding it.

Closes #171

## Test plan
- [x] `npm run build` succeeds