### PR TITLE
fix(vocabulary): persist deck rename with error reconciliation

### DIFF
--- a/src/app/vocabulary/components/deck-management-dialog/deck-management-dialog.html
+++ b/src/app/vocabulary/components/deck-management-dialog/deck-management-dialog.html
@@ -10,5 +10,5 @@
   }
 </mat-dialog-content>
 <mat-dialog-actions>
-  <button matButton cdkFocusInitial [mat-dialog-close]="deck()">Ok</button>
+  <button matButton cdkFocusInitial mat-dialog-close>Ok</button>
 </mat-dialog-actions>

--- a/src/app/vocabulary/components/deck-management-dialog/deck-management-dialog.spec.ts
+++ b/src/app/vocabulary/components/deck-management-dialog/deck-management-dialog.spec.ts
@@ -1,23 +1,82 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { DeckManagementDialog } from './deck-management-dialog';
+import { Deck } from '../../model/Deck';
 
 describe('DeckManagementDialog', () => {
   let component: DeckManagementDialog;
   let fixture: ComponentFixture<DeckManagementDialog>;
+  let httpMock: HttpTestingController;
+  let snackBar: MatSnackBar;
+
+  const deck: Deck = {id: 1, name: 'Old Name'};
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [DeckManagementDialog]
+      imports: [DeckManagementDialog],
+      providers: [provideHttpClient(), provideHttpClientTesting()]
     })
     .compileComponents();
 
     fixture = TestBed.createComponent(DeckManagementDialog);
     component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+    snackBar = TestBed.inject(MatSnackBar);
     fixture.detectChanges();
+
+    httpMock.expectOne(req => req.url.endsWith('/vocabulary/decks') && req.method === 'GET').flush([deck]);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should update local deck state and show a success snackbar when the rename succeeds', () => {
+    const snackBarSpy = spyOn(snackBar, 'open');
+
+    (component as any).vocabularyService.updateDeck = jasmine.createSpy().and.callFake(() => {
+      return {
+        subscribe: (handlers: any) => handlers.next({body: {id: 1, name: 'New Name'}})
+      };
+    });
+
+    (component as any).decks.set([deck]);
+
+    const dialogRef = {afterClosed: () => ({subscribe: (cb: (v: string | undefined) => void) => cb('New Name')})};
+    spyOn((component as any).dialog, 'open').and.returnValue(dialogRef);
+
+    component.openDialog(deck);
+
+    expect((component as any).decks()).toEqual([{id: 1, name: 'New Name'}]);
+    expect(snackBarSpy).toHaveBeenCalled();
+    expect(snackBarSpy.calls.mostRecent().args[0]).toContain('changed to New Name');
+  });
+
+  it('should keep local deck state unchanged and show an error snackbar when the rename fails', () => {
+    const snackBarSpy = spyOn(snackBar, 'open');
+
+    (component as any).vocabularyService.updateDeck = jasmine.createSpy().and.callFake(() => {
+      return {
+        subscribe: (handlers: any) => handlers.error('boom')
+      };
+    });
+
+    (component as any).decks.set([deck]);
+
+    const dialogRef = {afterClosed: () => ({subscribe: (cb: (v: string | undefined) => void) => cb('New Name')})};
+    spyOn((component as any).dialog, 'open').and.returnValue(dialogRef);
+
+    component.openDialog(deck);
+
+    expect((component as any).decks()).toEqual([deck]);
+    expect(snackBarSpy).toHaveBeenCalled();
+    expect(snackBarSpy.calls.mostRecent().args[0]).toContain('failed');
   });
 });

--- a/src/app/vocabulary/components/deck-management-dialog/deck-management-dialog.ts
+++ b/src/app/vocabulary/components/deck-management-dialog/deck-management-dialog.ts
@@ -1,10 +1,12 @@
-import {Component, inject, model, ModelSignal, signal, WritableSignal} from '@angular/core';
+import {Component, inject, signal, WritableSignal} from '@angular/core';
 import {VocabularyService} from "../../services/vocabulary.service";
 import {Deck} from "../../model/Deck";
 import {MatButton, MatIconButton} from "@angular/material/button";
 import {MatIcon} from "@angular/material/icon";
 import {MatDialog, MatDialogActions, MatDialogClose, MatDialogContent} from "@angular/material/dialog";
 import {DeckChangeNameDialog} from "../deck-change-name-dialog/deck-change-name-dialog";
