### PR TITLE
feat(nutrition): show validation errors on disabled-button forms

### DIFF
--- a/src/app/nutrition/components/nutrition-profile/nutrition-profile.component.html
+++ b/src/app/nutrition/components/nutrition-profile/nutrition-profile.component.html
@@ -25,11 +25,19 @@
           <input matInput formControlName="birthDate" [matDatepicker]="picker" />
           <mat-datepicker-toggle matIconSuffix [for]="picker" />
           <mat-datepicker #picker />
+          @if (form.get('birthDate')?.hasError('required')) {
+            <mat-error>Geburtsdatum ist erforderlich</mat-error>
+          }
         </mat-form-field>
 
         <mat-form-field appearance="outline">
           <mat-label>Größe (cm)</mat-label>
           <input matInput type="number" inputmode="numeric" formControlName="heightCm" />
+          @if (form.get('heightCm')?.hasError('required')) {
+            <mat-error>Größe ist erforderlich</mat-error>
+          } @else if (form.get('heightCm')?.hasError('min')) {
+            <mat-error>Muss 0 oder größer sein</mat-error>
+          }
         </mat-form-field>
 
         <mat-form-field appearance="outline">
@@ -54,12 +62,24 @@
           <mat-label>Protein pro kg</mat-label>
           <input matInput type="number" step="0.1" inputmode="decimal" formControlName="proteinPerKg" />
           <span matTextSuffix>g/kg</span>
+          @if (form.get('proteinPerKg')?.hasError('required')) {
+            <mat-error>Protein pro kg ist erforderlich</mat-error>
+          } @else if (form.get('proteinPerKg')?.hasError('min')) {
+            <mat-error>Muss 0 oder größer sein</mat-error>
+          }
         </mat-form-field>
 
         <mat-form-field appearance="outline">
           <mat-label>Fettanteil</mat-label>
           <input matInput type="number" inputmode="numeric" formControlName="fatPctPercent" />
           <span matTextSuffix>%</span>
+          @if (form.get('fatPctPercent')?.hasError('required')) {
+            <mat-error>Fettanteil ist erforderlich</mat-error>
+          } @else if (form.get('fatPctPercent')?.hasError('min')) {
+            <mat-error>Muss 0 oder größer sein</mat-error>
+          } @else if (form.get('fatPctPercent')?.hasError('max')) {
+            <mat-error>Höchstens 100 %</mat-error>
+          }
         </mat-form-field>
 
         <mat-form-field appearance="outline">
@@ -67,6 +87,9 @@
           <input matInput type="number" inputmode="numeric" formControlName="basalKcal" />
           <span matTextSuffix>kcal</span>
           <mat-hint>Optional — überschreibt die Formel, wenn gesetzt</mat-hint>
+          @if (form.get('basalKcal')?.hasError('min')) {
+            <mat-error>Muss 0 oder größer sein</mat-error>
+          }
         </mat-form-field>
       </div>
 

--- a/src/app/nutrition/components/nutrition-profile/nutrition-profile.component.ts
+++ b/src/app/nutrition/components/nutrition-profile/nutrition-profile.component.ts
@@ -1,7 +1,7 @@
 import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit, ViewChild} from '@angular/core';
 import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
 import {HttpErrorResponse} from '@angular/common/http';
-import {MatFormField, MatHint, MatLabel, MatSuffix} from '@angular/material/form-field';
+import {MatError, MatFormField, MatHint, MatLabel, MatSuffix} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
 import {NoWheelDirective} from '../../directives/no-wheel.directive';
 import {MatOption, MatSelect} from '@angular/material/select';
@@ -22,6 +22,7 @@ import {TargetsCardComponent} from '../targets-card/targets-card.component';
     MatFormField,
     MatLabel,
     MatHint,
+    MatError,
     MatSuffix,
     MatInput,
     NoWheelDirective,

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.html
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.html
@@ -42,6 +42,11 @@
       <mat-label>Menge</mat-label>
       <input matInput type="number" step="1" inputmode="numeric" formControlName="quantityG" />
       <span matSuffix>g</span>
