### PR TITLE
fix(nutrition): capture meal type per staged item

### DIFF
--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.css
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.css
@@ -200,6 +200,15 @@
   white-space: nowrap;
 }
 
+.staged-item__meal {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
 .staged-item__qty,
 .staged-item__kcal {
   font-family: 'JetBrains Mono', monospace;

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.html
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.html
@@ -75,6 +75,7 @@
       @for (item of staged; track item; let i = $index) {
         <div class="staged-item">
           <span class="staged-item__name">{{ item.food.name }}</span>
+          <span class="staged-item__meal">{{ mealTypeLabel(item.mealType) }}</span>
           <span class="staged-item__qty">{{ item.quantityG | number:'1.0-0':'de' }} g</span>
           <span class="staged-item__kcal">{{ scaledFor(item, item.food.kcalPer100) | number:'1.0-0':'de' }} kcal</span>
           <button mat-icon-button type="button" class="staged-item__remove" (click)="removeStaged(i)">

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.ts
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.ts
@@ -23,6 +23,7 @@ export interface AddDayEntryDialogData {
 interface StagedItem {
   food: Food;
   quantityG: number;
+  mealType: MealType;
 }
 
 const MEAL_TYPES: { value: MealType; label: string }[] = [
@@ -126,6 +127,11 @@ export class AddDayEntryDialogComponent implements OnInit {
     return per100 * item.quantityG / 100;
   }
 
+  /** Human-readable label for a staged item's meal type. */
+  mealTypeLabel(mealType: MealType): string {
+    return this.mealTypes.find(m => m.value === mealType)?.label ?? mealType;
+  }
+
   /** Running macro totals across all staged items. */
   get totals(): Macros {
     return this.staged.reduce((acc, item) => ({
@@ -147,7 +153,7 @@ export class AddDayEntryDialogComponent implements OnInit {
   /** Append the currently selected food + quantity to the staged list and reset the inputs. */
   addToStaged(): void {
     if (!this.canAdd || !this.selected) return;
-    this.staged.push({food: this.selected, quantityG: Number(this.quantityG.value)});
+    this.staged.push({food: this.selected, quantityG: Number(this.quantityG.value), mealType: this.mealType.value});
     this.selected = null;
     this.foodSearch.setValue('');
     this.quantityG.setValue(null);
@@ -162,11 +168,11 @@ export class AddDayEntryDialogComponent implements OnInit {
   save(): void {
     const items = [...this.staged];
     if (this.canAdd && this.selected) {
-      items.push({food: this.selected, quantityG: Number(this.quantityG.value)});
+      items.push({food: this.selected, quantityG: Number(this.quantityG.value), mealType: this.mealType.value});
     }
     if (items.length === 0) return;
     const result: FoodEntryInput[] = items.map(item => ({
-      mealType: this.mealType.value,
+      mealType: item.mealType,
       foodId: item.food.id,
       quantityG: item.quantityG
     }));


### PR DESCRIPTION
## Summary
- Each staged food in the "Essen hinzufügen" dialog now stores the meal type that was selected at the moment it was added to the batch.
- `save()` uses each item's stored meal type when building the `FoodEntryInput[]` payload, instead of reading the dialog-wide `mealType` control value at confirm time.
- The staged list now displays each item's meal type label.

Fixes #180

## Test plan
- [x] `npm run build` succeeds
- [ ] Manual: set meal type to "Mittagessen", stage a food, change dropdown to "Frühstück", stage another food, confirm — verify the first item is saved as "Mittagessen" and the second as "Frühstück"

🤖 Generated with [Claude Code](https://claude.com/claude-code)