### PR TITLE
feat(nutrition): add-entry dialog focus flow and clearer save action

### DIFF
--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.html
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.html
@@ -40,7 +40,7 @@
 
     <mat-form-field appearance="outline" class="field-full">
       <mat-label>Menge</mat-label>
-      <input matInput type="number" step="1" inputmode="numeric" formControlName="quantityG" />
+      <input matInput #quantityInput type="number" step="1" inputmode="numeric" formControlName="quantityG" />
       <span matSuffix>g</span>
       @if (quantityG.hasError('required')) {
         <mat-error>Menge ist erforderlich</mat-error>
@@ -74,7 +74,7 @@
 
       <button mat-stroked-button type="button" class="btn-add-staged" [disabled]="!canAdd" (click)="addToStaged()">
         <mat-icon>playlist_add</mat-icon>
-        Hinzufügen
+        Weiteres hinzufügen
       </button>
     }
   </form>
@@ -121,7 +121,11 @@
 <mat-dialog-actions align="center">
   <button mat-flat-button type="button" class="btn-confirm" [disabled]="!canSave" (click)="save()">
     <mat-icon>check_circle</mat-icon>
-    Speichern
+    @if (staged.length > 0) {
+      Speichern ({{ staged.length + (canAdd ? 1 : 0) }})
+    } @else {
+      Speichern
+    }
   </button>
   <button mat-stroked-button type="button" mat-dialog-close class="btn-cancel">
     <mat-icon>close</mat-icon>

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.ts
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, inject, OnInit} from '@angular/core';
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, ElementRef, inject, OnInit, ViewChild} from '@angular/core';
 import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import {DecimalPipe} from '@angular/common';
 import {FormControl, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
@@ -71,6 +71,8 @@ export class AddDayEntryDialogComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
   private data = inject<AddDayEntryDialogData>(MAT_DIALOG_DATA, {optional: true});
 
+  @ViewChild('quantityInput') quantityInput?: ElementRef<HTMLInputElement>;
+
   readonly mealTypes = MEAL_TYPES;
 
   mealType = new FormControl<MealType>(this.data?.mealType ?? 'LUNCH', {nonNullable: true});
@@ -126,6 +128,12 @@ export class AddDayEntryDialogComponent implements OnInit {
       this.quantityG.setValue(this.selected.defaultServingG);
     }
     this.cdr.markForCheck();
+    // Move focus to the quantity field after the value is patched and the input is rendered/enabled.
+    setTimeout(() => {
+      const input = this.quantityInput?.nativeElement;
+      input?.focus();
+      input?.select();
+    });
   }
 
   /** Macro value for the current portion, scaled from the per-100 g figure. */


### PR DESCRIPTION
## Summary
- After selecting a food from the autocomplete, focus now moves to the Menge (quantity) input so the user can immediately adjust the pre-filled value.
- Renamed the staging button from "Hinzufügen" to "Weiteres hinzufügen" to better convey it stages another item.
- "Speichern" now shows a count of items that will be saved (e.g. "Speichern (3)"), making it the clear primary action and clarifying that the currently selected-but-unstaged item is included.

Closes #208

## Test plan
- [x] `npm run build` succeeds
- [ ] Manually verify: select a food in the add-entry dialog → focus jumps to Menge field
- [ ] Manually verify: stage multiple items → "Speichern (n)" reflects staged + current selection count