### PR TITLE
feat(nutrition): sortable columns and larger header text in food table

### DIFF
--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.css
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.css
@@ -138,7 +138,7 @@ table {
 
 .col-header {
   font-family: 'JetBrains Mono', monospace !important;
-  font-size: 0.6rem !important;
+  font-size: 0.75rem !important;
   font-weight: 700 !important;
   letter-spacing: 0.12em !important;
   text-transform: uppercase !important;
@@ -147,6 +147,14 @@ table {
   border-bottom: 1px solid var(--border-mid) !important;
   height: 36px !important;
   padding: 0 12px !important;
+}
+
+::ng-deep .col-header .mat-sort-header-arrow {
+  color: var(--text-muted) !important;
+}
+
+::ng-deep .col-header.mat-sort-header-sorted {
+  color: var(--c-g) !important;
 }
 
 ::ng-deep .mat-mdc-header-row {

--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.html
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.html
@@ -43,10 +43,10 @@
   <section class="panel">
     @if (foods.data.length) {
       <div class="table-container">
-        <table mat-table [dataSource]="foods">
+        <table mat-table [dataSource]="foods" matSort>
 
           <ng-container matColumnDef="name">
-            <th *matHeaderCellDef mat-header-cell class="col-header">Name</th>
+            <th *matHeaderCellDef mat-header-cell mat-sort-header class="col-header">Name</th>
             <td *matCellDef="let food" mat-cell>
               <span class="food-name">{{ food.name }}</span>
               @if (food.brand) {
@@ -56,22 +56,22 @@
           </ng-container>
 
           <ng-container matColumnDef="kcal">
-            <th *matHeaderCellDef mat-header-cell class="col-header col-num">kcal</th>
+            <th *matHeaderCellDef mat-header-cell mat-sort-header class="col-header col-num">kcal</th>
             <td *matCellDef="let food" mat-cell class="col-num">{{ food.kcalPer100 | number:'1.0-0':'de' }}</td>
           </ng-container>
 
           <ng-container matColumnDef="protein">
-            <th *matHeaderCellDef mat-header-cell class="col-header col-num">P</th>
+            <th *matHeaderCellDef mat-header-cell mat-sort-header class="col-header col-num">P</th>
             <td *matCellDef="let food" mat-cell class="col-num">{{ food.proteinPer100 | number:'1.0-1':'de' }}</td>
           </ng-container>
 
           <ng-container matColumnDef="carbs">
-            <th *matHeaderCellDef mat-header-cell class="col-header col-num">KH</th>
+            <th *matHeaderCellDef mat-header-cell mat-sort-header class="col-header col-num">KH</th>
             <td *matCellDef="let food" mat-cell class="col-num">{{ food.carbsPer100 | number:'1.0-1':'de' }}</td>
           </ng-container>
 
           <ng-container matColumnDef="fat">
-            <th *matHeaderCellDef mat-header-cell class="col-header col-num">F</th>
+            <th *matHeaderCellDef mat-header-cell mat-sort-header class="col-header col-num">F</th>
             <td *matCellDef="let food" mat-cell class="col-num">{{ food.fatPer100 | number:'1.0-1':'de' }}</td>
           </ng-container>
 

--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.ts
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, inject, OnInit, ViewChild} from '@angular/core';
+import {AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, inject, OnInit, ViewChild} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {DecimalPipe} from '@angular/common';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
@@ -17,6 +17,7 @@ import {
 } from '@angular/material/table';
 import {MatFormField, MatLabel, MatPrefix} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
+import {MatSort, MatSortModule} from '@angular/material/sort';
 import {MatButton, MatIconButton} from '@angular/material/button';
 import {MatIcon} from '@angular/material/icon';
 import {MatProgressSpinner} from '@angular/material/progress-spinner';
@@ -54,14 +55,16 @@ import {BarcodeScanDialogComponent} from '../../dialogs/barcode-scan-dialog/barc
     MatIconButton,
     MatIcon,
     MatProgressSpinner,
-    MatTooltip
+    MatTooltip,
+    MatSortModule
   ],
   templateUrl: './nutrition-foods.component.html',
   styleUrl: './nutrition-foods.component.css'
 })
-export class NutritionFoodsComponent implements OnInit {
+export class NutritionFoodsComponent implements OnInit, AfterViewInit {
 
   @ViewChild('photoInput') photoInput!: { nativeElement: HTMLInputElement };
+  @ViewChild(MatSort) sort!: MatSort;
 
   search = new FormControl('', {nonNullable: true});
   foods = new MatTableDataSource<Food>();
@@ -78,6 +81,10 @@ export class NutritionFoodsComponent implements OnInit {
   private snackBar = inject(MatSnackBar);
   private cdr = inject(ChangeDetectorRef);
   private destroyRef = inject(DestroyRef);
+
+  ngAfterViewInit(): void {
+    this.foods.sort = this.sort;
+  }
 
   ngOnInit(): void {
     this.search.valueChanges.pipe(


### PR DESCRIPTION
## Summary
- Adds MatSort to the food catalog table (`nutrition-foods` component) so all columns (Name, kcal, P, KH, F) are sortable via mat-sort-header.
- Increases the table header font-size from 0.6rem to 0.75rem for better mobile readability.
- Adds dark-theme styling for the sort arrow/active state.

Fixes #185

## Test plan
- [x] `npm run build` succeeds
- [ ] Manually verify clicking each header sorts the food catalog ascending/descending
- [ ] Verify header text is legible on mobile