### PR TITLE
feat(nutrition): label confirm/cancel buttons in edit dialogs

### DIFF
--- a/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.css
+++ b/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.css
@@ -84,12 +84,29 @@
 
 ::ng-deep .mat-mdc-form-field.mat-focused .mat-mdc-floating-label { color: var(--c-g) !important; }
 
+.btn-confirm,
+.btn-cancel {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.85rem;
+  font-weight: 600;
+  border-radius: 8px !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-confirm mat-icon,
+.btn-cancel mat-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+}
+
 .btn-confirm {
   background: rgba(45, 212, 191, 0.10) !important;
   border: 1px solid rgba(45, 212, 191, 0.3) !important;
-  border-radius: 8px !important;
   color: var(--c-n) !important;
-  transition: background 0.2s, box-shadow 0.2s;
 }
 
 .btn-confirm:hover:not([disabled]) {
@@ -104,9 +121,7 @@
 .btn-cancel {
   background: rgba(251, 113, 133, 0.10) !important;
   border: 1px solid rgba(251, 113, 133, 0.3) !important;
-  border-radius: 8px !important;
   color: var(--c-e) !important;
-  transition: background 0.2s, box-shadow 0.2s;
 }
 
 .btn-cancel:hover {
@@ -115,3 +130,11 @@
 }
 
 .btn-cancel mat-icon { color: var(--c-e) !important; }
+
+@media (max-width: 420px) {
+  .btn-confirm,
+  .btn-cancel {
+    flex: 1;
+    justify-content: center;
+  }
+}

--- a/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.html
+++ b/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.html
@@ -51,10 +51,12 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="center">
-  <button mat-mini-fab class="btn-confirm" [disabled]="form.invalid" (click)="save()">
+  <button mat-flat-button type="button" class="btn-confirm" [disabled]="form.invalid" (click)="save()">
     <mat-icon>check_circle</mat-icon>
+    Speichern
   </button>
-  <button mat-mini-fab mat-dialog-close class="btn-cancel">
+  <button mat-stroked-button type="button" mat-dialog-close class="btn-cancel">
     <mat-icon>close</mat-icon>
+    Abbrechen
   </button>
 </mat-dialog-actions>

--- a/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.ts
+++ b/src/app/nutrition/dialogs/entry-edit-dialog/entry-edit-dialog.component.ts
@@ -7,7 +7,7 @@ import {NoWheelDirective} from '../../directives/no-wheel.directive';
 import {MatSelect} from '@angular/material/select';
 import {MatOption} from '@angular/material/core';
 import {MatIcon} from '@angular/material/icon';
-import {MatMiniFabButton} from '@angular/material/button';
+import {MatButton} from '@angular/material/button';
 import {MealEntry, MealEntryUpdate, MealType} from '../../models/nutrition.model';
 
 const MEAL_TYPES: { value: MealType; label: string }[] = [
@@ -39,7 +39,7 @@ const MEAL_TYPES: { value: MealType; label: string }[] = [
     MatSelect,
     MatOption,
     MatIcon,
-    MatMiniFabButton
+    MatButton
   ],
   templateUrl: './entry-edit-dialog.component.html',
   styleUrl: './entry-edit-dialog.component.css'

--- a/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.css
+++ b/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.css
@@ -88,12 +88,29 @@
 }
 
 /* Buttons */
+.btn-confirm,
+.btn-cancel {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.85rem;
+  font-weight: 600;
+  border-radius: 8px !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-confirm mat-icon,
+.btn-cancel mat-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+}
+
 .btn-confirm {
   background: rgba(45, 212, 191, 0.10) !important;
   border: 1px solid rgba(45, 212, 191, 0.3) !important;
-  border-radius: 8px !important;
   color: var(--c-n) !important;
-  transition: background 0.2s, box-shadow 0.2s;
 }
 
 .btn-confirm:hover:not([disabled]) {
@@ -110,9 +127,7 @@
 .btn-cancel {
   background: rgba(251, 113, 133, 0.10) !important;
   border: 1px solid rgba(251, 113, 133, 0.3) !important;
-  border-radius: 8px !important;
   color: var(--c-e) !important;
-  transition: background 0.2s, box-shadow 0.2s;
 }
 
 .btn-cancel:hover {
@@ -121,3 +136,11 @@
 }
 
 .btn-cancel mat-icon { color: var(--c-e) !important; }
+
+@media (max-width: 420px) {
+  .btn-confirm,
+  .btn-cancel {
+    flex: 1;
+    justify-content: center;
+  }
+}

--- a/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.html
+++ b/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.html
@@ -76,10 +76,12 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="center">
-  <button mat-mini-fab class="btn-confirm" [disabled]="form.invalid" (click)="save()">
+  <button mat-flat-button type="button" class="btn-confirm" [disabled]="form.invalid" (click)="save()">
     <mat-icon>check_circle</mat-icon>
+    Speichern
   </button>
-  <button mat-mini-fab mat-dialog-close class="btn-cancel">
+  <button mat-stroked-button type="button" mat-dialog-close class="btn-cancel">
     <mat-icon>close</mat-icon>
+    Abbrechen
   </button>
 </mat-dialog-actions>

--- a/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.ts
+++ b/src/app/nutrition/dialogs/food-edit-dialog/food-edit-dialog.component.ts
@@ -5,7 +5,7 @@ import {MatError, MatFormField, MatLabel} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
 import {NoWheelDirective} from '../../directives/no-wheel.directive';
 import {MatIcon} from '@angular/material/icon';
-import {MatMiniFabButton} from '@angular/material/button';
+import {MatButton} from '@angular/material/button';
 import {Food, FoodDraft, FoodInput, FoodSource} from '../../models/nutrition.model';
 
 /**
@@ -37,7 +37,7 @@ export interface FoodEditDialogData {
     MatInput,
     NoWheelDirective,
     MatIcon,
-    MatMiniFabButton
+    MatButton
   ],
   templateUrl: './food-edit-dialog.component.html',
   styleUrl: './food-edit-dialog.component.css'


### PR DESCRIPTION
## Summary
- Replace the icon-only `mat-mini-fab` confirm/cancel buttons in `food-edit-dialog` and `entry-edit-dialog` with labeled `Speichern`/`Abbrechen` buttons, matching the existing pattern in `add-day-entry-dialog`.
- Keeps the existing `save()` click handler and `[disabled]="form.invalid"` validation-hint behavior from #215 intact.
- Adds matching button layout/responsive CSS (icon + label, stacked full-width on narrow screens) to both dialogs' stylesheets.

Closes #207

## Test plan
- [x] `npm run build` succeeds
- [ ] Manually open "Edit food" and "Edit entry" dialogs and verify the Speichern/Abbrechen buttons render with labels, are keyboard accessible, and disable correctly when the form is invalid