+      @if (quantityG.hasError('required')) {
+        <mat-error>Menge ist erforderlich</mat-error>
+      } @else if (quantityG.hasError('min')) {
+        <mat-error>Muss 0 oder größer sein</mat-error>
+      }
     </mat-form-field>
 
     @if (selected) {

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.ts
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.ts
@@ -3,7 +3,7 @@ import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {DecimalPipe} from '@angular/common';
 import {FormControl, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
 import {MAT_DIALOG_DATA, MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
-import {MatFormField, MatLabel, MatSuffix} from '@angular/material/form-field';
+import {MatError, MatFormField, MatLabel, MatSuffix} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
 import {NoWheelDirective} from '../../directives/no-wheel.directive';
 import {MatSelect} from '@angular/material/select';
@@ -47,6 +47,7 @@ const MEAL_TYPES: { value: MealType; label: string }[] = [
     MatDialogClose,
     MatFormField,
     MatLabel,
+    MatError,
     MatSuffix,
     MatInput,
     NoWheelDirective,

--- a/src/app/nutrition/dialogs/barcode-scan-dialog/barcode-scan-dialog.component.html
+++ b/src/app/nutrition/dialogs/barcode-scan-dialog/barcode-scan-dialog.component.html
@@ -32,6 +32,11 @@
         <mat-form-field appearance="outline" class="manual__field">
           <mat-label>Barcode (EAN)</mat-label>
           <input matInput inputmode="numeric" autocomplete="off" [formControl]="manualEan" />
+          @if (manualEan.hasError('pattern')) {
+            <mat-error>8–14 Ziffern</mat-error>
+          } @else {
+            <mat-hint>8–14 Ziffern</mat-hint>
+          }
         </mat-form-field>
         <button mat-flat-button type="submit" class="btn-lookup" [disabled]="looking">
           <mat-icon>search</mat-icon>

--- a/src/app/nutrition/dialogs/barcode-scan-dialog/barcode-scan-dialog.component.ts
+++ b/src/app/nutrition/dialogs/barcode-scan-dialog/barcode-scan-dialog.component.ts
@@ -10,7 +10,7 @@ import {
 } from '@angular/core';
 import {FormControl, ReactiveFormsModule, Validators} from '@angular/forms';
 import {MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
-import {MatFormField, MatLabel} from '@angular/material/form-field';
+import {MatError, MatFormField, MatHint, MatLabel} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
 import {MatIcon} from '@angular/material/icon';
 import {MatButton, MatMiniFabButton} from '@angular/material/button';
@@ -51,6 +51,8 @@ const EAN_PATTERN = /^\d{8,14}$/;
     MatDialogClose,
     MatFormField,
     MatLabel,
+    MatError,
+    MatHint,
     MatInput,
     MatIcon,
     MatButton,

--- a/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.html
+++ b/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.html
@@ -5,6 +5,9 @@
     <mat-form-field appearance="outline" class="field-full">
       <mat-label>Name</mat-label>
       <input matInput formControlName="name" />
+      @if (form.get('name')?.hasError('required')) {
+        <mat-error>Name ist erforderlich</mat-error>
+      }
     </mat-form-field>
 
     <mat-form-field appearance="outline" class="field-full">
@@ -16,31 +19,57 @@
       <mat-form-field appearance="outline">
         <mat-label>kcal / 100 g</mat-label>
         <input matInput type="number" step="1" inputmode="numeric" formControlName="kcalPer100" />
+        @if (form.get('kcalPer100')?.hasError('required')) {
+          <mat-error>Erforderlich</mat-error>
+        } @else if (form.get('kcalPer100')?.hasError('min')) {
+          <mat-error>Muss 0 oder größer sein</mat-error>
+        }
       </mat-form-field>
 
       <mat-form-field appearance="outline">
         <mat-label>Protein (g)</mat-label>
         <input matInput type="number" step="0.1" inputmode="decimal" formControlName="proteinPer100" />
+        @if (form.get('proteinPer100')?.hasError('required')) {
+          <mat-error>Erforderlich</mat-error>
+        } @else if (form.get('proteinPer100')?.hasError('min')) {
+          <mat-error>Muss 0 oder größer sein</mat-error>
+        }
       </mat-form-field>
 
       <mat-form-field appearance="outline">
         <mat-label>Kohlenhydrate (g)</mat-label>
         <input matInput type="number" step="0.1" inputmode="decimal" formControlName="carbsPer100" />
+        @if (form.get('carbsPer100')?.hasError('required')) {
+          <mat-error>Erforderlich</mat-error>
+        } @else if (form.get('carbsPer100')?.hasError('min')) {
+          <mat-error>Muss 0 oder größer sein</mat-error>
+        }
       </mat-form-field>
 
       <mat-form-field appearance="outline">
         <mat-label>Fett (g)</mat-label>
         <input matInput type="number" step="0.1" inputmode="decimal" formControlName="fatPer100" />
+        @if (form.get('fatPer100')?.hasError('required')) {
+          <mat-error>Erforderlich</mat-error>
+        } @else if (form.get('fatPer100')?.hasError('min')) {
+          <mat-error>Muss 0 oder größer sein</mat-error>
+        }
       </mat-form-field>
 
       <mat-form-field appearance="outline">
         <mat-label>Ballaststoffe (g)</mat-label>
         <input matInput type="number" step="0.1" inputmode="decimal" formControlName="fiberPer100" />
+        @if (form.get('fiberPer100')?.hasError('min')) {
+          <mat-error>Muss 0 oder größer sein</mat-error>
+        }
       </mat-form-field>
 
       <mat-form-field appearance="outline">
         <mat-label>Portion (g)</mat-label>
         <input matInput type="number" step="1" inputmode="numeric" formControlName="defaultServingG" />
+        @if (form.get('defaultServingG')?.hasError('min')) {
+          <mat-error>Muss 0 oder größer sein</mat-error>
+        }
       </mat-form-field>
     </div>
   </form>

--- a/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.ts
+++ b/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.ts
@@ -1,7 +1,7 @@
 import {ChangeDetectionStrategy, Component, inject, OnInit} from '@angular/core';
 import {FormBuilder, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
 import {MAT_DIALOG_DATA, MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
-import {MatFormField, MatLabel} from '@angular/material/form-field';
+import {MatError, MatFormField, MatLabel} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
 import {NoWheelDirective} from '../../directives/no-wheel.directive';
 import {MatIcon} from '@angular/material/icon';
@@ -33,6 +33,7 @@ export interface FoodEditDialogData {
     MatDialogClose,
     MatFormField,
     MatLabel,
+    MatError,
     MatInput,
     NoWheelDirective,
     MatIcon,


### PR DESCRIPTION
## Summary
- Add `mat-error` messages to nutrition-profile, food-edit-dialog, barcode-scan-dialog, and add-day-entry-dialog so users can see why submit/confirm buttons are disabled
- Add `mat-hint`/`mat-error` "8–14 Ziffern" for the barcode-scan manual EAN field

## Test plan
- [x] `npm run build` succeeds

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)