### PR TITLE
fix(nutrition): add loading/disabled state to weight entry form

### DIFF
--- a/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.css
+++ b/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.css
@@ -84,6 +84,10 @@
 
 .btn-add[disabled] { opacity: 0.4 !important; }
 
+.btn-add mat-spinner { margin-right: 4px; }
+
+::ng-deep .btn-add mat-spinner circle { stroke: var(--c-g) !important; }
+
 /* ── Table ───────────────────────────────────────── */
 .table-container {
   background: var(--surface);

--- a/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.html
+++ b/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.html
@@ -21,8 +21,12 @@
         <input matInput type="number" step="0.1" formControlName="weightKg" />
       </mat-form-field>
 
-      <button mat-flat-button type="submit" class="btn-add" [disabled]="form.invalid">
-        <mat-icon>add</mat-icon>
+      <button mat-flat-button type="submit" class="btn-add" [disabled]="form.invalid || saving">
+        @if (saving) {
+          <mat-spinner diameter="18" />
+        } @else {
+          <mat-icon>add</mat-icon>
+        }
         Hinzufügen
       </button>
     </form>

--- a/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.ts
+++ b/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.ts
@@ -20,6 +20,7 @@ import {MatInput} from '@angular/material/input';
 import {MatDatepicker, MatDatepickerInput, MatDatepickerToggle} from '@angular/material/datepicker';
 import {MatButton, MatIconButton} from '@angular/material/button';
 import {MatIcon} from '@angular/material/icon';
+import {MatProgressSpinner} from '@angular/material/progress-spinner';
 import {MatTooltip} from '@angular/material/tooltip';
 import {MatDialog} from '@angular/material/dialog';
 import {MatSnackBar} from '@angular/material/snack-bar';
@@ -58,6 +59,7 @@ import {WeightDeleteDialogComponent} from '../../dialogs/weight-delete-dialog/we
     MatButton,
     MatIconButton,
     MatIcon,
+    MatProgressSpinner,
     MatTooltip,
     TargetsCardComponent
   ],
@@ -69,6 +71,7 @@ export class NutritionWeightComponent implements OnInit {
   @ViewChild(TargetsCardComponent) targetsCard?: TargetsCardComponent;
 
   form!: FormGroup;
+  saving = false;
   entries = new MatTableDataSource<WeightEntry>();
   columnsToDisplay = ['entryDate', 'weightKg', 'actions'];
 
@@ -110,8 +113,11 @@ export class NutritionWeightComponent implements OnInit {
       entryDate: format(entryDate, 'yyyy-MM-dd'),
       weightKg: Number(weightKg)
     };
+    this.saving = true;
+    this.cdr.markForCheck();
     this.nutritionService.addWeightEntry(payload).subscribe({
       next: created => {
+        this.saving = false;
         this.entries.data = this.sortDesc([...this.entries.data, created]);
         this.form.reset({entryDate: new Date(), weightKg: null});
         this.targetsCard?.reload();
@@ -119,6 +125,8 @@ export class NutritionWeightComponent implements OnInit {
         this.snackBar.open('Gewicht gespeichert', 'OK', {duration: 3000});
       },
       error: () => {
+        this.saving = false;
+        this.cdr.markForCheck();
         this.snackBar.open('Gewicht konnte nicht gespeichert werden', 'Schließen', {duration: 5000});
       }
     });


### PR DESCRIPTION
## Summary
- Adds a `saving` flag to `NutritionWeightComponent`, set while the add-weight request is in flight
- Disables the "Hinzufügen" button and shows a small spinner while saving, mirroring the pattern in `nutrition-profile`
- Prevents duplicate weight entries from repeated clicks on slow connections

Closes #190

## Test plan
- [x] `npm run build` succeeds