### PR TITLE
fix(vocabulary): a11y and overscroll fixes for dialog components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ Thumbs.db
 dependency-check-bin/**
 reports/**
 *.iml
+.claude/worktrees/

--- a/src/app/vocabulary/components/article-dialog/article-dialog.component.css
+++ b/src/app/vocabulary/components/article-dialog/article-dialog.component.css
@@ -9,6 +9,10 @@
   font-family: 'JetBrains Mono', monospace !important;
 }
 
+::ng-deep .mat-mdc-dialog-content {
+  overscroll-behavior: contain;
+}
+
 .article-btn-group {
   display: flex;
   justify-content: center;

--- a/src/app/vocabulary/components/deck-change-name-dialog/deck-change-name-dialog.css
+++ b/src/app/vocabulary/components/deck-change-name-dialog/deck-change-name-dialog.css
@@ -9,6 +9,10 @@
   font-family: 'JetBrains Mono', monospace !important;
 }
 
+::ng-deep .mat-mdc-dialog-content {
+  overscroll-behavior: contain;
+}
+
 .rename-dialog {
   display: flex;
   flex-direction: column;

--- a/src/app/vocabulary/components/deck-change-name-dialog/deck-change-name-dialog.html
+++ b/src/app/vocabulary/components/deck-change-name-dialog/deck-change-name-dialog.html
@@ -2,7 +2,7 @@
   <mat-dialog-content>
     <mat-form-field>
       <mat-label>New Name of Deck</mat-label>
-      <input matInput [(ngModel)]="deckname">
+      <input matInput [(ngModel)]="deckname" name="deckname" autocomplete="off">
     </mat-form-field>
   </mat-dialog-content>
   <mat-dialog-actions>

--- a/src/app/vocabulary/components/deck-management-dialog/deck-management-dialog.css
+++ b/src/app/vocabulary/components/deck-management-dialog/deck-management-dialog.css
@@ -9,6 +9,10 @@
   font-family: 'JetBrains Mono', monospace !important;
 }
 
+::ng-deep .mat-mdc-dialog-content {
+  overscroll-behavior: contain;
+}
+
 .deck-row {
   width: 75%;
   background: var(--raised, #111826);
@@ -30,7 +34,11 @@
 
 .deck-row__name {
   flex: 1 1 0;
+  min-width: 0;
   color: var(--text, #c8d4e8);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .icon-btn--yellow {

--- a/src/app/vocabulary/components/deck-management-dialog/deck-management-dialog.html
+++ b/src/app/vocabulary/components/deck-management-dialog/deck-management-dialog.html
@@ -3,7 +3,7 @@
     <div class="deck-row">
       <span class="deck-row__id">{{ deck.id }}</span>
       <span class="deck-row__name">{{ deck.name }}</span>
-      <button mat-icon-button class="icon-btn icon-btn--yellow" (click)="openDialog(deck)">
+      <button mat-icon-button class="icon-btn icon-btn--yellow" (click)="openDialog(deck)" [attr.aria-label]="'Rename deck ' + deck.name">
         <mat-icon>build</mat-icon>
       </button>
     </div>


### PR DESCRIPTION
## Summary
- Add an `aria-label` to the icon-only deck rename button in `deck-management-dialog`
- Truncate long deck names in `.deck-row__name` with `min-width: 0` and ellipsis
- Add `autocomplete="off"` and `name="deckname"` to the rename input in `deck-change-name-dialog`
- Add `overscroll-behavior: contain` to dialog content in `article-dialog`, `deck-management-dialog`, and `deck-change-name-dialog`

Closes #225

## Test plan
- [x] `npm run build` succeeds