### PR TITLE
feat(nutrition): add prev/next/today diary date navigation

### DIFF
--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.css
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.css
@@ -69,7 +69,70 @@
   gap: 0.75rem;
 }
 
-.field-date { flex: 1 1 200px; }
+.date-nav {
+  display: flex;
+  flex: 1 1 320px;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.field-date { flex: 1 1 160px; }
+
+.btn-step {
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+  margin-bottom: 1.34375em; /* align with form-field input baseline (subscript wrapper) */
+  color: var(--text-muted);
+  border: 1px solid var(--border-mid);
+  border-radius: 8px;
+  transition: color 0.2s, border-color 0.2s, background 0.2s;
+}
+
+.btn-step:hover:not([disabled]) {
+  color: var(--c-kcal);
+  border-color: color-mix(in srgb, var(--c-kcal) 40%, transparent);
+  background: color-mix(in srgb, var(--c-kcal) 8%, transparent);
+}
+
+.btn-step[disabled] {
+  color: var(--text-dim);
+  opacity: 0.4;
+}
+
+.date-rel {
+  flex-shrink: 0;
+  margin-bottom: 1.34375em;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.62rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--c-p);
+  white-space: nowrap;
+}
+
+.btn-today {
+  flex-shrink: 0;
+  height: 44px;
+  margin-bottom: 1.34375em;
+  border-radius: 8px !important;
+  font-weight: 600 !important;
+  font-size: 0.78rem !important;
+  color: var(--text-muted) !important;
+  border-color: var(--border-mid) !important;
+  transition: color 0.2s, border-color 0.2s, background 0.2s;
+}
+
+.btn-today:hover:not([disabled]) {
+  color: var(--c-kcal) !important;
+  border-color: color-mix(in srgb, var(--c-kcal) 40%, transparent) !important;
+  background: color-mix(in srgb, var(--c-kcal) 8%, transparent) !important;
+}
+
+.btn-today[disabled] {
+  opacity: 0.4;
+}
 
 .btn-add {
   height: 56px;

--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.html
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.html
@@ -7,12 +7,33 @@
     </header>
 
     <div class="toolbar">
-      <mat-form-field appearance="outline" class="field-date">
-        <mat-label>Datum</mat-label>
-        <input matInput [matDatepicker]="picker" [formControl]="date" />
-        <mat-datepicker-toggle matIconSuffix [for]="picker" />
-        <mat-datepicker #picker />
-      </mat-form-field>
+      <div class="date-nav">
+        <button mat-icon-button type="button" class="btn-step" matTooltip="Vorheriger Tag"
+                (click)="stepDay(-1)">
+          <mat-icon>chevron_left</mat-icon>
+        </button>
+
+        <mat-form-field appearance="outline" class="field-date">
+          <mat-label>Datum</mat-label>
+          <input matInput [matDatepicker]="picker" [formControl]="date" />
+          <mat-datepicker-toggle matIconSuffix [for]="picker" />
+          <mat-datepicker #picker />
+        </mat-form-field>
+
+        <button mat-icon-button type="button" class="btn-step" matTooltip="Nächster Tag"
+                [disabled]="isToday" (click)="stepDay(1)">
+          <mat-icon>chevron_right</mat-icon>
+        </button>
+
+        @if (relativeLabel) {
+          <span class="date-rel">{{ relativeLabel }}</span>
+        }
+
+        <button mat-stroked-button type="button" class="btn-today"
+                [disabled]="isToday" (click)="goToToday()">
+          Heute
+        </button>
+      </div>
 
       <button mat-flat-button type="button" class="btn-add" (click)="openAddDialog()">
         <mat-icon>add</mat-icon>

--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
@@ -12,7 +12,7 @@ import {MatTooltip} from '@angular/material/tooltip';
 import {MatDialog} from '@angular/material/dialog';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {EMPTY, switchMap} from 'rxjs';
-import {format} from 'date-fns';
+import {addDays, differenceInCalendarDays, format, isSameDay, startOfDay} from 'date-fns';
 import {NutritionService} from '../../services/nutrition.service';
 import {DaySummary, FoodEntryInput, MealEntry, MealEntryUpdate, MealType} from '../../models/nutrition.model';
 import {
@@ -89,6 +89,38 @@ export class NutritionDayComponent implements OnInit {
 
   private get isoDate(): string {
     return format(this.date.value, 'yyyy-MM-dd');
+  }
+
+  /** True when the selected date is today; stepping forward is then disabled. */
+  get isToday(): boolean {
+    return isSameDay(this.date.value, new Date());
+  }
+
+  /** Relative orientation label (Heute / Gestern / Vorgestern) or null. */
+  get relativeLabel(): string | null {
+    const diff = differenceInCalendarDays(startOfDay(this.date.value), startOfDay(new Date()));
+    switch (diff) {
+      case 0:
+        return 'Heute';
+      case -1:
+        return 'Gestern';
+      case -2:
+        return 'Vorgestern';
+      default:
+        return null;
+    }
+  }
+
+  /** Step the diary date by the given number of days. */
+  stepDay(days: number): void {
+    this.date.setValue(addDays(this.date.value, days));
+  }
+
+  /** Jump back to today. */
+  goToToday(): void {
+    if (!this.isToday) {
+      this.date.setValue(new Date());
+    }
   }
 
   private load(): void {


### PR DESCRIPTION
## Summary
Adds day-by-day navigation to the nutrition diary so changing the diary date no longer requires opening the Material datepicker each time.

- `‹` / `›` chevron buttons step the diary date by one day.
- A **Heute** shortcut jumps back to today.
- A relative label (Heute / Gestern / Vorgestern) shows next to the date for orientation.
- The next-day control and the **Heute** button are disabled when the selected date is today (future days have no data).

Date math uses `date-fns` (the library this component already imports). Build passes (`npm run build`).

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)