### PR TITLE
style(nutrition): highlight progress bars when target is exceeded

### DIFF
--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.css
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.css
@@ -15,6 +15,7 @@
   --c-p:    #2dd4bf;
   --c-c:    #4da6ff;
   --c-f:    #fb7185;
+  --c-warn: #ff5252;
 
   display: block;
   height: 100%;
@@ -136,6 +137,15 @@
   transition: width 0.4s ease;
 }
 
+.bar__fill--over {
+  background: repeating-linear-gradient(
+    135deg,
+    var(--c-warn) 0 6px,
+    color-mix(in srgb, var(--c-warn) 70%, black) 6px 12px
+  );
+  box-shadow: 0 0 8px color-mix(in srgb, var(--c-warn) 60%, transparent);
+}
+
 .bar__rem {
   display: block;
   margin-top: 0.25rem;
@@ -143,6 +153,11 @@
   font-size: 0.6rem;
   letter-spacing: 0.04em;
   color: var(--text-dim);
+}
+
+.bar__rem--over {
+  color: var(--c-warn);
+  font-weight: 600;
 }
 
 /* ── Meal groups ─────────────────────────────────── */

--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.html
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.html
@@ -46,9 +46,9 @@
               </span>
             </div>
             <div class="bar__track">
-              <div class="bar__fill" [style.width.%]="b.pct"></div>
+              <div class="bar__fill" [class.bar__fill--over]="b.over" [style.width.%]="b.pct"></div>
             </div>
-            <span class="bar__rem">
+            <span class="bar__rem" [class.bar__rem--over]="b.over">
               @if (b.remaining > 0) {
                 noch {{ b.remaining | number:'1.0-0':'de' }} {{ b.unit }}
               } @else {

--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
@@ -36,6 +36,7 @@ interface MacroBar {
   target: number;
   remaining: number;
   pct: number;
+  over: boolean;
   cls: string;
 }
 
@@ -144,7 +145,7 @@ export class NutritionDayComponent implements OnInit {
 
   private bar(label: string, unit: string, consumed: number, target: number, remaining: number, cls: string): MacroBar {
     const pct = target > 0 ? Math.min(100, Math.round(consumed / target * 100)) : 0;
-    return {label, unit, consumed, target, remaining, pct, cls};
+    return {label, unit, consumed, target, remaining, pct, over: remaining < 0, cls};
   }
 
   entryName(entry: MealEntry): string {


### PR DESCRIPTION
## Summary
- Adds a `.bar__fill--over` striped warning fill and `.bar__rem--over` warning-colored text to the daily summary bars (kcal/protein/carbs/fat) when consumption exceeds the target.
- Previously the only indication of an overage was the "X über Ziel" text, which is easy to miss since the bar itself stays clamped at 100% with its normal color.

## Test plan
- [x] `npm run build` succeeds
- [x] Verified template/CSS changes only affect the over-target visual state

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)