### PR TITLE
feat(nutrition): prevent wheel scroll on number inputs and add inputmode

### DIFF
--- a/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.html
+++ b/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.html
@@ -54,22 +54,22 @@
       <form class="grid" [formGroup]="valuesForm">
         <mat-form-field appearance="outline">
           <mat-label>kcal</mat-label>
-          <input matInput type="number" step="1" formControlName="kcal" />
+          <input matInput type="number" step="1" inputmode="numeric" formControlName="kcal" />
         </mat-form-field>
 
         <mat-form-field appearance="outline">
           <mat-label>Protein (g)</mat-label>
-          <input matInput type="number" step="0.1" formControlName="proteinG" />
+          <input matInput type="number" step="0.1" inputmode="decimal" formControlName="proteinG" />
         </mat-form-field>
 
         <mat-form-field appearance="outline">
           <mat-label>Kohlenhydrate (g)</mat-label>
-          <input matInput type="number" step="0.1" formControlName="carbsG" />
+          <input matInput type="number" step="0.1" inputmode="decimal" formControlName="carbsG" />
         </mat-form-field>
 
         <mat-form-field appearance="outline">
           <mat-label>Fett (g)</mat-label>
-          <input matInput type="number" step="0.1" formControlName="fatG" />
+          <input matInput type="number" step="0.1" inputmode="decimal" formControlName="fatG" />
         </mat-form-field>
       </form>
 

