### PR TITLE
feat(nutrition): add timeout and cancel for canteen AI estimate

### DIFF
--- a/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.css
+++ b/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.css
@@ -68,6 +68,18 @@
 .field-full { width: 100%; }
 
 /* ── Buttons ─────────────────────────────────────── */
+.estimate-row {
+  display: flex;
+  align-items: stretch;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.estimate-row .btn-estimate {
+  flex: 1 1 auto;
+  margin-top: 0;
+}
+
 .btn-estimate,
 .btn-log {
   height: 48px;
@@ -75,6 +87,19 @@
   font-weight: 600 !important;
   margin-top: 0.5rem;
   transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-cancel {
+  height: 48px;
+  border-radius: 8px !important;
+  font-weight: 600 !important;
+  flex: 0 0 auto;
+  color: var(--text-muted) !important;
+  border-color: var(--border-mid) !important;
+}
+
+.btn-cancel:hover {
+  background: color-mix(in srgb, #ffffff 6%, transparent) !important;
 }
 
 .btn-estimate {

--- a/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.html
+++ b/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.html
@@ -24,15 +24,24 @@
       <mat-hint>Hilft der KI, die Menge besser einzuschätzen.</mat-hint>
     </mat-form-field>
 
-    <button mat-flat-button type="button" class="btn-estimate"
-            [disabled]="description.invalid || estimating" (click)="estimate()">
+    <div class="estimate-row">
+      <button mat-flat-button type="button" class="btn-estimate"
+              [disabled]="description.invalid || estimating" (click)="estimate()">
+        @if (estimating) {
+          <mat-spinner diameter="18" />
+        } @else {
+          <mat-icon>auto_awesome</mat-icon>
+        }
+        Schätzen
+      </button>
+
       @if (estimating) {
-        <mat-spinner diameter="18" />
-      } @else {
-        <mat-icon>auto_awesome</mat-icon>
+        <button mat-stroked-button type="button" class="btn-cancel" (click)="cancelEstimate()">
+          <mat-icon>close</mat-icon>
+          Abbrechen
+        </button>
       }
-      Schätzen
-    </button>
+    </div>
   </section>
 
   @if (hasEstimate) {

--- a/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.ts
+++ b/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.ts
@@ -10,8 +10,11 @@ import {MatIcon} from '@angular/material/icon';
 import {MatProgressSpinner} from '@angular/material/progress-spinner';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {format} from 'date-fns';
+import {Subscription, timeout, TimeoutError} from 'rxjs';
 import {NutritionService} from '../../services/nutrition.service';
 import {AdHocEntryInput, MealEstimate, MealType} from '../../models/nutrition.model';
+
+const ESTIMATE_TIMEOUT_MS = 30000;
 
 const MEAL_TYPES: { value: MealType; label: string }[] = [
   {value: 'BREAKFAST', label: 'Frühstück'},
@@ -62,6 +65,7 @@ export class NutritionCanteenComponent implements OnInit {
   private nutritionService = inject(NutritionService);
   private snackBar = inject(MatSnackBar);
   private cdr = inject(ChangeDetectorRef);
+  private estimateSubscription?: Subscription;
 
   ngOnInit(): void {
     this.valuesForm = this.fb.group({
@@ -78,19 +82,32 @@ export class NutritionCanteenComponent implements OnInit {
     this.cdr.markForCheck();
 
     const hint = this.portionHint.value.trim();
-    this.nutritionService.estimateMeal(this.description.value.trim(), hint || undefined).subscribe({
-      next: (estimate: MealEstimate) => {
-        this.applyEstimate(estimate);
-        this.estimating = false;
-        this.hasEstimate = true;
-        this.cdr.markForCheck();
-      },
-      error: () => {
-        this.estimating = false;
-        this.cdr.markForCheck();
-        this.snackBar.open('Schätzung fehlgeschlagen', 'Schließen', {duration: 5000});
-      }
-    });
+    this.estimateSubscription = this.nutritionService.estimateMeal(this.description.value.trim(), hint || undefined)
+      .pipe(timeout(ESTIMATE_TIMEOUT_MS))
+      .subscribe({
+        next: (estimate: MealEstimate) => {
+          this.applyEstimate(estimate);
+          this.estimating = false;
+          this.hasEstimate = true;
+          this.cdr.markForCheck();
+        },
+        error: (err: unknown) => {
+          this.estimating = false;
+          this.cdr.markForCheck();
+          if (err instanceof TimeoutError) {
+            this.snackBar.open('Schätzung dauert zu lange – bitte erneut versuchen.', 'Schließen', {duration: 5000});
+          } else {
+            this.snackBar.open('Schätzung fehlgeschlagen', 'Schließen', {duration: 5000});
+          }
+        }
+      });
+  }
+
+  cancelEstimate(): void {
+    if (!this.estimating) return;
+    this.estimateSubscription?.unsubscribe();
+    this.estimating = false;
+    this.cdr.markForCheck();
   }
 
   private applyEstimate(estimate: MealEstimate): void {


### PR DESCRIPTION
## Summary
- Adds a 30s client-side timeout (`timeout()`) to the canteen AI meal estimation request
- Shows a friendly snackbar ("Schätzung dauert zu lange – bitte erneut versuchen.") if the request times out, resetting `estimating` so the button re-enables
- Adds an "Abbrechen" button visible while estimating, which unsubscribes from the in-flight request and resets state

Closes #188

## Test plan
- [x] `npm run build` succeeds
- [ ] Manually verify: trigger an estimate, click "Abbrechen", confirm spinner stops and button re-enables
- [ ] Manually verify: simulate slow backend, confirm timeout snackbar appears after 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)