### PR TITLE
fix(vocabulary): a11y and motion fixes for vocabulary-home

### DIFF
--- a/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.css
+++ b/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.css
@@ -36,6 +36,18 @@
   flex-shrink: 0;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 ::ng-deep .home-fab.mat-mdc-fab {
   --mdc-fab-container-color: var(--surface);
   --mdc-fab-icon-color: var(--c-v);
@@ -87,6 +99,13 @@
   transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
   animation: fadeUp 0.5s ease both;
   -webkit-tap-highlight-color: transparent;
+  font-family: inherit;
+  text-align: left;
+}
+
+.navcard:focus-visible {
+  outline: 2px solid var(--c-v);
+  outline-offset: 2px;
 }
 
 /* Radial glow overlay on hover */
@@ -132,6 +151,9 @@
 
 .navcard--action {
   user-select: none;
+  width: 100%;
+  background: var(--surface);
+  font-size: inherit;
 }
 
 /* ── Card Mark ───────────────────────────────────── */
@@ -205,6 +227,12 @@
 .navcard:nth-child(1) { animation-delay: 0.05s; }
 .navcard:nth-child(2) { animation-delay: 0.12s; }
 .navcard:nth-child(3) { animation-delay: 0.19s; }
+
+@media (prefers-reduced-motion: reduce) {
+  .navcard {
+    animation: none;
+  }
+}
 
 /* ── Content Area ────────────────────────────────── */
 .content-area {

--- a/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.html
+++ b/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.html
@@ -1,5 +1,7 @@
 <div class="page-header">
-  <button mat-fab routerLink="/" class="home-fab">
+  <h1 class="visually-hidden">Vocabulary</h1>
+
+  <button mat-fab routerLink="/" class="home-fab" aria-label="Home">
     <mat-icon>home</mat-icon>
   </button>
 
@@ -23,14 +25,14 @@
       <span class="navcard__arrow" aria-hidden="true">↗</span>
     </a>
 
-    <div class="navcard navcard--action" (click)="openDialog()">
+    <button type="button" class="navcard navcard--action" (click)="openDialog()">
       <div class="navcard__mark">D</div>
       <div class="navcard__body">
         <h2 class="navcard__title">Manage Decks</h2>
         <p class="navcard__sub">Rename and organise decks</p>
       </div>
       <span class="navcard__arrow" aria-hidden="true">↗</span>
-    </div>
+    </button>
 
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Add `aria-label="Home"` to the icon-only home FAB
- Convert the "Manage Decks" navcard `<div>` (click handler only) into a semantic `<button>`
- Add a visually-hidden `<h1>Vocabulary</h1>` to establish a proper heading hierarchy with the existing `<h2>` card titles
- Guard the `fadeUp` navcard entrance animation with `@media (prefers-reduced-motion: reduce)`
- Add a visible `:focus-visible` outline style for `.navcard` (anchor and button variants)

Closes #222

## Test plan
- [x] `npm run build` succeeds