### PR TITLE
fix(nutrition): contain scrolling to data regions

### DIFF
--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.css
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.css
@@ -17,9 +17,10 @@
   --c-f:    #fb7185;
   --c-warn: #ff5252;
 
-  display: block;
+  display: flex;
+  flex-direction: column;
   height: 100%;
-  overflow-y: auto;
+  overflow: hidden;
   font-family: 'Outfit', sans-serif;
   color: var(--text);
 }
@@ -30,8 +31,22 @@
   gap: 1.5rem;
   padding: 2rem clamp(1rem, 6vw, 4rem);
   max-width: 760px;
+  width: 100%;
   margin: 0 auto;
   box-sizing: border-box;
+  min-height: 0;
+  flex: 1;
+  overflow: hidden;
+}
+
+.meals {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-height: 0;
+  flex: 1;
+  overflow-y: auto;
+  padding-bottom: 0.25rem;
 }
 
 /* ── Panels ──────────────────────────────────────── */

--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.html
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.html
@@ -84,50 +84,52 @@
       <p class="empty">Tagesziele nicht verfügbar. Bitte zuerst ein Profil und einen Gewichtseintrag erfassen.</p>
     }
 
-    @for (group of groups; track group.type) {
-      <section class="panel meal">
-        <header class="meal__head">
-          <span class="meal__title">{{ group.label }}</span>
-          <span class="meal__kcal">{{ group.kcal | number:'1.0-0':'de' }} kcal</span>
-          <button mat-icon-button class="btn-meal-add" matTooltip="Hinzufügen" (click)="openAddDialog(group.type)">
-            <mat-icon>add</mat-icon>
-          </button>
-        </header>
+    <div class="meals">
+      @for (group of groups; track group.type) {
+        <section class="panel meal">
+          <header class="meal__head">
+            <span class="meal__title">{{ group.label }}</span>
+            <span class="meal__kcal">{{ group.kcal | number:'1.0-0':'de' }} kcal</span>
+            <button mat-icon-button class="btn-meal-add" matTooltip="Hinzufügen" (click)="openAddDialog(group.type)">
+              <mat-icon>add</mat-icon>
+            </button>
+          </header>
 
-        @if (group.entries.length > 0) {
-          <ul class="entries">
-            @for (entry of group.entries; track entry.id) {
-              <li class="entry">
-                <div class="entry__main">
-                  <span class="entry__name">{{ entryName(entry) }}</span>
-                  <span class="entry__meta">
-                    @if (entry.quantityG !== null) {
-                      {{ entry.quantityG | number:'1.0-0':'de' }} g ·
-                    }
-                    {{ entry.kcal | number:'1.0-0':'de' }} kcal ·
-                    P {{ entry.proteinG | number:'1.0-1':'de' }} ·
-                    KH {{ entry.carbsG | number:'1.0-1':'de' }} ·
-                    F {{ entry.fatG | number:'1.0-1':'de' }}
-                  </span>
-                </div>
-                <div class="entry__actions">
-                  <button mat-icon-button class="btn-edit" matTooltip="Bearbeiten" (click)="openEditDialog(entry)">
-                    <mat-icon>edit</mat-icon>
-                  </button>
-                  <button mat-icon-button class="btn-del" matTooltip="Löschen" (click)="openDeleteDialog(entry)">
-                    <mat-icon>delete</mat-icon>
-                  </button>
-                </div>
-              </li>
-            }
-          </ul>
-        } @else {
-          <button type="button" class="meal__empty" (click)="openAddDialog(group.type)">
-            Noch nichts erfasst – hinzufügen
-          </button>
-        }
-      </section>
-    }
+          @if (group.entries.length > 0) {
+            <ul class="entries">
+              @for (entry of group.entries; track entry.id) {
+                <li class="entry">
+                  <div class="entry__main">
+                    <span class="entry__name">{{ entryName(entry) }}</span>
+                    <span class="entry__meta">
+                      @if (entry.quantityG !== null) {
+                        {{ entry.quantityG | number:'1.0-0':'de' }} g ·
+                      }
+                      {{ entry.kcal | number:'1.0-0':'de' }} kcal ·
+                      P {{ entry.proteinG | number:'1.0-1':'de' }} ·
+                      KH {{ entry.carbsG | number:'1.0-1':'de' }} ·
+                      F {{ entry.fatG | number:'1.0-1':'de' }}
+                    </span>
+                  </div>
+                  <div class="entry__actions">
+                    <button mat-icon-button class="btn-edit" matTooltip="Bearbeiten" (click)="openEditDialog(entry)">
+                      <mat-icon>edit</mat-icon>
+                    </button>
+                    <button mat-icon-button class="btn-del" matTooltip="Löschen" (click)="openDeleteDialog(entry)">
+                      <mat-icon>delete</mat-icon>
+                    </button>
+                  </div>
+                </li>
+              }
+            </ul>
+          } @else {
+            <button type="button" class="meal__empty" (click)="openAddDialog(group.type)">
+              Noch nichts erfasst – hinzufügen
+            </button>
+          }
+        </section>
+      }
+    </div>
 
   }
 