+import {MatSnackBar} from "@angular/material/snack-bar";
+import {HttpResponse} from "@angular/common/http";
 
 @Component({
   selector: 'app-deck-management-dialog',
@@ -21,10 +23,9 @@ import {DeckChangeNameDialog} from "../deck-change-name-dialog/deck-change-name-
 })
 export class DeckManagementDialog {
 
-  readonly deck: ModelSignal<Deck | null> = model<Deck | null>(null);
-
   private dialog = inject(MatDialog);
   private vocabularyService: VocabularyService = inject(VocabularyService);
+  private snackBar: MatSnackBar = inject(MatSnackBar);
 
   protected decks: WritableSignal<Deck[]> = signal([]);
 
@@ -45,12 +46,18 @@ export class DeckManagementDialog {
         return;
       }
 
-      this.decks.update(decks => decks.map(d => d.id === deck.id ? {...d, name: newName} : d));
+      let updatedDeck: Deck = {...deck, name: newName};
 
-      let updatedDeck: Deck | undefined = this.decks().find(d => d.id === deck.id);
-      if (updatedDeck) {
-        this.deck.set(updatedDeck);
-      }
+      this.vocabularyService.updateDeck(updatedDeck).subscribe({
+        next: (res: HttpResponse<Deck>) => {
+          this.decks.update(decks => decks.map(d => d.id === deck.id ? {...d, name: res.body?.name ?? newName} : d));
+
+          this.snackBar.open(`Name of deck ${deck.id} changed to ${res.body?.name ?? newName}`, 'OK', {duration: 10000});
+        },
+        error: err => {
+          this.snackBar.open(`Changing name of deck ${deck.id} failed. ${err}`, 'OK', {duration: 10000});
+        }
+      });
     });
   }
 

--- a/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.spec.ts
+++ b/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.spec.ts
@@ -1,4 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
 
 import { VocabularyHomeComponent } from './vocabulary-home.component';
 
@@ -8,7 +11,8 @@ describe('HomeComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [VocabularyHomeComponent]
+      imports: [VocabularyHomeComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])]
     })
     .compileComponents();
 

--- a/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.ts
+++ b/src/app/vocabulary/components/vocabulary-home/vocabulary-home.component.ts
@@ -4,10 +4,6 @@ import {MatFabButton} from '@angular/material/button';
 import {MatIcon} from '@angular/material/icon';
 import {DeckManagementDialog} from "../deck-management-dialog/deck-management-dialog";
 import {MatDialog} from "@angular/material/dialog";
-import {Deck} from "../../model/Deck";
-import {VocabularyService} from "../../services/vocabulary.service";
-import {MatSnackBar} from "@angular/material/snack-bar";
-import {HttpResponse} from "@angular/common/http";
 
 @Component({
   selector: 'vocabulary-home',
@@ -23,27 +19,11 @@ import {HttpResponse} from "@angular/common/http";
 export class VocabularyHomeComponent {
 
   private dialog: MatDialog = inject(MatDialog);
-  private snackBar: MatSnackBar = inject(MatSnackBar);
-  private vocabularyService: VocabularyService = inject(VocabularyService);
 
   openDialog(): void {
-    let matDialogRef = this.dialog.open(DeckManagementDialog, {
+    this.dialog.open(DeckManagementDialog, {
       width: '800px',
       height: '600px'
-    });
-
-    matDialogRef.afterClosed().subscribe((updatedDeck: Deck | undefined) => {
-      if (!updatedDeck) {
-        return;
-      }
-      this.vocabularyService.updateDeck(updatedDeck).subscribe({
-        next: (res: HttpResponse<Deck>) => {
-          this.snackBar.open(`Name of deck ${updatedDeck.id} changed to ${res.body?.name}`, 'OK', {duration: 10000});
-        },
-        error: err => {
-          this.snackBar.open(`Changing name of deck ${updatedDeck.id} failed. ${err}`, 'OK', {duration: 10000});
-        }
-      });
     });
   }
 


### PR DESCRIPTION
## Summary
- Moves the `updateDeck` PUT call into `DeckManagementDialog`, where the rename is initiated, instead of letting the parent (`VocabularyHomeComponent`) perform persistence after the dialog already closed.
- The local `decks` signal is now only updated after the backend confirms success.
- On failure, an error snackbar is shown (matching the existing snackbar conventions in `vocabulary-home.component.ts`), and the displayed deck name no longer diverges from the server state.
- Removed the now-unused `deck` model output and dialog-result plumbing in `VocabularyHomeComponent`, since persistence and user feedback are fully handled inside the dialog.

Fixes #233

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test -- --watch=false` for the vocabulary module: `deck-management-dialog` and `vocabulary-home` specs pass (previously both were failing on master due to missing HTTP/Router test providers); added new specs covering successful rename (local state updates + success snackbar) and failed rename (local state unchanged + error snackbar)
- [x] Remaining pre-existing failures (`VocabularyService`, `ManageComponent`, `DeckChangeNameDialog`) are unrelated to this change and fail identically on master