### PR TITLE
feat(nutrition): paginate food catalog table

### DIFF
--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.css
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.css
@@ -216,6 +216,32 @@ table {
   color: var(--text-dim);
 }
 
+/* ── Paginator ───────────────────────────────────── */
+mat-paginator {
+  background: var(--surface) !important;
+  border: 1px solid var(--border);
+  border-top: none;
+  border-radius: 0 0 12px 12px;
+  color: var(--text-muted) !important;
+}
+
+::ng-deep mat-paginator .mat-mdc-paginator-container {
+  color: var(--text-muted) !important;
+}
+
+::ng-deep mat-paginator .mat-mdc-select-value,
+::ng-deep mat-paginator .mat-mdc-paginator-range-label {
+  color: var(--text) !important;
+}
+
+::ng-deep mat-paginator .mat-mdc-icon-button .mat-mdc-paginator-icon {
+  fill: var(--text-muted) !important;
+}
+
+::ng-deep mat-paginator .mat-mdc-icon-button[disabled] .mat-mdc-paginator-icon {
+  fill: var(--text-dim) !important;
+}
+
 /* ── Empty ───────────────────────────────────────── */
 .empty {
   margin: 0;

--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.html
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.html
@@ -92,6 +92,7 @@
 
         </table>
       </div>
+      <mat-paginator [pageSizeOptions]="pageSizeOptions" [pageSize]="25" showFirstLastButtons></mat-paginator>
       <p class="hint">Werte je 100 g · P Protein · KH Kohlenhydrate · F Fett</p>
     } @else {
       <p class="empty">

--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.ts
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.ts
@@ -18,6 +18,7 @@ import {
 import {MatFormField, MatLabel, MatPrefix} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
 import {MatSort, MatSortModule} from '@angular/material/sort';
+import {MatPaginator, MatPaginatorModule} from '@angular/material/paginator';
 import {MatButton, MatIconButton} from '@angular/material/button';
 import {MatIcon} from '@angular/material/icon';
 import {MatProgressSpinner} from '@angular/material/progress-spinner';
@@ -56,7 +57,8 @@ import {BarcodeScanDialogComponent} from '../../dialogs/barcode-scan-dialog/barc
     MatIcon,
     MatProgressSpinner,
     MatTooltip,
-    MatSortModule
+    MatSortModule,
+    MatPaginatorModule
   ],
   templateUrl: './nutrition-foods.component.html',
   styleUrl: './nutrition-foods.component.css'
@@ -65,10 +67,12 @@ export class NutritionFoodsComponent implements OnInit, AfterViewInit {
 
   @ViewChild('photoInput') photoInput!: { nativeElement: HTMLInputElement };
   @ViewChild(MatSort) sort!: MatSort;
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
 
   search = new FormControl('', {nonNullable: true});
   foods = new MatTableDataSource<Food>();
   columnsToDisplay = ['name', 'kcal', 'protein', 'carbs', 'fat', 'actions'];
+  pageSizeOptions = [10, 25, 50, 100];
   scanning = false;
   searching = false;
 
@@ -84,6 +88,7 @@ export class NutritionFoodsComponent implements OnInit, AfterViewInit {
 
   ngAfterViewInit(): void {
     this.foods.sort = this.sort;
+    this.foods.paginator = this.paginator;
   }
 
   ngOnInit(): void {
@@ -104,6 +109,9 @@ export class NutritionFoodsComponent implements OnInit, AfterViewInit {
       takeUntilDestroyed(this.destroyRef)
     ).subscribe(foods => {
       this.foods.data = foods;
+      if (this.foods.paginator) {
+        this.foods.paginator.firstPage();
+      }
       this.cdr.markForCheck();
     });
   }


### PR DESCRIPTION
## Summary
- Adds `MatPaginator` to the food catalog table, wired to the existing `MatTableDataSource.paginator` (built on top of #197's sort/data-source changes)
- Default page size of 25 with options 10/25/50/100, `showFirstLastButtons` enabled
- Resets to the first page whenever the search results change
- Styles the paginator to match the existing dark theme

## Test plan
- [x] `npm run build` succeeds
- [ ] Manually verify pagination controls appear under the food table and page through results
- [ ] Verify sorting still works alongside pagination

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)