### PR TITLE
feat(nutrition): show loading indicator during food search debounce

### DIFF
--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.css
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.css
@@ -121,6 +121,8 @@
 
 ::ng-deep .btn-scan mat-spinner circle { stroke: var(--c-n) !important; }
 
+::ng-deep .field-search mat-spinner circle { stroke: var(--c-g) !important; }
+
 /* ── Table ───────────────────────────────────────── */
 .table-container {
   background: var(--surface);

--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.html
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.html
@@ -9,7 +9,11 @@
     <div class="toolbar">
       <mat-form-field appearance="outline" class="field-search">
         <mat-label>Suchen</mat-label>
-        <mat-icon matPrefix>search</mat-icon>
+        @if (searching) {
+          <mat-spinner matPrefix diameter="18" />
+        } @else {
+          <mat-icon matPrefix>search</mat-icon>
+        }
         <input matInput autocomplete="off" [formControl]="search" />
       </mat-form-field>
 

--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.ts
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.ts
@@ -22,7 +22,7 @@ import {MatIcon} from '@angular/material/icon';
 import {MatProgressSpinner} from '@angular/material/progress-spinner';
 import {MatDialog} from '@angular/material/dialog';
 import {MatSnackBar} from '@angular/material/snack-bar';
-import {debounceTime, distinctUntilChanged, EMPTY, startWith, switchMap} from 'rxjs';
+import {debounceTime, distinctUntilChanged, EMPTY, finalize, startWith, switchMap, tap} from 'rxjs';
 import {NutritionService} from '../../services/nutrition.service';
 import {Food, FoodDraft, FoodInput} from '../../models/nutrition.model';
 import {FoodEditDialogComponent, FoodEditDialogData} from '../../dialogs/food-edit-dialog/food-edit-dialog.component';
@@ -65,6 +65,7 @@ export class NutritionFoodsComponent implements OnInit {
   foods = new MatTableDataSource<Food>();
   columnsToDisplay = ['name', 'kcal', 'protein', 'carbs', 'fat', 'actions'];
   scanning = false;
+  searching = false;
 
   get searchTerm(): string {
     return this.search.value.trim();
@@ -81,7 +82,16 @@ export class NutritionFoodsComponent implements OnInit {
       startWith(this.search.value),
       debounceTime(300),
       distinctUntilChanged(),
-      switchMap(query => this.nutritionService.searchFoods(query.trim())),
+      tap(() => {
+        this.searching = true;
+        this.cdr.markForCheck();
+      }),
+      switchMap(query => this.nutritionService.searchFoods(query.trim()).pipe(
+        finalize(() => {
+          this.searching = false;
+          this.cdr.markForCheck();
+        })
+      )),
       takeUntilDestroyed(this.destroyRef)
     ).subscribe(foods => {
       this.foods.data = foods;

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.css
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.css
@@ -58,6 +58,10 @@
   color: var(--c-e);
 }
 
+::ng-deep .mat-mdc-form-field mat-spinner circle {
+  stroke: var(--c-n) !important;
+}
+
 /* ── Autocomplete options ────────────────────────── */
 .opt-name { font-weight: 600; }
 

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.html
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.html
@@ -13,7 +13,11 @@
 
     <mat-form-field appearance="outline" class="field-full">
       <mat-label>Lebensmittel</mat-label>
-      <mat-icon matSuffix>search</mat-icon>
+      @if (searching) {
+        <mat-spinner matSuffix diameter="18" />
+      } @else {
+        <mat-icon matSuffix>search</mat-icon>
+      }
       <input matInput autocomplete="off" formControlName="foodSearch"
              [matAutocomplete]="auto" placeholder="Suchen…" />
       <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayFood"

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.ts
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.ts
@@ -9,8 +9,9 @@ import {MatSelect} from '@angular/material/select';
 import {MatOption} from '@angular/material/core';
 import {MatAutocomplete, MatAutocompleteSelectedEvent, MatAutocompleteTrigger} from '@angular/material/autocomplete';
 import {MatIcon} from '@angular/material/icon';
+import {MatProgressSpinner} from '@angular/material/progress-spinner';
 import {MatButton, MatIconButton, MatMiniFabButton} from '@angular/material/button';
-import {catchError, debounceTime, distinctUntilChanged, of, startWith, switchMap} from 'rxjs';
+import {catchError, debounceTime, distinctUntilChanged, finalize, of, startWith, switchMap, tap} from 'rxjs';
 import {NutritionService} from '../../services/nutrition.service';
 import {Food, FoodEntryInput, Macros, MealType} from '../../models/nutrition.model';
 
@@ -52,6 +53,7 @@ const MEAL_TYPES: { value: MealType; label: string }[] = [
     MatAutocomplete,
     MatAutocompleteTrigger,
     MatIcon,
+    MatProgressSpinner,
     MatMiniFabButton,
     MatIconButton,
     MatButton
@@ -77,6 +79,7 @@ export class AddDayEntryDialogComponent implements OnInit {
   results: Food[] = [];
   selected: Food | null = null;
   searchFailed = false;
+  searching = false;
 
   /** Foods staged in this dialog session, returned together as one batch on confirm. */
   staged: StagedItem[] = [];
@@ -87,12 +90,20 @@ export class AddDayEntryDialogComponent implements OnInit {
       // Once a food is picked the control holds a Food object; skip searching then.
       debounceTime(300),
       distinctUntilChanged(),
-      switchMap(value => {
+      tap(() => {
         this.searchFailed = false;
+        this.searching = true;
+        this.cdr.markForCheck();
+      }),
+      switchMap(value => {
         return this.nutritionService.searchFoods(typeof value === 'string' ? value.trim() : '').pipe(
           catchError(() => {
             this.searchFailed = true;
             return of<Food[]>([]);
+          }),
+          finalize(() => {
+            this.searching = false;
+            this.cdr.markForCheck();
           })
         );
       }),


### PR DESCRIPTION
## Summary
- Adds a small `mat-spinner` in place of the search icon while the debounced food search request is in flight
- Applied to both the "Essen hinzufügen" dialog (`add-day-entry-dialog`) and the food catalog page (`nutrition-foods`)
- Uses `tap` before `switchMap` to set `searching = true`, and `finalize` inside the inner observable to reset it on completion/error

Fixes #181

## Test plan
- [x] `npm run build` succeeds
- [ ] Manually verify: type in the food search field in "Essen hinzufügen" dialog and on the food catalog page — a small spinner appears in place of the search icon while the request is pending, then results update