### PR TITLE
fix(vocabulary): consolidate duplicated Google Fonts loading

### DIFF
--- a/src/app/vocabulary/components/add-word/add-word.component.css
+++ b/src/app/vocabulary/components/add-word/add-word.component.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;700&display=swap');
-
 :host {
   --bg:          #06080e;
   --surface:     #0c1018;

--- a/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.css
+++ b/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
-
 /* ── Design Tokens ───────────────────────────────── */
 :host {
   --bg:          #06080e;

--- a/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.css
+++ b/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;700&display=swap');
-
 :host {
   --bg:          #06080e;
   --surface:     #0c1018;

--- a/src/index.html
+++ b/src/index.html
@@ -6,8 +6,11 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
 </head>
 <body class="mat-typography">
   <app-root></app-root>


### PR DESCRIPTION
## Summary
- Consolidate three duplicated `@import url(...)` Google Fonts rules (Outfit + JetBrains Mono) from `vocabulary-home`, `add-word`, and `vocabulary-list` component CSS files into a single set of `<link>` tags in `src/index.html`.
- Add `<link rel="preconnect">` for `fonts.googleapis.com` and `fonts.gstatic.com` to speed up font loading and avoid render-blocking `@import`.
- The combined stylesheet link includes the union of weights used by the three components (Outfit 300/400/500/600/700, JetBrains Mono 400/500/700).

Closes #226

## Test plan
- [x] `npm run build` succeeds