### PR TITLE
fix(nutrition): repair day view crash and dead dialog close buttons

### DIFF
--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
@@ -122,7 +122,7 @@ export class NutritionDayComponent implements OnInit {
   }
 
   get hasEntries(): boolean {
-    return (this.summary?.entries.length ?? 0) > 0;
+    return (this.summary?.entries?.length ?? 0) > 0;
   }
 
   get hasTargets(): boolean {

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.css
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.css
@@ -52,6 +52,12 @@
 
 .field-full { width: 100%; }
 
+.search-error {
+  margin: 0 0 0.25rem;
+  font-size: 0.75rem;
+  color: var(--c-e);
+}
+
 /* ── Autocomplete options ────────────────────────── */
 .opt-name { font-weight: 600; }
 

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.html
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.html
@@ -30,6 +30,10 @@
       </mat-autocomplete>
     </mat-form-field>
 
+    @if (searchFailed) {
+      <p class="search-error">Lebensmittel konnten nicht geladen werden.</p>
+    }
+
     <mat-form-field appearance="outline" class="field-full">
       <mat-label>Menge</mat-label>
       <input matInput type="number" step="1" formControlName="quantityG" />

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.ts
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.ts
@@ -2,7 +2,7 @@ import {ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, injec
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {DecimalPipe} from '@angular/common';
 import {FormControl, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
-import {MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MAT_DIALOG_DATA, MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
 import {MatFormField, MatLabel, MatSuffix} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
 import {MatSelect} from '@angular/material/select';
@@ -10,7 +10,7 @@ import {MatOption} from '@angular/material/core';
 import {MatAutocomplete, MatAutocompleteSelectedEvent, MatAutocompleteTrigger} from '@angular/material/autocomplete';
 import {MatIcon} from '@angular/material/icon';
 import {MatMiniFabButton} from '@angular/material/button';
-import {debounceTime, distinctUntilChanged, startWith, switchMap} from 'rxjs';
+import {catchError, debounceTime, distinctUntilChanged, of, startWith, switchMap} from 'rxjs';
 import {NutritionService} from '../../services/nutrition.service';
 import {Food, FoodEntryInput, MealType} from '../../models/nutrition.model';
 
@@ -35,6 +35,7 @@ const MEAL_TYPES: { value: MealType; label: string }[] = [
     MatDialogTitle,
     MatDialogContent,
     MatDialogActions,
+    MatDialogClose,
     MatFormField,
     MatLabel,
     MatSuffix,
@@ -66,6 +67,7 @@ export class AddDayEntryDialogComponent implements OnInit {
 
   results: Food[] = [];
   selected: Food | null = null;
+  searchFailed = false;
 
   ngOnInit(): void {
     this.foodSearch.valueChanges.pipe(
@@ -73,7 +75,15 @@ export class AddDayEntryDialogComponent implements OnInit {
       // Once a food is picked the control holds a Food object; skip searching then.
       debounceTime(300),
       distinctUntilChanged(),
-      switchMap(value => this.nutritionService.searchFoods(typeof value === 'string' ? value.trim() : '')),
+      switchMap(value => {
+        this.searchFailed = false;
+        return this.nutritionService.searchFoods(typeof value === 'string' ? value.trim() : '').pipe(
+          catchError(() => {
+            this.searchFailed = true;
+            return of<Food[]>([]);
+          })
+        );
+      }),
       takeUntilDestroyed(this.destroyRef)
     ).subscribe(foods => {
       this.results = foods;

--- a/src/app/nutrition/dialogs/barcode-scan-dialog/barcode-scan-dialog.component.ts
+++ b/src/app/nutrition/dialogs/barcode-scan-dialog/barcode-scan-dialog.component.ts
@@ -9,7 +9,7 @@ import {
   ViewChild
 } from '@angular/core';
 import {FormControl, ReactiveFormsModule, Validators} from '@angular/forms';
-import {MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
 import {MatFormField, MatLabel} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
 import {MatIcon} from '@angular/material/icon';
@@ -47,6 +47,7 @@ const EAN_PATTERN = /^\d{8,14}$/;
     MatDialogTitle,
     MatDialogContent,
     MatDialogActions,
+    MatDialogClose,
     MatFormField,
     MatLabel,
     MatInput,

--- a/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.ts
+++ b/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.ts
@@ -1,6 +1,6 @@
 import {ChangeDetectionStrategy, Component, inject, OnInit} from '@angular/core';
 import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
-import {MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MAT_DIALOG_DATA, MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
 import {MatFormField, MatLabel, MatSuffix} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
 import {MatSelect} from '@angular/material/select';
@@ -29,6 +29,7 @@ const MEAL_TYPES: { value: MealType; label: string }[] = [
     MatDialogTitle,
     MatDialogContent,
     MatDialogActions,
+    MatDialogClose,
     MatFormField,
     MatLabel,
     MatSuffix,

--- a/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.ts
+++ b/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.ts
@@ -1,6 +1,6 @@
 import {ChangeDetectionStrategy, Component, inject, OnInit} from '@angular/core';
 import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
-import {MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MAT_DIALOG_DATA, MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
 import {MatFormField, MatLabel} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
 import {MatIcon} from '@angular/material/icon';
@@ -29,6 +29,7 @@ export interface FoodEditDialogData {
     MatDialogTitle,
     MatDialogContent,
     MatDialogActions,
+    MatDialogClose,
     MatFormField,
     MatLabel,
     MatInput,

--- a/src/app/nutrition/dialogs/weight-edit-dialog/weight-edit-dialog.component.ts
+++ b/src/app/nutrition/dialogs/weight-edit-dialog/weight-edit-dialog.component.ts
@@ -1,6 +1,6 @@
 import {ChangeDetectionStrategy, Component, inject, OnInit} from '@angular/core';
 import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
-import {MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MAT_DIALOG_DATA, MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
 import {MatFormField, MatLabel, MatSuffix} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
 import {MatDatepicker, MatDatepickerInput, MatDatepickerToggle} from '@angular/material/datepicker';
@@ -17,6 +17,7 @@ import {WeightEntry, WeightEntryInput} from '../../models/nutrition.model';
     MatDialogTitle,
     MatDialogContent,
     MatDialogActions,
+    MatDialogClose,
     MatFormField,
     MatLabel,
     MatSuffix,


### PR DESCRIPTION
## Problem
On `/nutrition/day`, opening **Essen hinzufügen** showed an empty *Lebensmittel* dropdown and a non-working close button. Console showed `TypeError: Cannot read properties of undefined (reading 'length')` in `hasEntries`, firing on **every click** (i.e. every change-detection cycle).

## Root cause
`nutrition-day.component.ts` `hasEntries` did `this.summary?.entries.length` — the `?.` only guarded `summary`, not `entries`. When a day summary has an absent/null `entries` array, `.length` throws. The thrown error aborts change detection, which is why the dialog overlay never updated (empty autocomplete, dead buttons).

Verified out-of-band that the backend and data are fine: `backend.home-lab.com/nutrition/foods` returns the full catalog and CORS is correct — so this was purely a frontend render crash.

## Changes
- **Fix the crash:** guard `hasEntries` with `?.` (mirrors the existing `groups` getter).
- **Dead close buttons:** add the missing `MatDialogClose` import to 5 dialogs (`add-day-entry`, `food-edit`, `barcode-scan`, `weight-edit`, `entry-edit`) — they used `mat-dialog-close` in the template without importing the directive, so the attribute was inert.
- **Harden food search:** add `catchError` + a visible "Lebensmittel konnten nicht geladen werden." message so a failed request no longer surfaces as a silently empty dropdown.

## Verification
- `npm run build` ✅
- `npm run lint` on changed files ✅ (repo-wide pre-existing lint issues untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)