### PR TITLE
fix(vocabulary): rename markedAsupdated signal to markedAsUpdated

### DIFF
--- a/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.html
+++ b/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.html
@@ -17,7 +17,7 @@
       Without Article
     </mat-checkbox>
     <mat-checkbox
-        [(ngModel)]="markedAsupdated"
+        [(ngModel)]="markedAsUpdated"
         (change)="filterMarkedAsUpdated('markedAsUpdated')">
       Updated
     </mat-checkbox>

--- a/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.ts
+++ b/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.ts
@@ -89,7 +89,7 @@ export class VocabularyListComponent implements OnInit, AfterViewInit, OnDestroy
   filters: string[] = [];
 
   readonly withoutArticle: ModelSignal<boolean> = model(false);
-  readonly markedAsupdated: ModelSignal<boolean> = model(false);
+  readonly markedAsUpdated: ModelSignal<boolean> = model(false);
   readonly withoutDescription: ModelSignal<boolean> = model(false);
 
   // Use signals to track count updates properly
@@ -163,7 +163,7 @@ export class VocabularyListComponent implements OnInit, AfterViewInit, OnDestroy
     this.searchText.set(search);
     this.selectedDeckId.set(deckId ? Number(deckId) : null);
     this.withoutArticle.set(withoutArticle);
-    this.markedAsupdated.set(markedAsUpdated);
+    this.markedAsUpdated.set(markedAsUpdated);
     this.withoutDescription.set(withoutDescription);
 
     this.filters = [];
@@ -247,8 +247,8 @@ export class VocabularyListComponent implements OnInit, AfterViewInit, OnDestroy
   }
 
   filterMarkedAsUpdated(value: string): void {
-    this.filterFlashcards(value, this.markedAsupdated());
-    this.updateQueryParam('markedAsUpdated', this.markedAsupdated());
+    this.filterFlashcards(value, this.markedAsUpdated());
+    this.updateQueryParam('markedAsUpdated', this.markedAsUpdated());
   }
 
   filterWithoutDescription(value: string): void {


### PR DESCRIPTION
## Summary
- Renames the `markedAsupdated` signal in `vocabulary-list.component.ts` to `markedAsUpdated`, aligning it with the `markedAsUpdated` filter token and query-param key used throughout the component and template.
- Updates the corresponding `[(ngModel)]` binding in `vocabulary-list.component.html`.

The filter previously worked only because the literal string `'markedAsUpdated'` was passed through correctly from the template; the signal name itself disagreed with the token. This rename removes that inconsistency so future edits relying on the signal name won't silently produce a no-op filter.

Fixes #234

## Test plan
- [x] `npm run build` succeeds
- [x] Verified no remaining references to `markedAsupdated` (grep across .ts/.html/.spec.ts)