--- a/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.ts
+++ b/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.ts
@@ -2,6 +2,7 @@ import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit} f
 import {FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
 import {MatFormField, MatHint, MatLabel} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
+import {NoWheelDirective} from '../../directives/no-wheel.directive';
 import {MatSelect} from '@angular/material/select';
 import {MatOption} from '@angular/material/core';
 import {MatDatepicker, MatDatepickerInput, MatDatepickerToggle} from '@angular/material/datepicker';
@@ -32,6 +33,7 @@ const MEAL_TYPES: { value: MealType; label: string }[] = [
     MatLabel,
     MatHint,
     MatInput,
+    NoWheelDirective,
     MatSelect,
     MatOption,
     MatDatepicker,

--- a/src/app/nutrition/components/nutrition-profile/nutrition-profile.component.html
+++ b/src/app/nutrition/components/nutrition-profile/nutrition-profile.component.html
@@ -29,7 +29,7 @@
 
         <mat-form-field appearance="outline">
           <mat-label>Größe (cm)</mat-label>
-          <input matInput type="number" formControlName="heightCm" />
+          <input matInput type="number" inputmode="numeric" formControlName="heightCm" />
         </mat-form-field>
 
         <mat-form-field appearance="outline">
@@ -52,19 +52,19 @@
 
         <mat-form-field appearance="outline">
           <mat-label>Protein pro kg</mat-label>
-          <input matInput type="number" step="0.1" formControlName="proteinPerKg" />
+          <input matInput type="number" step="0.1" inputmode="decimal" formControlName="proteinPerKg" />
           <span matTextSuffix>g/kg</span>
         </mat-form-field>
 
         <mat-form-field appearance="outline">
           <mat-label>Fettanteil</mat-label>
-          <input matInput type="number" formControlName="fatPctPercent" />
+          <input matInput type="number" inputmode="numeric" formControlName="fatPctPercent" />
           <span matTextSuffix>%</span>
         </mat-form-field>
 
         <mat-form-field appearance="outline">
           <mat-label>Grundumsatz (manuell)</mat-label>
-          <input matInput type="number" formControlName="basalKcal" />
+          <input matInput type="number" inputmode="numeric" formControlName="basalKcal" />
           <span matTextSuffix>kcal</span>
           <mat-hint>Optional — überschreibt die Formel, wenn gesetzt</mat-hint>
         </mat-form-field>

--- a/src/app/nutrition/components/nutrition-profile/nutrition-profile.component.ts
+++ b/src/app/nutrition/components/nutrition-profile/nutrition-profile.component.ts
@@ -3,6 +3,7 @@ import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/
 import {HttpErrorResponse} from '@angular/common/http';
 import {MatFormField, MatHint, MatLabel, MatSuffix} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
+import {NoWheelDirective} from '../../directives/no-wheel.directive';
 import {MatOption, MatSelect} from '@angular/material/select';
 import {MatDatepicker, MatDatepickerInput, MatDatepickerToggle} from '@angular/material/datepicker';
 import {MatButton} from '@angular/material/button';
@@ -23,6 +24,7 @@ import {TargetsCardComponent} from '../targets-card/targets-card.component';
     MatHint,
     MatSuffix,
     MatInput,
+    NoWheelDirective,
     MatSelect,
     MatOption,
     MatDatepicker,

--- a/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.html
+++ b/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.html
@@ -18,7 +18,7 @@
 
       <mat-form-field appearance="outline" class="field-weight">
         <mat-label>Gewicht (kg)</mat-label>
-        <input matInput type="number" step="0.1" formControlName="weightKg" />
+        <input matInput type="number" step="0.1" inputmode="decimal" formControlName="weightKg" />
       </mat-form-field>
 
       <button mat-flat-button type="submit" class="btn-add" [disabled]="form.invalid || saving">

--- a/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.ts
+++ b/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.ts
@@ -17,6 +17,7 @@ import {
 } from '@angular/material/table';
 import {MatFormField, MatLabel, MatSuffix} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
+import {NoWheelDirective} from '../../directives/no-wheel.directive';
 import {MatDatepicker, MatDatepickerInput, MatDatepickerToggle} from '@angular/material/datepicker';
 import {MatButton, MatIconButton} from '@angular/material/button';
 import {MatIcon} from '@angular/material/icon';
@@ -53,6 +54,7 @@ import {WeightDeleteDialogComponent} from '../../dialogs/weight-delete-dialog/we
     MatLabel,
     MatSuffix,
     MatInput,
+    NoWheelDirective,
     MatDatepicker,
     MatDatepickerInput,
     MatDatepickerToggle,

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.html
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.html
@@ -40,7 +40,7 @@
 
     <mat-form-field appearance="outline" class="field-full">
       <mat-label>Menge</mat-label>
-      <input matInput type="number" step="1" formControlName="quantityG" />
+      <input matInput type="number" step="1" inputmode="numeric" formControlName="quantityG" />
       <span matSuffix>g</span>
     </mat-form-field>
 

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.ts
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.ts
@@ -5,6 +5,7 @@ import {FormControl, FormGroup, ReactiveFormsModule, Validators} from '@angular/
 import {MAT_DIALOG_DATA, MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
 import {MatFormField, MatLabel, MatSuffix} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
+import {NoWheelDirective} from '../../directives/no-wheel.directive';
 import {MatSelect} from '@angular/material/select';
 import {MatOption} from '@angular/material/core';
 import {MatAutocomplete, MatAutocompleteSelectedEvent, MatAutocompleteTrigger} from '@angular/material/autocomplete';
@@ -48,6 +49,7 @@ const MEAL_TYPES: { value: MealType; label: string }[] = [
     MatLabel,
     MatSuffix,
     MatInput,
+    NoWheelDirective,
     MatSelect,
     MatOption,
     MatAutocomplete,

--- a/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.html
+++ b/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.html
@@ -22,28 +22,28 @@
       <div class="grid">
         <mat-form-field appearance="outline">
           <mat-label>kcal</mat-label>
-          <input matInput type="number" step="1" formControlName="kcal" />
+          <input matInput type="number" step="1" inputmode="numeric" formControlName="kcal" />
         </mat-form-field>
 
         <mat-form-field appearance="outline">
           <mat-label>Protein (g)</mat-label>
-          <input matInput type="number" step="0.1" formControlName="proteinG" />
+          <input matInput type="number" step="0.1" inputmode="decimal" formControlName="proteinG" />
         </mat-form-field>
 
         <mat-form-field appearance="outline">
           <mat-label>Kohlenhydrate (g)</mat-label>
-          <input matInput type="number" step="0.1" formControlName="carbsG" />
+          <input matInput type="number" step="0.1" inputmode="decimal" formControlName="carbsG" />
         </mat-form-field>
 
         <mat-form-field appearance="outline">
           <mat-label>Fett (g)</mat-label>
-          <input matInput type="number" step="0.1" formControlName="fatG" />
+          <input matInput type="number" step="0.1" inputmode="decimal" formControlName="fatG" />
         </mat-form-field>
       </div>
     } @else {
       <mat-form-field appearance="outline" class="field-full">
         <mat-label>Menge</mat-label>
-        <input matInput type="number" step="1" formControlName="quantityG" />
+        <input matInput type="number" step="1" inputmode="numeric" formControlName="quantityG" />
         <span matSuffix>g</span>
       </mat-form-field>
     }

--- a/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.ts
+++ b/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.ts
@@ -3,6 +3,7 @@ import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/
 import {MAT_DIALOG_DATA, MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
 import {MatFormField, MatLabel, MatSuffix} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
+import {NoWheelDirective} from '../../directives/no-wheel.directive';
 import {MatSelect} from '@angular/material/select';
 import {MatOption} from '@angular/material/core';
 import {MatIcon} from '@angular/material/icon';
@@ -34,6 +35,7 @@ const MEAL_TYPES: { value: MealType; label: string }[] = [
     MatLabel,
     MatSuffix,
     MatInput,
+    NoWheelDirective,
     MatSelect,
     MatOption,
     MatIcon,

--- a/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.html
+++ b/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.html
@@ -15,32 +15,32 @@
     <div class="grid">
       <mat-form-field appearance="outline">
         <mat-label>kcal / 100 g</mat-label>
-        <input matInput type="number" step="1" formControlName="kcalPer100" />
+        <input matInput type="number" step="1" inputmode="numeric" formControlName="kcalPer100" />
       </mat-form-field>
 
       <mat-form-field appearance="outline">
         <mat-label>Protein (g)</mat-label>
-        <input matInput type="number" step="0.1" formControlName="proteinPer100" />
+        <input matInput type="number" step="0.1" inputmode="decimal" formControlName="proteinPer100" />
       </mat-form-field>
 
       <mat-form-field appearance="outline">
         <mat-label>Kohlenhydrate (g)</mat-label>
-        <input matInput type="number" step="0.1" formControlName="carbsPer100" />
+        <input matInput type="number" step="0.1" inputmode="decimal" formControlName="carbsPer100" />
       </mat-form-field>
 
       <mat-form-field appearance="outline">
         <mat-label>Fett (g)</mat-label>
-        <input matInput type="number" step="0.1" formControlName="fatPer100" />
+        <input matInput type="number" step="0.1" inputmode="decimal" formControlName="fatPer100" />
       </mat-form-field>
 
       <mat-form-field appearance="outline">
         <mat-label>Ballaststoffe (g)</mat-label>
-        <input matInput type="number" step="0.1" formControlName="fiberPer100" />
+        <input matInput type="number" step="0.1" inputmode="decimal" formControlName="fiberPer100" />
       </mat-form-field>
 
       <mat-form-field appearance="outline">
         <mat-label>Portion (g)</mat-label>
-        <input matInput type="number" step="1" formControlName="defaultServingG" />
+        <input matInput type="number" step="1" inputmode="numeric" formControlName="defaultServingG" />
       </mat-form-field>
     </div>
   </form>

--- a/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.ts
+++ b/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.ts
@@ -3,6 +3,7 @@ import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/
 import {MAT_DIALOG_DATA, MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
 import {MatFormField, MatLabel} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
+import {NoWheelDirective} from '../../directives/no-wheel.directive';
 import {MatIcon} from '@angular/material/icon';
 import {MatMiniFabButton} from '@angular/material/button';
 import {Food, FoodDraft, FoodInput, FoodSource} from '../../models/nutrition.model';
@@ -33,6 +34,7 @@ export interface FoodEditDialogData {
     MatFormField,
     MatLabel,
     MatInput,
+    NoWheelDirective,
     MatIcon,
     MatMiniFabButton
   ],

--- a/src/app/nutrition/dialogs/weight-edit-dialog/weight-edit-dialog.component.html
+++ b/src/app/nutrition/dialogs/weight-edit-dialog/weight-edit-dialog.component.html
@@ -11,7 +11,7 @@
 
     <mat-form-field appearance="outline" class="field-full">
       <mat-label>Gewicht (kg)</mat-label>
-      <input matInput type="number" step="0.1" formControlName="weightKg" />
+      <input matInput type="number" step="0.1" inputmode="decimal" formControlName="weightKg" />
     </mat-form-field>
   </form>
 </mat-dialog-content>

--- a/src/app/nutrition/dialogs/weight-edit-dialog/weight-edit-dialog.component.ts
+++ b/src/app/nutrition/dialogs/weight-edit-dialog/weight-edit-dialog.component.ts
@@ -3,6 +3,7 @@ import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/
 import {MAT_DIALOG_DATA, MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
 import {MatFormField, MatLabel, MatSuffix} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
+import {NoWheelDirective} from '../../directives/no-wheel.directive';
 import {MatDatepicker, MatDatepickerInput, MatDatepickerToggle} from '@angular/material/datepicker';
 import {MatIcon} from '@angular/material/icon';
 import {MatMiniFabButton} from '@angular/material/button';
@@ -22,6 +23,7 @@ import {WeightEntry, WeightEntryInput} from '../../models/nutrition.model';
     MatLabel,
     MatSuffix,
     MatInput,
+    NoWheelDirective,
     MatDatepicker,
     MatDatepickerInput,
     MatDatepickerToggle,

--- a/src/app/nutrition/directives/no-wheel.directive.ts
+++ b/src/app/nutrition/directives/no-wheel.directive.ts
@@ -1,0 +1,23 @@
+import {Directive, HostListener} from '@angular/core';
+
+/**
+ * Prevents mouse-wheel scrolling from silently changing the value of a focused
+ * `<input type="number">`. When the input is focused and the user scrolls, the
+ * browser would otherwise increment/decrement the value (a data-loss bug). This
+ * blurs the input and stops the default wheel behaviour so the page scrolls
+ * instead of mutating the field.
+ */
+@Directive({
+  selector: 'input[type=number]'
+})
+export class NoWheelDirective {
+
+  @HostListener('wheel', ['$event'])
+  onWheel(event: WheelEvent): void {
+    const target = event.target as HTMLElement;
+    if (document.activeElement === target) {
+      event.preventDefault();
+      target.blur();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Fixes two UX/data-loss issues affecting every `<input type="number">` in the nutrition module (#205):

1. **Wheel scroll mutating values** — a new standalone `NoWheelDirective` (selector `input[type=number]`) blurs the focused input and calls `preventDefault()` on the `wheel` event, so scrolling the page no longer silently increments/decrements a focused number field. Imported into each nutrition component that has number inputs.
2. **Missing `inputmode`** — added `inputmode="numeric"` to integer fields (kcal, quantity, height, percent, basal, serving) and `inputmode="decimal"` to fractional fields (weight, macros, protein/kg) so mobile users get the right keypad.

## Directive
`src/app/nutrition/directives/no-wheel.directive.ts`

## Inputs touched
- add-day-entry: `quantityG`
- entry-edit: `kcal`, `proteinG`, `carbsG`, `fatG`, `quantityG`
- weight + weight-edit: `weightKg`
- profile: `heightCm`, `proteinPerKg`, `fatPctPercent`, `basalKcal`
- food-edit: `kcalPer100`, `proteinPer100`, `carbsPer100`, `fatPer100`, `fiberPer100`, `defaultServingG`
- canteen: `kcal`, `proteinG`, `carbsG`, `fatG`

## Build
`npm run build` succeeds.

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)