### PR TITLE
feat(nutrition): a11y labels, tooltips, range selector for dashboard charts

### DIFF
--- a/src/app/nutrition/components/nutrition-dashboard/nutrition-dashboard.component.css
+++ b/src/app/nutrition/components/nutrition-dashboard/nutrition-dashboard.component.css
@@ -116,10 +116,15 @@
   stroke-width: 1.5;
 }
 
-.bar { transition: opacity 0.2s; }
+.bar { transition: opacity 0.2s; cursor: pointer; }
 .bar--within { fill: var(--c-within); }
 .bar--under  { fill: var(--c-under); opacity: 0.65; }
-.bar--over   { fill: var(--c-over); }
+.bar--over   { fill: url(#overHatch); }
+
+.dot--w { cursor: pointer; }
+
+.hatch-bg { fill: var(--c-over); }
+.hatch-fg { fill: color-mix(in srgb, var(--c-over) 70%, black); }
 
 .target-line {
   stroke: var(--text-muted);
@@ -160,7 +165,44 @@
 
 .legend__item--within::before { background: var(--c-within); }
 .legend__item--under::before  { background: var(--c-under); opacity: 0.65; }
-.legend__item--over::before   { background: var(--c-over); }
+.legend__item--over::before {
+  background: repeating-linear-gradient(
+    135deg,
+    var(--c-over) 0 3px,
+    color-mix(in srgb, var(--c-over) 70%, black) 3px 6px
+  );
+}
+
+/* ── Range toggle ────────────────────────────────── */
+.range-toggle {
+  display: flex;
+  margin-bottom: 0.75rem;
+}
+
+::ng-deep .range-toggle .mat-button-toggle {
+  background: var(--raised);
+  color: var(--text-muted);
+}
+
+::ng-deep .range-toggle .mat-button-toggle-label-content {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.62rem;
+  line-height: 32px;
+  padding: 0 0.75rem;
+}
+
+::ng-deep .range-toggle .mat-button-toggle-checked {
+  background: color-mix(in srgb, var(--c-k) 18%, transparent);
+  color: var(--c-k);
+}
+
+::ng-deep .range-toggle.mat-button-toggle-group {
+  border-color: var(--border-mid);
+}
+
+::ng-deep .range-toggle .mat-button-toggle + .mat-button-toggle {
+  border-left: 1px solid var(--border-mid);
+}
 
 /* ── Stats ───────────────────────────────────────── */
 .stats {

--- a/src/app/nutrition/components/nutrition-dashboard/nutrition-dashboard.component.html
+++ b/src/app/nutrition/components/nutrition-dashboard/nutrition-dashboard.component.html
@@ -25,11 +25,14 @@
 
       @if (hasWeight) {
         <div class="chart">
-          <svg [attr.viewBox]="'0 0 ' + vbW + ' ' + vbH" preserveAspectRatio="none" class="svg">
+          <svg [attr.viewBox]="'0 0 ' + vbW + ' ' + vbH" preserveAspectRatio="none" class="svg"
+               role="img" [attr.aria-label]="weightChartLabel">
             <polygon class="area area--w" [attr.points]="weightArea" />
             <polyline class="line line--w" [attr.points]="weightLine" />
             @for (p of weightPoints; track p.label + p.x) {
-              <circle class="dot dot--w" [attr.cx]="p.x" [attr.cy]="p.y" r="2.4" />
+              <circle class="dot dot--w" [attr.cx]="p.x" [attr.cy]="p.y" r="2.4"
+                      tabindex="0" role="img" [attr.aria-label]="p.tooltip"
+                      [matTooltip]="p.tooltip" />
             }
           </svg>
         </div>
@@ -52,12 +55,29 @@
         }
       </header>
 
+      <mat-button-toggle-group class="range-toggle" name="intakeRange" aria-label="Zeitraum"
+                                [value]="intakeRangeDays"
+                                (change)="onIntakeRangeChange($event.value)">
+        @for (range of intakeRanges; track range) {
+          <mat-button-toggle [value]="range">{{ range }} Tage</mat-button-toggle>
+        }
+      </mat-button-toggle-group>
+
       @if (hasIntake) {
         <div class="chart">
-          <svg [attr.viewBox]="'0 0 ' + vbW + ' ' + vbH" class="svg">
+          <svg [attr.viewBox]="'0 0 ' + vbW + ' ' + vbH" class="svg"
+               role="img" [attr.aria-label]="intakeChartLabel">
+            <defs>
+              <pattern id="overHatch" width="6" height="6" patternUnits="userSpaceOnUse" patternTransform="rotate(135)">
+                <rect width="6" height="6" class="hatch-bg" />
+                <rect width="3" height="6" class="hatch-fg" />
+              </pattern>
+            </defs>
             @for (d of intakeDays; track d.date) {
               <rect class="bar bar--{{ d.state }}"
-                    [attr.x]="d.x" [attr.y]="d.y" [attr.width]="barWidth" [attr.height]="d.h" rx="1.5" />
+                    [attr.x]="d.x" [attr.y]="d.y" [attr.width]="barWidth" [attr.height]="d.h" rx="1.5"
+                    tabindex="0" role="img" [attr.aria-label]="d.tooltip"
+                    [matTooltip]="d.tooltip" />
             }
             @if (intakeTargetY !== null) {
               <line class="target-line"

--- a/src/app/nutrition/components/nutrition-dashboard/nutrition-dashboard.component.ts
+++ b/src/app/nutrition/components/nutrition-dashboard/nutrition-dashboard.component.ts
@@ -1,6 +1,8 @@
 import {ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, OnInit} from '@angular/core';
 import {DecimalPipe} from '@angular/common';
 import {MatProgressSpinner} from '@angular/material/progress-spinner';
+import {MatTooltipModule} from '@angular/material/tooltip';
+import {MatButtonToggleModule} from '@angular/material/button-toggle';
 import {catchError, forkJoin, of} from 'rxjs';
 import {format, parseISO, subDays} from 'date-fns';
 import {NutritionService} from '../../services/nutrition.service';
@@ -14,8 +16,11 @@ const PAD_R = 6;
 const PAD_T = 12;
 const PAD_B = 20;
 
-/** Days of intake history to load for the trend chart. */
-const INTAKE_DAYS = 14;
+/** Selectable ranges (in days) for the intake trend chart. */
+const INTAKE_RANGES = [7, 14, 30] as const;
+
+/** Default number of days of intake history to load for the trend chart. */
+const DEFAULT_INTAKE_DAYS = 14;
 
 /** A day's consumed kcal against its target, for the intake chart. */
 interface IntakeDay {
@@ -29,6 +34,7 @@ interface IntakeDay {
   h: number;
   /** within | under | over target */
   state: 'within' | 'under' | 'over';
+  tooltip: string;
 }
 
 interface WeightPoint {
@@ -36,12 +42,13 @@ interface WeightPoint {
   y: number;
   weightKg: number;
   label: string;
+  tooltip: string;
 }
 
 @Component({
   selector: 'app-nutrition-dashboard',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [DecimalPipe, MatProgressSpinner],
+  imports: [DecimalPipe, MatProgressSpinner, MatTooltipModule, MatButtonToggleModule],
   templateUrl: './nutrition-dashboard.component.html',
   styleUrl: './nutrition-dashboard.component.css'
 })
@@ -52,6 +59,9 @@ export class NutritionDashboardComponent implements OnInit {
   readonly axisX1 = PAD_L;
   readonly axisX2 = VB_W - PAD_R;
   readonly baselineY = VB_H - PAD_B;
+
+  readonly intakeRanges = INTAKE_RANGES;
+  intakeRangeDays: number = DEFAULT_INTAKE_DAYS;
 
   loading = true;
 
@@ -79,18 +89,24 @@ export class NutritionDashboardComponent implements OnInit {
   private nutritionService = inject(NutritionService);
   private cdr = inject(ChangeDetectorRef);
 
+  private weightEntries: WeightEntry[] = [];
+  private daySummaries: DaySummary[] = [];
+
   ngOnInit(): void {
     const today = new Date();
-    const dates = Array.from({length: INTAKE_DAYS}, (_, i) =>
-      format(subDays(today, INTAKE_DAYS - 1 - i), 'yyyy-MM-dd'));
+    const maxDays = Math.max(...INTAKE_RANGES);
+    const dates = Array.from({length: maxDays}, (_, i) =>
+      format(subDays(today, maxDays - 1 - i), 'yyyy-MM-dd'));
 
     forkJoin({
       weights: this.nutritionService.getWeightEntries().pipe(catchError(() => of([] as WeightEntry[]))),
       days: this.nutritionService.getDaySummaries(dates[0], dates[dates.length - 1])
         .pipe(catchError(() => of([] as DaySummary[])))
     }).subscribe(({weights, days}) => {
+      this.weightEntries = weights;
+      this.daySummaries = days;
       this.buildWeightChart(weights);
-      this.buildIntakeChart(dates, days);
+      this.rebuildIntakeChart();
       this.loading = false;
       this.cdr.markForCheck();
     });
@@ -102,6 +118,28 @@ export class NutritionDashboardComponent implements OnInit {
 
   get hasIntake(): boolean {
     return this.intakeDays.length > 0;
+  }
+
+  get weightChartLabel(): string {
+    return `Gewichtsverlauf der letzten ${this.weightPoints.length} Tage`;
+  }
+
+  get intakeChartLabel(): string {
+    return `Kalorienaufnahme der letzten ${this.intakeRangeDays} Tage`;
+  }
+
+  onIntakeRangeChange(days: number): void {
+    if (days === this.intakeRangeDays) return;
+    this.intakeRangeDays = days;
+    this.rebuildIntakeChart();
+    this.cdr.markForCheck();
+  }
+
+  private rebuildIntakeChart(): void {
+    const today = new Date();
+    const dates = Array.from({length: this.intakeRangeDays}, (_, i) =>
+      format(subDays(today, this.intakeRangeDays - 1 - i), 'yyyy-MM-dd'));
+    this.buildIntakeChart(dates, this.daySummaries);
   }
 
   // ── Weight ─────────────────────────────────────────
@@ -125,7 +163,12 @@ export class NutritionDashboardComponent implements OnInit {
       const x = PAD_L + (sorted.length > 1 ? stepX * i : innerW / 2);
       const t = (e.weightKg - this.weightMin) / (this.weightMax - this.weightMin);
       const y = PAD_T + innerH * (1 - t);
-      return {x, y, weightKg: e.weightKg, label: format(parseISO(e.entryDate), 'dd.MM.')};
+      const label = format(parseISO(e.entryDate), 'dd.MM.');
+      const dateLabel = format(parseISO(e.entryDate), 'dd.MM.yyyy');
+      return {
+        x, y, weightKg: e.weightKg, label,
+        tooltip: `${dateLabel}: ${e.weightKg.toFixed(1)} kg`
+      };
     });
 
     this.weightLine = this.weightPoints.map(p => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');
@@ -160,6 +203,7 @@ export class NutritionDashboardComponent implements OnInit {
       const h = innerH * (kcal / this.intakeMax);
       const x = PAD_L + slot * i + (slot - this.barWidth) / 2;
       const y = PAD_T + innerH - h;
+      const dateLabel = format(parseISO(date), 'dd.MM.yyyy');
       return {
         date,
         label: format(parseISO(date), 'dd.MM.'),
@@ -168,7 +212,8 @@ export class NutritionDashboardComponent implements OnInit {
         x,
         y,
         h,
-        state: this.targetState(kcal, dayTarget)
+        state: this.targetState(kcal, dayTarget),
+        tooltip: `${dateLabel}: ${Math.round(kcal)} kcal`
       };
     });
 


### PR DESCRIPTION
## Summary
- Add `role="img"` + descriptive `aria-label` to the weight-trend and kcal-intake SVG charts
- Add hover/keyboard-focus tooltips (matTooltip) on data points (weight) and bars (intake) showing date and exact value
- Replace hard-coded 14-day intake range with a 7/14/30-day `mat-button-toggle-group` selector
- Add a diagonal hatch pattern (matching the over-target style in nutrition-day) to "darüber" bars and the legend swatch, so the over-target state isn't colour-only

Closes #210

## Test plan
- [x] `npm run build` succeeds
- [ ] Manually verify tooltips appear on hover/focus for chart points and bars
- [ ] Verify range toggle (7/14/30) updates the kcal chart and aria-label
- [ ] Verify screen reader announces chart aria-labels