--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.css
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.css
@@ -16,9 +16,10 @@
   --c-b:  #4da6ff;
   --c-e:  #fb7185;
 
-  display: block;
+  display: flex;
+  flex-direction: column;
   height: 100%;
-  overflow-y: auto;
+  overflow: hidden;
   font-family: 'Outfit', sans-serif;
   color: var(--text);
 }
@@ -29,8 +30,19 @@
   gap: 1.5rem;
   padding: 2rem clamp(1rem, 6vw, 4rem);
   max-width: 760px;
+  width: 100%;
   margin: 0 auto;
   box-sizing: border-box;
+  min-height: 0;
+  flex: 1;
+  overflow: hidden;
+}
+
+.panel-table {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
 }
 
 /* ── Panels ──────────────────────────────────────── */
@@ -128,7 +140,9 @@
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 12px;
-  overflow-x: auto;
+  overflow: auto;
+  min-height: 0;
+  flex: 1;
 }
 
 table {
@@ -159,6 +173,9 @@ table {
 
 ::ng-deep .mat-mdc-header-row {
   background: var(--raised) !important;
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
 
 ::ng-deep .mat-mdc-cell {

--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.html
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.html
@@ -40,7 +40,7 @@
     </div>
   </section>
 
-  <section class="panel">
+  <section class="panel panel-table">
     @if (foods.data.length) {
       <div class="table-container">
         <table mat-table [dataSource]="foods" matSort>

--- a/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.css
+++ b/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.css
@@ -14,9 +14,10 @@
   --c-g:  #a3e635;
   --c-e:  #fb7185;
 
-  display: block;
+  display: flex;
+  flex-direction: column;
   height: 100%;
-  overflow-y: auto;
+  overflow: hidden;
   font-family: 'Outfit', sans-serif;
   color: var(--text);
 }
@@ -27,8 +28,19 @@
   gap: 1.5rem;
   padding: 2rem clamp(1rem, 6vw, 4rem);
   max-width: 760px;
+  width: 100%;
   margin: 0 auto;
   box-sizing: border-box;
+  min-height: 0;
+  flex: 1;
+  overflow: hidden;
+}
+
+.panel-table {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
 }
 
 /* ── Panels ──────────────────────────────────────── */
@@ -93,7 +105,9 @@
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 12px;
-  overflow: hidden;
+  overflow: auto;
+  min-height: 0;
+  flex: 1;
 }
 
 table {
@@ -116,6 +130,9 @@ table {
 
 ::ng-deep .mat-mdc-header-row {
   background: var(--raised) !important;
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
 
 ::ng-deep .mat-mdc-cell {

--- a/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.html
+++ b/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.html
@@ -32,7 +32,7 @@
     </form>
   </section>
 
-  <section class="panel">
+  <section class="panel panel-table">
     <header class="panel__head">
       <span class="panel__dot"></span>
       <span class="panel__label">VERLAUF</span>


### PR DESCRIPTION
## Summary
- Changed `nutrition-day`, `nutrition-foods`, and `nutrition-weight` `:host` from `overflow-y: auto` to a flex column constrained to `height: 100%; overflow: hidden`, so the page itself never grows a scrollbar.
- Wrapped the scrollable data region (meal entries list, foods table, weight history table) in a flex child with `flex: 1; min-height: 0; overflow: auto`, so only that region scrolls.
- Static chrome (panel headers, toolbar/search, date nav, summary bars/targets card) stays pinned and always visible.
- Added sticky table headers for foods and weight history tables so column labels stay visible while scrolling.

## Test plan
- [x] `npm run build` succeeds
- [ ] Diary page: with many meal entries, verify toolbar/date-nav/summary stay fixed and only the meal list scrolls
- [ ] Foods page: with many foods, verify search/toolbar stays fixed and only the table scrolls (with sticky header)
- [ ] Weight page: with many entries, verify targets card/add-form stays fixed and only the history table scrolls (with sticky header)
- [ ] Confirm no outer page scrollbar appears on any of the three pages

Closes #211