### PR TITLE
style(nutrition): label confirm/cancel buttons in add-entry dialog

### DIFF
--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.css
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.css
@@ -241,12 +241,29 @@
 }
 
 /* ── Buttons ─────────────────────────────────────── */
+.btn-confirm,
+.btn-cancel {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.85rem;
+  font-weight: 600;
+  border-radius: 8px !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-confirm mat-icon,
+.btn-cancel mat-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+}
+
 .btn-confirm {
   background: rgba(45, 212, 191, 0.10) !important;
   border: 1px solid rgba(45, 212, 191, 0.3) !important;
-  border-radius: 8px !important;
   color: var(--c-n) !important;
-  transition: background 0.2s, box-shadow 0.2s;
 }
 
 .btn-confirm:hover:not([disabled]) {
@@ -261,9 +278,7 @@
 .btn-cancel {
   background: rgba(251, 113, 133, 0.10) !important;
   border: 1px solid rgba(251, 113, 133, 0.3) !important;
-  border-radius: 8px !important;
   color: var(--c-e) !important;
-  transition: background 0.2s, box-shadow 0.2s;
 }
 
 .btn-cancel:hover {
@@ -272,3 +287,11 @@
 }
 
 .btn-cancel mat-icon { color: var(--c-e) !important; }
+
+@media (max-width: 420px) {
+  .btn-confirm,
+  .btn-cancel {
+    flex: 1;
+    justify-content: center;
+  }
+}

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.html
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.html
@@ -114,10 +114,12 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="center">
-  <button mat-mini-fab class="btn-confirm" [disabled]="!canSave" (click)="save()">
+  <button mat-flat-button type="button" class="btn-confirm" [disabled]="!canSave" (click)="save()">
     <mat-icon>check_circle</mat-icon>
+    Speichern
   </button>
-  <button mat-mini-fab mat-dialog-close class="btn-cancel">
+  <button mat-stroked-button type="button" mat-dialog-close class="btn-cancel">
     <mat-icon>close</mat-icon>
+    Abbrechen
   </button>
 </mat-dialog-actions>

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.ts
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.ts
@@ -10,7 +10,7 @@ import {MatOption} from '@angular/material/core';
 import {MatAutocomplete, MatAutocompleteSelectedEvent, MatAutocompleteTrigger} from '@angular/material/autocomplete';
 import {MatIcon} from '@angular/material/icon';
 import {MatProgressSpinner} from '@angular/material/progress-spinner';
-import {MatButton, MatIconButton, MatMiniFabButton} from '@angular/material/button';
+import {MatButton, MatIconButton} from '@angular/material/button';
 import {catchError, debounceTime, distinctUntilChanged, finalize, of, startWith, switchMap, tap} from 'rxjs';
 import {NutritionService} from '../../services/nutrition.service';
 import {Food, FoodEntryInput, Macros, MealType} from '../../models/nutrition.model';
@@ -54,7 +54,6 @@ const MEAL_TYPES: { value: MealType; label: string }[] = [
     MatAutocompleteTrigger,
     MatIcon,
     MatProgressSpinner,
-    MatMiniFabButton,
     MatIconButton,
     MatButton
   ],


### PR DESCRIPTION
## Summary
- Replaces the unlabeled `mat-mini-fab` confirm (✓) and cancel (✕) icon buttons in the "Essen hinzufügen" dialog footer with labeled `mat-flat-button` / `mat-stroked-button` buttons showing "Speichern" and "Abbrechen" alongside their icons.
- Keeps the existing color scheme (teal confirm, red cancel) and adds a small mobile breakpoint so the buttons stretch full-width on narrow screens.
- Removes now-unused `MatMiniFabButton` import.

Fixes #182

## Test plan
- [x] `npm run build` succeeds with no new warnings
- [ ] Manually verify dialog footer shows "Speichern" / "Abbrechen" with icons, both on desktop and mobile widths