### PR TITLE
style(home): fix missing fade-in animation for Nutrition card

### DIFF
--- a/src/app/home/home.component.css
+++ b/src/app/home/home.component.css
@@ -367,3 +367,4 @@
 .navcard:nth-child(5)  { animation-delay: 0.33s; }
 .navcard:nth-child(6)  { animation-delay: 0.40s; }
 .navcard:nth-child(7)  { animation-delay: 0.47s; }
+.navcard:nth-child(8)  { animation-delay: 0.54s; }


### PR DESCRIPTION
## Summary
- The home page's nav card entrance animation only defined `animation-delay` rules up to `nth-child(7)`, leaving the 8th card (Nutrition) without a stagger delay so it appeared instantly instead of fading in with the others.
- Added the missing `nth-child(8)` delay rule following the existing 0.07s stagger pattern.

## Test plan
- [x] `npm run build` succeeds
- [ ] Visually confirm the Nutrition card now fades in with the same stagger as the other cards on the home page