### PR TITLE
fix(vocabulary): add-word a11y and validation feedback

### DIFF
--- a/src/app/vocabulary/components/add-word/add-word.component.css
+++ b/src/app/vocabulary/components/add-word/add-word.component.css
@@ -47,7 +47,7 @@
   background: transparent;
   color: var(--text-muted);
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .icon-btn--yellow {

--- a/src/app/vocabulary/components/add-word/add-word.component.html
+++ b/src/app/vocabulary/components/add-word/add-word.component.html
@@ -8,9 +8,10 @@
           <input
               matInput
               type="text"
+              autocomplete="off"
               [(ngModel)]="word"
               (keyup.enter)="getWord(word)"
-              placeholder="Type a word and press Enter"
+              placeholder="Type a word and press Enter…"
           >
         </mat-form-field>
         @if (word) {
@@ -63,10 +64,10 @@
                             type="button"
                         >
                           @if (isChosen(getDefinitionIndex(entryIndex, meaningIndex, definitionIndex))) {
-                            <mat-icon>check_circle</mat-icon>
+                            <mat-icon aria-hidden="true">check_circle</mat-icon>
                             <span>Using as description</span>
                           } @else {
-                            <mat-icon>description</mat-icon>
+                            <mat-icon aria-hidden="true">description</mat-icon>
                             <span>Use as description</span>
                           }
                         </button>
@@ -77,10 +78,10 @@
                             type="button"
                         >
                           @if (isChosenForContext(getDefinitionIndex(entryIndex, meaningIndex, definitionIndex))) {
-                            <mat-icon>check_circle</mat-icon>
+                            <mat-icon aria-hidden="true">check_circle</mat-icon>
                             <span>Added to context</span>
                           } @else {
-                            <mat-icon>add_circle</mat-icon>
+                            <mat-icon aria-hidden="true">add_circle</mat-icon>
                             <span>Add to context</span>
                           }
                         </button>
@@ -106,31 +107,42 @@
         </header>
 
         <form
+            #wordFormTranslationEl
             [formGroup]="wordFormTranslation"
             (ngSubmit)="onSubmitTranslation()"
         >
           <mat-form-field appearance="outline">
             <mat-label>Word</mat-label>
-            <input matInput formControlName="word">
+            <input matInput formControlName="word" autocomplete="off">
+            @if (wordFormTranslation.get('word')?.invalid) {
+              <mat-error>Word is required.</mat-error>
+            }
           </mat-form-field>
 
           <mat-form-field appearance="outline">
             <mat-label>Context</mat-label>
-            <input matInput formControlName="context">
+            <input matInput formControlName="context" autocomplete="off">
+            @if (wordFormTranslation.get('context')?.invalid) {
+              <mat-error>Context is required.</mat-error>
+            }
           </mat-form-field>
 
           <button
               mat-flat-button
               color="primary"
-              [disabled]="!wordFormTranslation.valid"
+              [disabled]="isTranslating()"
               type="submit"
           >
-            Translate
+            @if (isTranslating()) {
+              <mat-spinner diameter="18" aria-hidden="true"></mat-spinner>
+            } @else {
+              Translate
+            }
           </button>
         </form>
 
         @if (translation()) {
-          <div class="translation-result">{{ translation() }}</div>
+          <div class="translation-result" aria-live="polite">{{ translation() }}</div>
         }
       </div>
     }
@@ -158,36 +170,59 @@
           </div>
 
           <form
+              #wordFormEl
               [formGroup]="wordForm"
               (ngSubmit)="onSubmit()"
           >
             <mat-form-field appearance="outline">
               <mat-label>Deck</mat-label>
-              <input matInput formControlName="deck">
+              <input matInput formControlName="deck" autocomplete="off">
+              @if (wordForm.get('deck')?.invalid) {
+                <mat-error>Deck is required.</mat-error>
+              }
             </mat-form-field>
 
             <mat-form-field appearance="outline">
               <mat-label>Front</mat-label>
-              <input matInput formControlName="front">
+              <input matInput formControlName="front" autocomplete="off">
+              @if (wordForm.get('front')?.hasError('required')) {
+                <mat-error>Front is required.</mat-error>
+              } @else if (wordForm.get('front')?.hasError('partOfSpeechIsMissing')) {
+                <mat-error>Please select a part of speech above.</mat-error>
+              } @else if (wordForm.get('front')?.hasError('articleIsMissing')) {
+                <mat-error>Noun must start with "a" or "an".</mat-error>
+              } @else if (wordForm.get('front')?.hasError('toIsMissing')) {
+                <mat-error>Verb must start with "to".</mat-error>
+              }
             </mat-form-field>
 
             <mat-form-field appearance="outline">
               <mat-label>Back</mat-label>
-              <input matInput formControlName="back">
+              <input matInput formControlName="back" autocomplete="off">
+              @if (wordForm.get('back')?.invalid) {
+                <mat-error>Back is required.</mat-error>
+              }
             </mat-form-field>
 
             <mat-form-field appearance="outline">
               <mat-label>Description</mat-label>
-              <textarea matInput formControlName="description" rows="3"></textarea>
+              <textarea matInput formControlName="description" rows="3" autocomplete="off"></textarea>
+              @if (wordForm.get('description')?.invalid) {
+                <mat-error>Description is required.</mat-error>
+              }
             </mat-form-field>
 
             <button
                 mat-flat-button
                 color="primary"
-                [disabled]="!wordForm.valid"
+                [disabled]="isSaving()"
                 type="submit"
             >
-              {{ update() ? 'Update' : 'Save' }}
+              @if (isSaving()) {
+                <mat-spinner diameter="18" aria-hidden="true"></mat-spinner>
+              } @else {
+                {{ update() ? 'Update' : 'Save' }}
+              }
             </button>
           </form>
         </div>

--- a/src/app/vocabulary/components/add-word/add-word.component.ts
+++ b/src/app/vocabulary/components/add-word/add-word.component.ts
@@ -1,6 +1,7 @@
-import {Component, OnInit, signal, WritableSignal, DestroyRef} from '@angular/core';
+import {Component, ElementRef, OnInit, signal, WritableSignal, DestroyRef, ViewChild} from '@angular/core';
 import {VocabularyService} from '../../services/vocabulary.service';
-import {MatFormField, MatInput} from '@angular/material/input';
+import {MatInput} from '@angular/material/input';
+import {MatError, MatFormField} from '@angular/material/form-field';
 import {
   AbstractControl,
   FormControl,
@@ -22,6 +23,7 @@ import {ActivatedRoute} from '@angular/router';
 import {MatButtonToggle, MatButtonToggleGroup} from '@angular/material/button-toggle';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {NgClass} from '@angular/common';
+import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {
   DictionaryApiError,
   DictionaryServiceUnavailableError,
@@ -86,7 +88,9 @@ function validateWordPrefix(
     MatFormField,
     MatButtonToggleGroup,
     MatButtonToggle,
-    NgClass
+    NgClass,
+    MatProgressSpinnerModule,
+    MatError
   ],
   templateUrl: './add-word.component.html',
   styleUrl: './add-word.component.css',
@@ -106,6 +110,11 @@ export class AddWordComponent implements OnInit {
   public isFromRouteCall: boolean = false;
   public chosenIndex: string | null = null;
   public chosenForContext: ChosenContextItem[] = [];
+  public isTranslating: WritableSignal<boolean> = signal(false);
+  public isSaving: WritableSignal<boolean> = signal(false);
+
+  @ViewChild('wordFormTranslationEl') private wordFormTranslationEl?: ElementRef<HTMLFormElement>;
+  @ViewChild('wordFormEl') private wordFormEl?: ElementRef<HTMLFormElement>;
 
   private id: number | null = null;
   private ankiId: string | null = null;
@@ -338,24 +347,38 @@ export class AddWordComponent implements OnInit {
   }
 
   public onSubmit(): void {
+    if (this.wordForm.invalid) {
+      this.wordForm.markAllAsTouched();
+      this.focusFirstInvalidControl(this.wordFormEl);
+      return;
+    }
+
     const flashcard: Flashcard = this.createFlashcardFromForm();
 
     const observable = this.update()
       ? this.vocabularyService.updateFlashcard(flashcard)
       : this.vocabularyService.postFlashcard(flashcard);
 
+    this.isSaving.set(true);
     observable
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => {
           const message = this.update() ? 'Flashcard updated successfully' : 'Flashcard created successfully';
           this.showSnackBar(message, 10000);
+          this.isSaving.set(false);
         },
         error: err => {
           const action = this.update() ? 'update' : 'creation';
           this.showSnackBar(`Flashcard ${action} failed: ${err.error.message}`, 10000);
+          this.isSaving.set(false);
         }
       });
+  }
+
+  private focusFirstInvalidControl(formRef?: ElementRef<HTMLFormElement>): void {
+    const invalidControl = formRef?.nativeElement?.querySelector<HTMLElement>('.ng-invalid');
+    invalidControl?.focus();
   }
 
   private createFlashcardFromForm(): Flashcard {
@@ -371,6 +394,12 @@ export class AddWordComponent implements OnInit {
   }
 
   public onSubmitTranslation(): void {
+    if (this.wordFormTranslation.invalid) {
+      this.wordFormTranslation.markAllAsTouched();
+      this.focusFirstInvalidControl(this.wordFormTranslationEl);
+      return;
+    }
+
     const word: string = this.wordFormTranslation.get('word')?.value;
     const context: string = this.wordFormTranslation.get('context')?.value;
 
@@ -379,6 +408,7 @@ export class AddWordComponent implements OnInit {
     }
 
     this.translation.set('');
+    this.isTranslating.set(true);
     this.vocabularyService.getTranslation(word, context)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
@@ -386,9 +416,11 @@ export class AddWordComponent implements OnInit {
           if (response && response.length > 0) {
             this.translation.set(response[0].text);
           }
+          this.isTranslating.set(false);
         },
         error: err => {
           this.showSnackBar(`Getting translation failed: ${err.error.message}`, 10000);
+          this.isTranslating.set(false);
         }
       });
   }


### PR DESCRIPTION
## Summary
- Add `autocomplete="off"` to word-lookup, Word/Context/Deck/Front/Back/Description inputs; placeholder now ends with "…"
- Add `aria-hidden="true"` to decorative `mat-icon`s paired with adjacent text labels (check_circle, description, add_circle)
- Add inline `mat-error` messages for required fields and the custom prefix validator on `wordFormTranslation`/`wordForm`; on submit, focus moves to the first invalid control
- Translate/Save/Update buttons stay enabled and validate on click; show a small `mat-spinner` and disable only while the request is in flight
- Add `aria-live="polite"` to `.translation-result`
- Replace `.icon-btn { transition: all 0.2s ease; }` with explicit `background-color, box-shadow, border-color` transitions

Closes #223

## Test plan
- [x] `npm run build` succeeds
- [ ] Manually verify Translate/Save buttons show spinner during request and re-enable afterward
- [ ] Manually verify mat-error messages appear and focus moves to first invalid field on submit with empty/invalid form