### PR TITLE
feat(nutrition): add per-meal quick-add and time-based default meal

### DIFF
--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.css
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.css
@@ -163,12 +163,13 @@
 /* ── Meal groups ─────────────────────────────────── */
 .meal__head {
   display: flex;
-  justify-content: space-between;
-  align-items: baseline;
+  align-items: center;
+  gap: 0.5rem;
   margin-bottom: 0.5rem;
 }
 
 .meal__title {
+  flex: 1;
   font-size: 0.95rem;
   font-weight: 600;
   color: var(--text);
@@ -178,6 +179,40 @@
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.72rem;
   color: var(--c-kcal);
+}
+
+.btn-meal-add {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  color: var(--text-dim);
+  transition: color 0.2s, background 0.2s;
+}
+
+.btn-meal-add:hover {
+  color: var(--c-kcal);
+  background: color-mix(in srgb, var(--c-kcal) 12%, transparent);
+}
+
+.meal__empty {
+  display: block;
+  width: 100%;
+  padding: 0.85rem;
+  text-align: center;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  background: var(--surface);
+  border: 1px dashed var(--border-mid);
+  border-radius: 12px;
+  cursor: pointer;
+  transition: color 0.2s, border-color 0.2s, background 0.2s;
+}
+
+.meal__empty:hover {
+  color: var(--c-kcal);
+  border-color: color-mix(in srgb, var(--c-kcal) 40%, transparent);
+  background: color-mix(in srgb, var(--c-kcal) 6%, transparent);
 }
 
 .entries {

--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.html
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.html
@@ -63,14 +63,17 @@
       <p class="empty">Tagesziele nicht verfügbar. Bitte zuerst ein Profil und einen Gewichtseintrag erfassen.</p>
     }
 
-    @if (hasEntries) {
-      @for (group of groups; track group.type) {
-        <section class="panel meal">
-          <header class="meal__head">
-            <span class="meal__title">{{ group.label }}</span>
-            <span class="meal__kcal">{{ group.kcal | number:'1.0-0':'de' }} kcal</span>
-          </header>
+    @for (group of groups; track group.type) {
+      <section class="panel meal">
+        <header class="meal__head">
+          <span class="meal__title">{{ group.label }}</span>
+          <span class="meal__kcal">{{ group.kcal | number:'1.0-0':'de' }} kcal</span>
+          <button mat-icon-button class="btn-meal-add" matTooltip="Hinzufügen" (click)="openAddDialog(group.type)">
+            <mat-icon>add</mat-icon>
+          </button>
+        </header>
 
+        @if (group.entries.length > 0) {
           <ul class="entries">
             @for (entry of group.entries; track entry.id) {
               <li class="entry">
@@ -97,10 +100,12 @@
               </li>
             }
           </ul>
-        </section>
-      }
-    } @else {
-      <p class="empty">Noch nichts erfasst. Füge dein erstes Essen hinzu.</p>
+        } @else {
+          <button type="button" class="meal__empty" (click)="openAddDialog(group.type)">
+            Noch nichts erfasst – hinzufügen
+          </button>
+        }
+      </section>
     }
 
   }

--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
@@ -121,11 +121,16 @@ export class NutritionDayComponent implements OnInit {
         entries: groupEntries,
         kcal: groupEntries.reduce((sum, e) => sum + e.kcal, 0)
       };
-    }).filter(g => g.entries.length > 0);
+    });
   }
 
-  get hasEntries(): boolean {
-    return (this.summary?.entries?.length ?? 0) > 0;
+  /** Default meal type based on the current time of day (German meal conventions). */
+  private defaultMealType(): MealType {
+    const hour = new Date().getHours();
+    if (hour < 11) return 'BREAKFAST';
+    if (hour < 15) return 'LUNCH';
+    if (hour < 21) return 'DINNER';
+    return 'SNACK';
   }
 
   get hasTargets(): boolean {
@@ -153,7 +158,7 @@ export class NutritionDayComponent implements OnInit {
   }
 
   openAddDialog(mealType?: MealType): void {
-    const data: AddDayEntryDialogData = {mealType};
+    const data: AddDayEntryDialogData = {mealType: mealType ?? this.defaultMealType()};
     const ref = this.dialog.open(AddDayEntryDialogComponent, {data});
     ref.afterClosed().pipe(
       switchMap((result: FoodEntryInput[] | undefined) => result?.length ? this.nutritionService.addEntries(this.isoDate, result) : EMPTY),


### PR DESCRIPTION
## Summary
Improves the nutrition diary (Tagebuch) add flow so each meal has its own quick-add and the generic add no longer always defaults to lunch.

- Render **all four** meal slots (Frühstück / Mittagessen / Abendessen / Snack) even when empty, so each always has an add target (previously empty groups were filtered out of the `groups` getter).
- Add a small `+` button in every meal header wired to `openAddDialog(group.type)`.
- Empty meal groups render a tappable "Noch nichts erfasst – hinzufügen" affordance that also opens the dialog pre-set to that meal.
- The generic "Essen" button now picks a sensible default meal type by time of day (before 11:00 → Frühstück, 11–15 → Mittagessen, 15–21 → Abendessen, otherwise Snack) instead of always LUNCH.
- Removed the now-unused `hasEntries` getter.

## Files
- `src/app/nutrition/components/nutrition-day/nutrition-day.component.ts`
- `src/app/nutrition/components/nutrition-day/nutrition-day.component.html`
- `src/app/nutrition/components/nutrition-day/nutrition-day.component.css`

Build: `npm run build` succeeds.

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)