### PR TITLE
feat(nutrition): confirmation step in barcode scan dialog

### DIFF
--- a/src/app/nutrition/dialogs/barcode-scan-dialog/barcode-scan-dialog.component.css
+++ b/src/app/nutrition/dialogs/barcode-scan-dialog/barcode-scan-dialog.component.css
@@ -156,6 +156,57 @@
   color: var(--c-n) !important;
 }
 
+/* ── Found confirmation ──────────────────────────── */
+.found {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 1.5rem 0.5rem;
+  text-align: center;
+}
+
+.found__icon {
+  font-size: 2.5rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  color: var(--c-g) !important;
+}
+
+.found__text {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text);
+}
+
+.btn-confirm {
+  background: color-mix(in srgb, var(--c-g) 14%, transparent) !important;
+  border: 1px solid color-mix(in srgb, var(--c-g) 35%, transparent) !important;
+  border-radius: 8px !important;
+  color: var(--c-g) !important;
+  font-weight: 600 !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-confirm:hover {
+  background: color-mix(in srgb, var(--c-g) 22%, transparent) !important;
+  box-shadow: 0 0 12px rgba(163, 230, 53, 0.25) !important;
+}
+
+.btn-rescan {
+  background: color-mix(in srgb, var(--c-n) 14%, transparent) !important;
+  border: 1px solid color-mix(in srgb, var(--c-n) 35%, transparent) !important;
+  border-radius: 8px !important;
+  color: var(--c-n) !important;
+  font-weight: 600 !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-rescan:hover {
+  background: color-mix(in srgb, var(--c-n) 22%, transparent) !important;
+  box-shadow: 0 0 12px rgba(45, 212, 191, 0.25) !important;
+}
+
 /* ── Cancel button ───────────────────────────────── */
 .btn-cancel {
   background: rgba(251, 113, 133, 0.10) !important;

--- a/src/app/nutrition/dialogs/barcode-scan-dialog/barcode-scan-dialog.component.html
+++ b/src/app/nutrition/dialogs/barcode-scan-dialog/barcode-scan-dialog.component.html
@@ -3,38 +3,60 @@
 <mat-dialog-content>
   <div class="scan-body">
 
-    @if (cameraSupported) {
-      <div class="viewport" [class.viewport--off]="!cameraActive">
-        <video #video class="viewport__video" muted playsinline></video>
-        <div class="viewport__frame" aria-hidden="true"></div>
-        @if (looking) {
-          <div class="viewport__overlay">Suche…</div>
-        }
+    @if (foundFood) {
+      <div class="found">
+        <mat-icon class="found__icon">check_circle</mat-icon>
+        <p class="found__text">
+          Gefunden: {{ foundFood.name }}@if (foundFood.brand) {, {{ foundFood.brand }}}
+        </p>
       </div>
-    }
+    } @else {
 
-    @if (message) {
-      <p class="msg">{{ message }}</p>
-    } @else if (cameraActive) {
-      <p class="hint">Barcode vor die Kamera halten.</p>
-    }
+      @if (cameraSupported) {
+        <div class="viewport" [class.viewport--off]="!cameraActive">
+          <video #video class="viewport__video" muted playsinline></video>
+          <div class="viewport__frame" aria-hidden="true"></div>
+          @if (looking) {
+            <div class="viewport__overlay">Suche…</div>
+          }
+        </div>
+      }
 
-    <form class="manual" (ngSubmit)="lookupManual()">
-      <mat-form-field appearance="outline" class="manual__field">
-        <mat-label>Barcode (EAN)</mat-label>
-        <input matInput inputmode="numeric" autocomplete="off" [formControl]="manualEan" />
-      </mat-form-field>
-      <button mat-flat-button type="submit" class="btn-lookup" [disabled]="looking">
-        <mat-icon>search</mat-icon>
-        Suchen
-      </button>
-    </form>
+      @if (message) {
+        <p class="msg">{{ message }}</p>
+      } @else if (cameraActive) {
+        <p class="hint">Barcode vor die Kamera halten.</p>
+      }
+
+      <form class="manual" (ngSubmit)="lookupManual()">
+        <mat-form-field appearance="outline" class="manual__field">
+          <mat-label>Barcode (EAN)</mat-label>
+          <input matInput inputmode="numeric" autocomplete="off" [formControl]="manualEan" />
+        </mat-form-field>
+        <button mat-flat-button type="submit" class="btn-lookup" [disabled]="looking">
+          <mat-icon>search</mat-icon>
+          Suchen
+        </button>
+      </form>
+
+    }
 
   </div>
 </mat-dialog-content>
 
 <mat-dialog-actions align="center">
-  <button mat-mini-fab mat-dialog-close class="btn-cancel" aria-label="Abbrechen">
-    <mat-icon>close</mat-icon>
-  </button>
+  @if (foundFood) {
+    <button mat-flat-button class="btn-rescan" (click)="rescan()">
+      <mat-icon>refresh</mat-icon>
+      Erneut scannen
+    </button>
+    <button mat-flat-button class="btn-confirm" (click)="confirmFound()">
+      <mat-icon>check</mat-icon>
+      Übernehmen
+    </button>
+  } @else {
+    <button mat-mini-fab mat-dialog-close class="btn-cancel" aria-label="Abbrechen">
+      <mat-icon>close</mat-icon>
+    </button>
+  }
 </mat-dialog-actions>

--- a/src/app/nutrition/dialogs/barcode-scan-dialog/barcode-scan-dialog.component.ts
+++ b/src/app/nutrition/dialogs/barcode-scan-dialog/barcode-scan-dialog.component.ts
@@ -14,6 +14,7 @@ import {MatFormField, MatLabel} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
 import {MatIcon} from '@angular/material/icon';
 import {MatButton, MatMiniFabButton} from '@angular/material/button';
+import {FoodDraft} from '../../models/nutrition.model';
 import {NutritionService} from '../../services/nutrition.service';
 
 /**
@@ -69,6 +70,9 @@ export class BarcodeScanDialogComponent implements AfterViewInit, OnDestroy {
   cameraActive = false;
   looking = false;
   message = '';
+
+  /** Set once a barcode lookup succeeds, pending user confirmation. */
+  foundFood: FoodDraft | null = null;
 
   private dialogRef = inject(MatDialogRef<BarcodeScanDialogComponent>);
   private service = inject(NutritionService);
@@ -142,7 +146,11 @@ export class BarcodeScanDialogComponent implements AfterViewInit, OnDestroy {
     this.message = '';
     this.cdr.markForCheck();
     this.service.getFoodByBarcode(ean).subscribe({
-      next: draft => this.dialogRef.close(draft),
+      next: draft => {
+        this.looking = false;
+        this.foundFood = draft;
+        this.cdr.markForCheck();
+      },
       error: err => {
         this.looking = false;
         this.message = err.status === 404
@@ -154,6 +162,22 @@ export class BarcodeScanDialogComponent implements AfterViewInit, OnDestroy {
         this.cdr.markForCheck();
       }
     });
+  }
+
+  /** User confirmed the matched product; hand off to the food-edit-dialog. */
+  confirmFound(): void {
+    if (!this.foundFood) return;
+    this.dialogRef.close(this.foundFood);
+  }
+
+  /** User rejected the match; return to scanning. */
+  rescan(): void {
+    this.foundFood = null;
+    this.handled = false;
+    this.message = '';
+    this.manualEan.reset('');
+    if (this.cameraSupported) void this.startCamera();
+    this.cdr.markForCheck();
   }
 
   private stopCamera(): void {


### PR DESCRIPTION
## Summary
- Adds an intermediate "found" state to the barcode scan dialog after a successful barcode lookup
- Shows "Gefunden: {name}, {brand}" with the matched product
- User can accept ("Übernehmen") to proceed to the food-edit-dialog, or "Erneut scannen" to return to scanning

Fixes #191

## Test plan
- [x] `npm run build` succeeds
- [ ] Manually verify: scan/enter a valid barcode, confirm "Gefunden: ..." appears with name/brand
- [ ] Verify "Übernehmen" closes the dialog and opens food-edit-dialog prefilled
- [ ] Verify "Erneut scannen" returns to scanning UI and camera restarts