### PR TITLE
style(nutrition): add disclaimer for AI-estimated canteen values

### DIFF
--- a/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.css
+++ b/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.css
@@ -119,6 +119,28 @@
   .grid { grid-template-columns: 1fr; }
 }
 
+.disclaimer {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin: 0.5rem 0 0.25rem;
+  padding: 0.7rem 0.8rem;
+  background: color-mix(in srgb, #f5a623 12%, transparent);
+  border: 1px solid color-mix(in srgb, #f5a623 35%, transparent);
+  border-radius: 10px;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+
+.disclaimer mat-icon {
+  flex-shrink: 0;
+  font-size: 1.05rem;
+  width: 1.05rem;
+  height: 1.05rem;
+  color: #f5a623;
+}
+
 .assumptions {
   display: flex;
   align-items: flex-start;

--- a/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.html
+++ b/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.html
@@ -64,6 +64,11 @@
         </mat-form-field>
       </form>
 
+      <p class="disclaimer">
+        <mat-icon>warning</mat-icon>
+        <span>Geschätzter Wert – kann abweichen. Vor dem Eintragen bei Bedarf anpassen.</span>
+      </p>
+
       @if (assumptions) {
         <p class="assumptions">
           <mat-icon>info</mat-icon>


### PR DESCRIPTION
## Summary
- Adds a short disclaimer below the AI-estimated macro grid on the Kantine ("nutrition-canteen") page, clarifying that values are estimates and may be edited before logging.
- Styled distinctly (amber/warning tone) from the existing assumptions hint to draw attention.

Closes #187

## Test plan
- [x] `npm run build` succeeds
- [ ] Manually verify the disclaimer appears under the estimate grid after clicking "Schätzen"