### PR TITLE
style(nutrition): add tooltips and 48px touch targets to icon buttons

### DIFF
--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.css
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.css
@@ -210,6 +210,10 @@
   white-space: nowrap;
 }
 
+.btn-edit, .btn-del {
+  min-width: 48px;
+  min-height: 48px;
+}
 .btn-edit { color: var(--text-dim); transition: color 0.2s; }
 .btn-edit:hover { color: var(--c-kcal); }
 .btn-del { color: var(--text-dim); transition: color 0.2s; }

--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.html
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.html
@@ -87,10 +87,10 @@
                   </span>
                 </div>
                 <div class="entry__actions">
-                  <button mat-icon-button class="btn-edit" (click)="openEditDialog(entry)">
+                  <button mat-icon-button class="btn-edit" matTooltip="Bearbeiten" (click)="openEditDialog(entry)">
                     <mat-icon>edit</mat-icon>
                   </button>
-                  <button mat-icon-button class="btn-del" (click)="openDeleteDialog(entry)">
+                  <button mat-icon-button class="btn-del" matTooltip="Löschen" (click)="openDeleteDialog(entry)">
                     <mat-icon>delete</mat-icon>
                   </button>
                 </div>

--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
@@ -8,6 +8,7 @@ import {MatDatepicker, MatDatepickerInput, MatDatepickerToggle} from '@angular/m
 import {MatButton, MatIconButton} from '@angular/material/button';
 import {MatIcon} from '@angular/material/icon';
 import {MatProgressSpinner} from '@angular/material/progress-spinner';
+import {MatTooltip} from '@angular/material/tooltip';
 import {MatDialog} from '@angular/material/dialog';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {EMPTY, switchMap} from 'rxjs';
@@ -60,7 +61,8 @@ const MEAL_GROUPS: { type: MealType; label: string }[] = [
     MatButton,
     MatIconButton,
     MatIcon,
-    MatProgressSpinner
+    MatProgressSpinner,
+    MatTooltip
   ],
   templateUrl: './nutrition-day.component.html',
   styleUrl: './nutrition-day.component.css'

--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.css
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.css
@@ -181,6 +181,11 @@ table {
   white-space: nowrap;
 }
 
+.btn-edit, .btn-del {
+  min-width: 48px;
+  min-height: 48px;
+}
+
 .btn-edit {
   color: var(--text-dim);
   transition: color 0.2s;

--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.html
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.html
@@ -78,10 +78,10 @@
           <ng-container matColumnDef="actions">
             <th *matHeaderCellDef mat-header-cell class="col-header"></th>
             <td *matCellDef="let food" mat-cell class="col-actions">
-              <button mat-icon-button class="btn-edit" (click)="openEditDialog(food)">
+              <button mat-icon-button class="btn-edit" matTooltip="Bearbeiten" (click)="openEditDialog(food)">
                 <mat-icon>edit</mat-icon>
               </button>
-              <button mat-icon-button class="btn-del" (click)="openDeleteDialog(food)">
+              <button mat-icon-button class="btn-del" matTooltip="Löschen" (click)="openDeleteDialog(food)">
                 <mat-icon>delete</mat-icon>
               </button>
             </td>

--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.ts
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.ts
@@ -20,6 +20,7 @@ import {MatInput} from '@angular/material/input';
 import {MatButton, MatIconButton} from '@angular/material/button';
 import {MatIcon} from '@angular/material/icon';
 import {MatProgressSpinner} from '@angular/material/progress-spinner';
+import {MatTooltip} from '@angular/material/tooltip';
 import {MatDialog} from '@angular/material/dialog';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {debounceTime, distinctUntilChanged, EMPTY, finalize, startWith, switchMap, tap} from 'rxjs';
@@ -52,7 +53,8 @@ import {BarcodeScanDialogComponent} from '../../dialogs/barcode-scan-dialog/barc
     MatButton,
     MatIconButton,
     MatIcon,
-    MatProgressSpinner
+    MatProgressSpinner,
+    MatTooltip
   ],
   templateUrl: './nutrition-foods.component.html',
   styleUrl: './nutrition-foods.component.css'

--- a/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.css
+++ b/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.css
@@ -127,6 +127,11 @@ table {
   padding-right: 8px !important;
 }
 
+.btn-edit, .btn-del {
+  min-width: 48px;
+  min-height: 48px;
+}
+
 .btn-edit {
   color: var(--text-dim);
   transition: color 0.2s;

--- a/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.html
+++ b/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.html
@@ -51,10 +51,10 @@
           <ng-container matColumnDef="actions">
             <th *matHeaderCellDef mat-header-cell class="col-header"></th>
             <td *matCellDef="let entry" mat-cell class="col-actions">
-              <button mat-icon-button class="btn-edit" (click)="openEditDialog(entry)">
+              <button mat-icon-button class="btn-edit" matTooltip="Bearbeiten" (click)="openEditDialog(entry)">
                 <mat-icon>edit</mat-icon>
               </button>
-              <button mat-icon-button class="btn-del" (click)="openDeleteDialog(entry)">
+              <button mat-icon-button class="btn-del" matTooltip="Löschen" (click)="openDeleteDialog(entry)">
                 <mat-icon>delete</mat-icon>
               </button>
             </td>

--- a/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.ts
+++ b/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.ts
@@ -20,6 +20,7 @@ import {MatInput} from '@angular/material/input';
 import {MatDatepicker, MatDatepickerInput, MatDatepickerToggle} from '@angular/material/datepicker';
 import {MatButton, MatIconButton} from '@angular/material/button';
 import {MatIcon} from '@angular/material/icon';
+import {MatTooltip} from '@angular/material/tooltip';
 import {MatDialog} from '@angular/material/dialog';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {EMPTY, switchMap} from 'rxjs';
@@ -57,6 +58,7 @@ import {WeightDeleteDialogComponent} from '../../dialogs/weight-delete-dialog/we
     MatButton,
     MatIconButton,
     MatIcon,
+    MatTooltip,
     TargetsCardComponent
   ],
   templateUrl: './nutrition-weight.component.html',


### PR DESCRIPTION
## Summary
- Add `matTooltip="Bearbeiten"` / `matTooltip="Löschen"` to all icon-only edit/delete buttons in the nutrition module (day entries, weight history, food catalog).
- Increase touch target to 48x48px via CSS `min-width`/`min-height` while keeping the visual icon size unchanged.
- Import `MatTooltip` / `MatTooltipModule` where needed.

Closes #183

## Test plan
- [x] `npm run build` succeeds
- [ ] Manually verify tooltips appear on hover for edit/delete buttons in /nutrition (day, weight, foods)
- [ ] Manually verify buttons feel larger/easier to tap on mobile viewport