### PR TITLE
fix(nutrition): a11y and design audit fixes for Web Interface Guidelines

### DIFF
--- a/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.html
+++ b/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.html
@@ -14,13 +14,13 @@
     <mat-form-field appearance="outline" class="field-full">
       <mat-label>Beschreibung</mat-label>
       <textarea matInput rows="3" [formControl]="description"
-                placeholder="z. B. Schnitzel mit Pommes und Salat, großer Teller"></textarea>
+                placeholder="z. B. Schnitzel mit Pommes und Salat, großer Teller…"></textarea>
     </mat-form-field>
 
     <mat-form-field appearance="outline" class="field-full">
       <mat-label>Portionsgröße (optional)</mat-label>
       <input matInput [formControl]="portionHint"
-             placeholder="z. B. großer Teller, ca. 350 g" />
+             placeholder="z. B. großer Teller, ca. 350 g…" />
       <mat-hint>Hilft der KI, die Menge besser einzuschätzen.</mat-hint>
     </mat-form-field>
 

--- a/src/app/nutrition/components/nutrition-dashboard/nutrition-dashboard.component.html
+++ b/src/app/nutrition/components/nutrition-dashboard/nutrition-dashboard.component.html
@@ -31,7 +31,7 @@
             <polyline class="line line--w" [attr.points]="weightLine" />
             @for (p of weightPoints; track p.label + p.x) {
               <circle class="dot dot--w" [attr.cx]="p.x" [attr.cy]="p.y" r="2.4"
-                      tabindex="0" role="img" [attr.aria-label]="p.tooltip"
+                      role="img" [attr.aria-label]="p.tooltip"
                       [matTooltip]="p.tooltip" />
             }
           </svg>
