### PR TITLE
feat(nutrition): stage multiple foods in add-entry dialog, save as batch

### DIFF
--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
@@ -153,12 +153,13 @@ export class NutritionDayComponent implements OnInit {
     const data: AddDayEntryDialogData = {mealType};
     const ref = this.dialog.open(AddDayEntryDialogComponent, {data});
     ref.afterClosed().pipe(
-      switchMap((result: FoodEntryInput | undefined) => result ? this.nutritionService.addEntry(this.isoDate, result) : EMPTY),
+      switchMap((result: FoodEntryInput[] | undefined) => result?.length ? this.nutritionService.addEntries(this.isoDate, result) : EMPTY),
       takeUntilDestroyed(this.destroyRef)
     ).subscribe({
-      next: () => {
+      next: created => {
         this.load();
-        this.snackBar.open('Eintrag hinzugefügt', 'OK', {duration: 3000});
+        const message = created.length === 1 ? '1 Eintrag hinzugefügt' : `${created.length} Einträge hinzugefügt`;
+        this.snackBar.open(message, 'OK', {duration: 3000});
       },
       error: () => this.snackBar.open('Eintrag konnte nicht gespeichert werden', 'Schließen', {duration: 5000})
     });

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.css
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.css
@@ -159,6 +159,74 @@
 
 ::ng-deep .mat-mdc-form-field.mat-focused .mat-mdc-floating-label { color: var(--c-g) !important; }
 
+/* ── Staged list ─────────────────────────────────── */
+.btn-add-staged {
+  align-self: flex-start;
+  margin-top: 0.5rem;
+  border-color: var(--border-mid) !important;
+  color: var(--c-n) !important;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.8rem;
+}
+
+.btn-add-staged mat-icon {
+  margin-right: 0.25rem;
+  color: var(--c-n) !important;
+}
+
+.staged-list {
+  margin-top: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.staged-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  background: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.staged-item__name {
+  flex: 1;
+  font-weight: 600;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.staged-item__qty,
+.staged-item__kcal {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.staged-item__remove {
+  width: 32px !important;
+  height: 32px !important;
+  padding: 0 !important;
+  color: var(--c-e) !important;
+}
+
+.staged-item__remove mat-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+  color: var(--c-e) !important;
+}
+
+.macros--total {
+  margin-top: 0.5rem;
+  border-color: var(--border-mid);
+}
+
 /* ── Buttons ─────────────────────────────────────── */
 .btn-confirm {
   background: rgba(45, 212, 191, 0.10) !important;

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.html
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.html
@@ -62,8 +62,50 @@
           </div>
         </div>
       </div>
+
+      <button mat-stroked-button type="button" class="btn-add-staged" [disabled]="!canAdd" (click)="addToStaged()">
+        <mat-icon>playlist_add</mat-icon>
+        Hinzufügen
+      </button>
     }
   </form>
+
+  @if (staged.length > 0) {
+    <div class="staged-list">
+      @for (item of staged; track item; let i = $index) {
+        <div class="staged-item">
+          <span class="staged-item__name">{{ item.food.name }}</span>
+          <span class="staged-item__qty">{{ item.quantityG | number:'1.0-0':'de' }} g</span>
+          <span class="staged-item__kcal">{{ scaledFor(item, item.food.kcalPer100) | number:'1.0-0':'de' }} kcal</span>
+          <button mat-icon-button type="button" class="staged-item__remove" (click)="removeStaged(i)">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </div>
+      }
+    </div>
+
+    <div class="macros macros--total">
+      <span class="macros__label">Gesamt</span>
+      <div class="macros__grid">
+        <div class="macro macro--kcal">
+          <span class="macro__v">{{ totals.kcal | number:'1.0-0':'de' }}</span>
+          <span class="macro__u">kcal</span>
+        </div>
+        <div class="macro macro--p">
+          <span class="macro__v">{{ totals.proteinG | number:'1.0-1':'de' }}</span>
+          <span class="macro__u">P</span>
+        </div>
+        <div class="macro macro--c">
+          <span class="macro__v">{{ totals.carbsG | number:'1.0-1':'de' }}</span>
+          <span class="macro__u">KH</span>
+        </div>
+        <div class="macro macro--f">
+          <span class="macro__v">{{ totals.fatG | number:'1.0-1':'de' }}</span>
+          <span class="macro__u">F</span>
+        </div>
+      </div>
+    </div>
+  }
 </mat-dialog-content>
 
 <mat-dialog-actions align="center">

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.ts
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.ts
@@ -9,14 +9,20 @@ import {MatSelect} from '@angular/material/select';
 import {MatOption} from '@angular/material/core';
 import {MatAutocomplete, MatAutocompleteSelectedEvent, MatAutocompleteTrigger} from '@angular/material/autocomplete';
 import {MatIcon} from '@angular/material/icon';
-import {MatMiniFabButton} from '@angular/material/button';
+import {MatButton, MatIconButton, MatMiniFabButton} from '@angular/material/button';
 import {catchError, debounceTime, distinctUntilChanged, of, startWith, switchMap} from 'rxjs';
 import {NutritionService} from '../../services/nutrition.service';
-import {Food, FoodEntryInput, MealType} from '../../models/nutrition.model';
+import {Food, FoodEntryInput, Macros, MealType} from '../../models/nutrition.model';
 
 /** Optional defaults for the add-entry dialog (e.g. the meal type tapped). */
 export interface AddDayEntryDialogData {
   mealType?: MealType;
+}
+
+/** A food + portion staged for the batch result, before the dialog is confirmed. */
+interface StagedItem {
+  food: Food;
+  quantityG: number;
 }
 
 const MEAL_TYPES: { value: MealType; label: string }[] = [
@@ -45,7 +51,9 @@ const MEAL_TYPES: { value: MealType; label: string }[] = [
     MatAutocomplete,
     MatAutocompleteTrigger,
     MatIcon,
-    MatMiniFabButton
+    MatMiniFabButton,
+    MatIconButton,
+    MatButton
   ],
   templateUrl: './add-day-entry-dialog.component.html',
   styleUrl: './add-day-entry-dialog.component.css'
@@ -68,6 +76,9 @@ export class AddDayEntryDialogComponent implements OnInit {
   results: Food[] = [];
   selected: Food | null = null;
   searchFailed = false;
+
+  /** Foods staged in this dialog session, returned together as one batch on confirm. */
+  staged: StagedItem[] = [];
 
   ngOnInit(): void {
     this.foodSearch.valueChanges.pipe(
@@ -110,17 +121,55 @@ export class AddDayEntryDialogComponent implements OnInit {
     return per100 * qty / 100;
   }
 
-  get canSave(): boolean {
+  /** Macro value for a staged item's portion, scaled from the per-100 g figure. */
+  scaledFor(item: StagedItem, per100: number): number {
+    return per100 * item.quantityG / 100;
+  }
+
+  /** Running macro totals across all staged items. */
+  get totals(): Macros {
+    return this.staged.reduce((acc, item) => ({
+      kcal: acc.kcal + this.scaledFor(item, item.food.kcalPer100),
+      proteinG: acc.proteinG + this.scaledFor(item, item.food.proteinPer100),
+      carbsG: acc.carbsG + this.scaledFor(item, item.food.carbsPer100),
+      fatG: acc.fatG + this.scaledFor(item, item.food.fatPer100)
+    }), {kcal: 0, proteinG: 0, carbsG: 0, fatG: 0});
+  }
+
+  get canAdd(): boolean {
     return !!this.selected && this.quantityG.valid && Number(this.quantityG.value) > 0;
   }
 
+  get canSave(): boolean {
+    return this.staged.length > 0 || this.canAdd;
+  }
+
+  /** Append the currently selected food + quantity to the staged list and reset the inputs. */
+  addToStaged(): void {
+    if (!this.canAdd || !this.selected) return;
+    this.staged.push({food: this.selected, quantityG: Number(this.quantityG.value)});
+    this.selected = null;
+    this.foodSearch.setValue('');
+    this.quantityG.setValue(null);
+    this.cdr.markForCheck();
+  }
+
+  removeStaged(index: number): void {
+    this.staged.splice(index, 1);
+    this.cdr.markForCheck();
+  }
+
   save(): void {
-    if (!this.canSave || !this.selected) return;
-    const result: FoodEntryInput = {
+    const items = [...this.staged];
+    if (this.canAdd && this.selected) {
+      items.push({food: this.selected, quantityG: Number(this.quantityG.value)});
+    }
+    if (items.length === 0) return;
+    const result: FoodEntryInput[] = items.map(item => ({
       mealType: this.mealType.value,
-      foodId: this.selected.id,
-      quantityG: Number(this.quantityG.value)
-    };
+      foodId: item.food.id,
+      quantityG: item.quantityG
+    }));
     this.dialogRef.close(result);
   }
 }

--- a/src/app/nutrition/services/nutrition.service.ts
+++ b/src/app/nutrition/services/nutrition.service.ts
@@ -112,6 +112,11 @@ export class NutritionService {
     return this.http.post<MealEntry>(`${this.host}/days/${date}/entries`, entry);
   }
 
+  /** Log multiple meal entries on a day in a single transaction. */
+  addEntries(date: string, entries: MealEntryInput[]): Observable<MealEntry[]> {
+    return this.http.post<MealEntry[]>(`${this.host}/days/${date}/entries/batch`, {entries});
+  }
+
   /** Edit an entry's portion (food-based) or values (ad-hoc). */
   updateEntry(id: string, update: MealEntryUpdate): Observable<MealEntry> {
     return this.http.put<MealEntry>(`${this.host}/entries/${id}`, update);


### PR DESCRIPTION
## Summary
- `AddDayEntryDialogComponent` now lets users stage multiple foods (food + quantity) with a running macro total before confirming; it returns `FoodEntryInput[]` instead of a single object. One meal type applies to the whole batch (matches the tap-a-meal entry point); per-item meal type is left as a possible follow-up.
- `NutritionService.addEntries()` posts the staged entries to `POST /nutrition/days/{date}/entries/batch` (backend: Marvin1912/backend#168, already merged).
- `NutritionDayComponent.openAddDialog` handles the array result, calls `addEntries`, reloads the day summary, and shows a count-aware snackbar ("1 Eintrag hinzugefügt" / "{n} Einträge hinzugefügt").

Closes #176, closes #177.

## Test plan
- [x] `npm run build` succeeds
- [ ] Manually: open "Essen hinzufügen", stage 2+ foods, verify running total, remove one, confirm → single batch POST, day summary refreshes, snackbar shows correct count
- [ ] Manually: cancel dialog → no request
- [ ] Manually: confirm with just the current (unstaged) selection → still works (single-item batch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)