### PR TITLE
fix(vocabulary): correct deck filter regex for multi-digit deck ids

### DIFF
--- a/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.spec.ts
+++ b/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.spec.ts
@@ -1,6 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
 
 import { VocabularyListComponent } from './vocabulary-list.component';
+import { Flashcard } from '../../model/Flashcard';
 
 describe('ListComponent', () => {
   let component: VocabularyListComponent;
@@ -8,7 +12,8 @@ describe('ListComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [VocabularyListComponent]
+      imports: [VocabularyListComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])]
     })
     .compileComponents();
 
@@ -19,5 +24,32 @@ describe('ListComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should filter by deck id with two or more digits, not just the last digit', () => {
+    const flashcardDeck2: Flashcard = {
+      id: 1,
+      deckId: 2,
+      ankiId: null,
+      front: 'front2',
+      back: 'back2',
+      description: '',
+      updated: false
+    };
+    const flashcardDeck12: Flashcard = {
+      id: 2,
+      deckId: 12,
+      ankiId: null,
+      front: 'front12',
+      back: 'back12',
+      description: '',
+      updated: false
+    };
+
+    component.flashcards.data = [flashcardDeck2, flashcardDeck12];
+    component.flashcards.filter = 'deck#12';
+
+    expect(component.flashcards.filteredData).toEqual([flashcardDeck12]);
+    expect(component.flashcards.filteredData).not.toContain(flashcardDeck2);
   });
 });

--- a/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.ts
+++ b/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.ts
@@ -29,7 +29,7 @@ import {Deck} from "../../model/Deck";
 
 function applyFilter(flashcard: Flashcard, filter: string, value: string): boolean {
 
-  const deckFilter: RegExpExecArray | null = /deck#([0-9])+/i.exec(filter);
+  const deckFilter: RegExpExecArray | null = /deck#([0-9]+)/i.exec(filter);
   if (deckFilter) {
     return flashcard.deckId === Number(deckFilter[1]);
   }


### PR DESCRIPTION
## Summary
- Fixes the deck filter regex in `vocabulary-list.component.ts` which only captured a single digit, causing `deck#12` to incorrectly match `deckId === 2`.
- Moved the `+` quantifier inside the capture group: `/deck#([0-9])+/i` -> `/deck#([0-9]+)/i`.
- Added a spec test asserting that filter token `deck#12` matches a flashcard with `deckId === 12` and not `deckId === 2`.

Fixes #232

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test -- --watch=false` — new vocabulary-list tests pass (pre-existing unrelated failures in other components remain, due to a pre-existing HttpClient/ActivatedRoute provider gap in their specs, not introduced by this change)