@@ -76,7 +76,7 @@
             @for (d of intakeDays; track d.date) {
               <rect class="bar bar--{{ d.state }}"
                     [attr.x]="d.x" [attr.y]="d.y" [attr.width]="barWidth" [attr.height]="d.h" rx="1.5"
-                    tabindex="0" role="img" [attr.aria-label]="d.tooltip"
+                    role="img" [attr.aria-label]="d.tooltip"
                     [matTooltip]="d.tooltip" />
             }
             @if (intakeTargetY !== null) {

--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.html
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.html
@@ -9,7 +9,7 @@
     <div class="toolbar">
       <div class="date-nav">
         <button mat-icon-button type="button" class="btn-step" matTooltip="Vorheriger Tag"
-                (click)="stepDay(-1)">
+                aria-label="Vorheriger Tag" (click)="stepDay(-1)">
           <mat-icon>chevron_left</mat-icon>
         </button>
 
@@ -21,7 +21,7 @@
         </mat-form-field>
 
         <button mat-icon-button type="button" class="btn-step" matTooltip="Nächster Tag"
-                [disabled]="isToday" (click)="stepDay(1)">
+                aria-label="Nächster Tag" [disabled]="isToday" (click)="stepDay(1)">
           <mat-icon>chevron_right</mat-icon>
         </button>
 
@@ -90,7 +90,7 @@
           <header class="meal__head">
             <span class="meal__title">{{ group.label }}</span>
             <span class="meal__kcal">{{ group.kcal | number:'1.0-0':'de' }} kcal</span>
-            <button mat-icon-button class="btn-meal-add" matTooltip="Hinzufügen" (click)="openAddDialog(group.type)">
+            <button mat-icon-button class="btn-meal-add" matTooltip="Hinzufügen" aria-label="Hinzufügen" (click)="openAddDialog(group.type)">
               <mat-icon>add</mat-icon>
             </button>
           </header>
@@ -112,10 +112,10 @@
                     </span>
                   </div>
                   <div class="entry__actions">
-                    <button mat-icon-button class="btn-edit" matTooltip="Bearbeiten" (click)="openEditDialog(entry)">
+                    <button mat-icon-button class="btn-edit" matTooltip="Bearbeiten" aria-label="Bearbeiten" (click)="openEditDialog(entry)">
                       <mat-icon>edit</mat-icon>
                     </button>
-                    <button mat-icon-button class="btn-del" matTooltip="Löschen" (click)="openDeleteDialog(entry)">
+                    <button mat-icon-button class="btn-del" matTooltip="Löschen" aria-label="Löschen" (click)="openDeleteDialog(entry)">
                       <mat-icon>delete</mat-icon>
                     </button>
                   </div>

--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.html
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.html
@@ -78,10 +78,10 @@
           <ng-container matColumnDef="actions">
             <th *matHeaderCellDef mat-header-cell class="col-header"></th>
             <td *matCellDef="let food" mat-cell class="col-actions">
-              <button mat-icon-button class="btn-edit" matTooltip="Bearbeiten" (click)="openEditDialog(food)">
+              <button mat-icon-button class="btn-edit" matTooltip="Bearbeiten" aria-label="Bearbeiten" (click)="openEditDialog(food)">
                 <mat-icon>edit</mat-icon>
               </button>
-              <button mat-icon-button class="btn-del" matTooltip="Löschen" (click)="openDeleteDialog(food)">
+              <button mat-icon-button class="btn-del" matTooltip="Löschen" aria-label="Löschen" (click)="openDeleteDialog(food)">
                 <mat-icon>delete</mat-icon>
               </button>
             </td>

--- a/src/app/nutrition/components/nutrition-layout/nutrition-layout.component.html
+++ b/src/app/nutrition/components/nutrition-layout/nutrition-layout.component.html
@@ -8,27 +8,27 @@
         <mat-icon>more_vert</mat-icon>
       </button>
       <mat-menu #menu="matMenu">
-        <button mat-menu-item routerLink="/nutrition">
+        <a mat-menu-item routerLink="/nutrition">
           <span>Home</span>
-        </button>
-        <button mat-menu-item routerLink="/nutrition/dashboard">
+        </a>
+        <a mat-menu-item routerLink="/nutrition/dashboard">
           <span>Dashboard</span>
-        </button>
-        <button mat-menu-item routerLink="/nutrition/day">
+        </a>
+        <a mat-menu-item routerLink="/nutrition/day">
           <span>Tagebuch</span>
-        </button>
-        <button mat-menu-item routerLink="/nutrition/canteen">
+        </a>
+        <a mat-menu-item routerLink="/nutrition/canteen">
           <span>Kantine</span>
-        </button>
-        <button mat-menu-item routerLink="/nutrition/weight">
+        </a>
+        <a mat-menu-item routerLink="/nutrition/weight">
           <span>Gewicht</span>
-        </button>
-        <button mat-menu-item routerLink="/nutrition/foods">
+        </a>
+        <a mat-menu-item routerLink="/nutrition/foods">
           <span>Lebensmittel</span>
-        </button>
-        <button mat-menu-item routerLink="/nutrition/profile">
+        </a>
+        <a mat-menu-item routerLink="/nutrition/profile">
           <span>Profil</span>
-        </button>
+        </a>
       </mat-menu>
     </div>
 

--- a/src/app/nutrition/components/nutrition-profile/nutrition-profile.component.html
+++ b/src/app/nutrition/components/nutrition-profile/nutrition-profile.component.html
@@ -22,7 +22,7 @@
 
         <mat-form-field appearance="outline">
           <mat-label>Geburtsdatum</mat-label>
-          <input matInput formControlName="birthDate" [matDatepicker]="picker" [max]="today" />
+          <input matInput formControlName="birthDate" autocomplete="bday" [matDatepicker]="picker" [max]="today" />
           <mat-datepicker-toggle matIconSuffix [for]="picker" />
           <mat-datepicker #picker startView="multi-year" />
           @if (form.get('birthDate')?.hasError('required')) {

--- a/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.html
+++ b/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.html
@@ -55,10 +55,10 @@
           <ng-container matColumnDef="actions">
             <th *matHeaderCellDef mat-header-cell class="col-header"></th>
             <td *matCellDef="let entry" mat-cell class="col-actions">
-              <button mat-icon-button class="btn-edit" matTooltip="Bearbeiten" (click)="openEditDialog(entry)">
+              <button mat-icon-button class="btn-edit" matTooltip="Bearbeiten" aria-label="Bearbeiten" (click)="openEditDialog(entry)">
                 <mat-icon>edit</mat-icon>
               </button>
-              <button mat-icon-button class="btn-del" matTooltip="Löschen" (click)="openDeleteDialog(entry)">
+              <button mat-icon-button class="btn-del" matTooltip="Löschen" aria-label="Löschen" (click)="openDeleteDialog(entry)">
                 <mat-icon>delete</mat-icon>
               </button>
             </td>

--- a/src/app/nutrition/components/targets-card/targets-card.component.html
+++ b/src/app/nutrition/components/targets-card/targets-card.component.html
@@ -33,15 +33,15 @@
 
     <div class="macros">
       <div class="macro macro--p">
-        <span class="macro__value">{{ targets.proteinG | number:'1.0-0':'de' }}<span class="macro__unit">g</span></span>
+        <span class="macro__value">{{ targets.proteinG | number:'1.0-0':'de' }}&nbsp;<span class="macro__unit">g</span></span>
         <span class="macro__label">Protein</span>
       </div>
       <div class="macro macro--c">
-        <span class="macro__value">{{ targets.carbsG | number:'1.0-0':'de' }}<span class="macro__unit">g</span></span>
+        <span class="macro__value">{{ targets.carbsG | number:'1.0-0':'de' }}&nbsp;<span class="macro__unit">g</span></span>
         <span class="macro__label">Kohlenhydrate</span>
       </div>
       <div class="macro macro--f">
-        <span class="macro__value">{{ targets.fatG | number:'1.0-0':'de' }}<span class="macro__unit">g</span></span>
+        <span class="macro__value">{{ targets.fatG | number:'1.0-0':'de' }}&nbsp;<span class="macro__unit">g</span></span>
         <span class="macro__label">Fett</span>
       </div>
     </div>

--- a/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.html
+++ b/src/app/nutrition/dialogs/add-day-entry-dialog/add-day-entry-dialog.component.html
@@ -87,7 +87,7 @@
           <span class="staged-item__meal">{{ mealTypeLabel(item.mealType) }}</span>
           <span class="staged-item__qty">{{ item.quantityG | number:'1.0-0':'de' }} g</span>
           <span class="staged-item__kcal">{{ scaledFor(item, item.food.kcalPer100) | number:'1.0-0':'de' }} kcal</span>
-          <button mat-icon-button type="button" class="staged-item__remove" (click)="removeStaged(i)">
+          <button mat-icon-button type="button" class="staged-item__remove" aria-label="Eintrag entfernen" (click)="removeStaged(i)">
             <mat-icon>delete</mat-icon>
           </button>
         </div>

--- a/src/app/nutrition/dialogs/entry-delete-dialog/entry-delete-dialog.component.html
+++ b/src/app/nutrition/dialogs/entry-delete-dialog/entry-delete-dialog.component.html
@@ -5,10 +5,10 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="center">
-  <button mat-mini-fab class="btn-confirm" (click)="confirm()">
+  <button mat-mini-fab class="btn-confirm" aria-label="Löschen bestätigen" (click)="confirm()">
     <mat-icon>check_circle</mat-icon>
   </button>
-  <button mat-mini-fab mat-dialog-close class="btn-cancel">
+  <button mat-mini-fab mat-dialog-close class="btn-cancel" aria-label="Abbrechen">
     <mat-icon>close</mat-icon>
   </button>
 </mat-dialog-actions>

--- a/src/app/nutrition/dialogs/food-delete-dialog/food-delete-dialog.component.html
+++ b/src/app/nutrition/dialogs/food-delete-dialog/food-delete-dialog.component.html
@@ -5,10 +5,10 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="center">
-  <button mat-mini-fab class="btn-confirm" (click)="confirm()">
+  <button mat-mini-fab class="btn-confirm" aria-label="Löschen bestätigen" (click)="confirm()">
     <mat-icon>check_circle</mat-icon>
   </button>
-  <button mat-mini-fab mat-dialog-close class="btn-cancel">
+  <button mat-mini-fab mat-dialog-close class="btn-cancel" aria-label="Abbrechen">
     <mat-icon>close</mat-icon>
   </button>
 </mat-dialog-actions>

--- a/src/app/nutrition/dialogs/weight-delete-dialog/weight-delete-dialog.component.html
+++ b/src/app/nutrition/dialogs/weight-delete-dialog/weight-delete-dialog.component.html
@@ -5,10 +5,10 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="center">
-  <button mat-mini-fab class="btn-confirm" (click)="confirm()">
+  <button mat-mini-fab class="btn-confirm" aria-label="Löschen bestätigen" (click)="confirm()">
     <mat-icon>check_circle</mat-icon>
   </button>
-  <button mat-mini-fab mat-dialog-close class="btn-cancel">
+  <button mat-mini-fab mat-dialog-close class="btn-cancel" aria-label="Abbrechen">
     <mat-icon>close</mat-icon>
   </button>
 </mat-dialog-actions>

--- a/src/app/nutrition/dialogs/weight-edit-dialog/weight-edit-dialog.component.html
+++ b/src/app/nutrition/dialogs/weight-edit-dialog/weight-edit-dialog.component.html
@@ -17,10 +17,10 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="center">
-  <button mat-mini-fab class="btn-confirm" [disabled]="form.invalid" (click)="save()">
+  <button mat-mini-fab class="btn-confirm" aria-label="Speichern" [disabled]="form.invalid" (click)="save()">
     <mat-icon>check_circle</mat-icon>
   </button>
-  <button mat-mini-fab mat-dialog-close class="btn-cancel">
+  <button mat-mini-fab mat-dialog-close class="btn-cancel" aria-label="Abbrechen">
     <mat-icon>close</mat-icon>
   </button>
 </mat-dialog-actions>


### PR DESCRIPTION
## Summary
- Add `aria-label` to icon-only buttons (day/foods/weight edit/delete actions, day step navigation, meal add, all confirm/cancel delete & weight-edit dialogs, staged-item remove) so screen readers announce their action
- Switch `nutrition-layout` menu items from `<button routerLink>` to `<a mat-menu-item routerLink>` for correct link semantics (Cmd/Ctrl/middle-click)
- Append `…` to canteen description/portion placeholders to match example-pattern convention
- Add `&nbsp;` between macro values and their unit (`g`) in the targets card
- Remove `tabindex="0"` from per-data-point SVG chart elements (dashboard) to avoid excessive tab stops, keeping `role="img"`/`aria-label` for tooltip content
- Add `autocomplete="bday"` to the profile birth date field

## Test plan
- [x] `npm run build` succeeds
- [ ] Manually verify icon buttons announce correctly via screen reader/accessibility tree on nutrition-day, nutrition-foods, nutrition-weight, and delete/edit dialogs
- [ ] Verify canteen placeholders and targets-card spacing render correctly