### PR TITLE
feat(nutrition): cap date pickers at today and open birthdate at year view

### DIFF
--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.html
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.html
@@ -15,7 +15,7 @@
 
         <mat-form-field appearance="outline" class="field-date">
           <mat-label>Datum</mat-label>
-          <input matInput [matDatepicker]="picker" [formControl]="date" />
+          <input matInput [matDatepicker]="picker" [formControl]="date" [max]="today" />
           <mat-datepicker-toggle matIconSuffix [for]="picker" />
           <mat-datepicker #picker />
         </mat-form-field>

--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
@@ -71,6 +71,7 @@ const MEAL_GROUPS: { type: MealType; label: string }[] = [
 export class NutritionDayComponent implements OnInit {
 
   date = new FormControl<Date>(new Date(), {nonNullable: true});
+  readonly today = new Date();
   summary: DaySummary | null = null;
   loading = false;
   /** Set when the day summary cannot be loaded due to an error. */

--- a/src/app/nutrition/components/nutrition-profile/nutrition-profile.component.html
+++ b/src/app/nutrition/components/nutrition-profile/nutrition-profile.component.html
@@ -22,9 +22,9 @@
 
         <mat-form-field appearance="outline">
           <mat-label>Geburtsdatum</mat-label>
-          <input matInput formControlName="birthDate" [matDatepicker]="picker" />
+          <input matInput formControlName="birthDate" [matDatepicker]="picker" [max]="today" />
           <mat-datepicker-toggle matIconSuffix [for]="picker" />
-          <mat-datepicker #picker />
+          <mat-datepicker #picker startView="multi-year" />
           @if (form.get('birthDate')?.hasError('required')) {
             <mat-error>Geburtsdatum ist erforderlich</mat-error>
           }

--- a/src/app/nutrition/components/nutrition-profile/nutrition-profile.component.ts
+++ b/src/app/nutrition/components/nutrition-profile/nutrition-profile.component.ts
@@ -44,6 +44,7 @@ export class NutritionProfileComponent implements OnInit {
 
   form!: FormGroup;
   saving = false;
+  readonly today = new Date();
 
   readonly sexes: {value: Sex; label: string}[] = [
     {value: 'MALE', label: 'Männlich'},

--- a/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.html
+++ b/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.html
@@ -11,7 +11,7 @@
     <form class="add-form" [formGroup]="form" (ngSubmit)="add()">
       <mat-form-field appearance="outline" class="field-date">
         <mat-label>Datum</mat-label>
-        <input matInput formControlName="entryDate" [matDatepicker]="picker" />
+        <input matInput formControlName="entryDate" [matDatepicker]="picker" [max]="today" />
         <mat-datepicker-toggle matIconSuffix [for]="picker" />
         <mat-datepicker #picker />
       </mat-form-field>

--- a/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.ts
+++ b/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.ts
@@ -74,6 +74,7 @@ export class NutritionWeightComponent implements OnInit {
 
   form!: FormGroup;
   saving = false;
+  readonly today = new Date();
   entries = new MatTableDataSource<WeightEntry>();
   columnsToDisplay = ['entryDate', 'weightKg', 'actions'];
 


### PR DESCRIPTION
## Summary
- Add `[max]="today"` to the birthDate (profile), entryDate (weight), and diary date pickers so no future date can be selected.
- Set `startView="multi-year"` on the birthDate `mat-datepicker` so year selection is the first step instead of the day view.

Closes #209

## Test plan
- [x] `npm run build` succeeds
- [ ] Manually verify birthdate picker opens at year view and future dates are disabled
- [ ] Manually verify weight entry date and diary date pickers disable future dates