### PR TITLE
refactor(vocabulary): standardize subscription cleanup with takeUntilDestroyed

### DIFF
--- a/src/app/vocabulary/components/deck-management-dialog/deck-management-dialog.ts
+++ b/src/app/vocabulary/components/deck-management-dialog/deck-management-dialog.ts
@@ -1,4 +1,4 @@
-import {Component, inject, signal, WritableSignal} from '@angular/core';
+import {Component, DestroyRef, inject, OnInit, signal, WritableSignal} from '@angular/core';
 import {VocabularyService} from "../../services/vocabulary.service";
 import {Deck} from "../../model/Deck";
 import {MatButton, MatIconButton} from "@angular/material/button";
@@ -7,6 +7,7 @@ import {MatDialog, MatDialogActions, MatDialogClose, MatDialogContent} from "@an
 import {DeckChangeNameDialog} from "../deck-change-name-dialog/deck-change-name-dialog";
 import {MatSnackBar} from "@angular/material/snack-bar";
 import {HttpResponse} from "@angular/common/http";
+import {takeUntilDestroyed} from "@angular/core/rxjs-interop";
 
 @Component({
   selector: 'app-deck-management-dialog',
@@ -21,18 +22,21 @@ import {HttpResponse} from "@angular/common/http";
   templateUrl: './deck-management-dialog.html',
   styleUrl: './deck-management-dialog.css',
 })
-export class DeckManagementDialog {
+export class DeckManagementDialog implements OnInit {
 
   private dialog = inject(MatDialog);
   private vocabularyService: VocabularyService = inject(VocabularyService);
   private snackBar: MatSnackBar = inject(MatSnackBar);
+  private destroyRef: DestroyRef = inject(DestroyRef);
 
   protected decks: WritableSignal<Deck[]> = signal([]);
 
-  constructor() {
-    this.vocabularyService.getDecks().subscribe(decks => {
-      this.decks.set(decks);
-    })
+  ngOnInit(): void {
+    this.vocabularyService.getDecks()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(decks => {
+        this.decks.set(decks);
+      });
   }
 
   openDialog(deck: Deck): void {
@@ -41,24 +45,28 @@ export class DeckManagementDialog {
       data: {name: deck.name}
     });
 
-    matDialogRef.afterClosed().subscribe((newName: string | undefined) => {
-      if (!newName || deck.name == newName) {
-        return;
-      }
-
-      let updatedDeck: Deck = {...deck, name: newName};
-
-      this.vocabularyService.updateDeck(updatedDeck).subscribe({
-        next: (res: HttpResponse<Deck>) => {
-          this.decks.update(decks => decks.map(d => d.id === deck.id ? {...d, name: res.body?.name ?? newName} : d));
-
-          this.snackBar.open(`Name of deck ${deck.id} changed to ${res.body?.name ?? newName}`, 'OK', {duration: 10000});
-        },
-        error: err => {
-          this.snackBar.open(`Changing name of deck ${deck.id} failed. ${err}`, 'OK', {duration: 10000});
+    matDialogRef.afterClosed()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((newName: string | undefined) => {
+        if (!newName || deck.name == newName) {
+          return;
         }
+
+        let updatedDeck: Deck = {...deck, name: newName};
+
+        this.vocabularyService.updateDeck(updatedDeck)
+          .pipe(takeUntilDestroyed(this.destroyRef))
+          .subscribe({
+            next: (res: HttpResponse<Deck>) => {
+              this.decks.update(decks => decks.map(d => d.id === deck.id ? {...d, name: res.body?.name ?? newName} : d));
+
+              this.snackBar.open(`Name of deck ${deck.id} changed to ${res.body?.name ?? newName}`, 'OK', {duration: 10000});
+            },
+            error: err => {
+              this.snackBar.open(`Changing name of deck ${deck.id} failed. ${err}`, 'OK', {duration: 10000});
+            }
+          });
       });
-    });
   }
 
 }

--- a/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.ts
+++ b/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, inject, model, ModelSignal, OnDestroy, OnInit, Signal, signal, ViewChild} from '@angular/core';
+import {AfterViewInit, Component, DestroyRef, inject, model, ModelSignal, OnDestroy, OnInit, Signal, signal, ViewChild} from '@angular/core';
 import {Subject} from 'rxjs';
 import {debounceTime, takeUntil} from 'rxjs/operators';
 import {VocabularyService} from '../../services/vocabulary.service';
@@ -24,7 +24,7 @@ import {MatLabel, MatOption, MatSelect, MatSelectChange} from '@angular/material
 import {MatCheckbox} from '@angular/material/checkbox';
 import {FormsModule} from '@angular/forms';
 
-import {toSignal} from "@angular/core/rxjs-interop";
+import {takeUntilDestroyed, toSignal} from "@angular/core/rxjs-interop";
 import {Deck} from "../../model/Deck";
 
 function applyFilter(flashcard: Flashcard, filter: string, value: string): boolean {
@@ -106,20 +106,23 @@ export class VocabularyListComponent implements OnInit, AfterViewInit, OnDestroy
   private vocabularyService: VocabularyService = inject(VocabularyService);
   private router: Router = inject(Router);
   private route: ActivatedRoute = inject(ActivatedRoute);
+  private destroyRef: DestroyRef = inject(DestroyRef);
 
   readonly decks: Signal<Deck[]> = toSignal(this.vocabularyService.getDecks(), {initialValue: []})
 
   ngOnInit(): void {
-    this.vocabularyService.getFlashcards().subscribe({
-      next: value => {
-        this.flashcards.data = value;
-        this.applyStateFromQueryParams();
-        this.updateCounts();
-      },
-      error: err => {
-        console.log(err)
-      }
-    });
+    this.vocabularyService.getFlashcards()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: value => {
+          this.flashcards.data = value;
+          this.applyStateFromQueryParams();
+          this.updateCounts();
+        },
+        error: err => {
+          console.log(err)
+        }
+      });
 
     this.flashcards.filterPredicate = (data: Flashcard, filter) => {
 


### PR DESCRIPTION
## Summary
- Use `takeUntilDestroyed(destroyRef)` consistently across vocabulary component subscriptions, following the convention in `add-word.component.ts`.
- `VocabularyListComponent.ngOnInit`: `getFlashcards().subscribe(...)` now uses `takeUntilDestroyed`.
- `DeckManagementDialog`: moved `getDecks().subscribe(...)` from the constructor to `ngOnInit` (implements `OnInit`), and applied `takeUntilDestroyed` to `getDecks()`, `afterClosed()`, and the `updateDeck()` subscriptions.

This is a low-severity consistency/best-practice cleanup (no actual leaks — HttpClient and `afterClosed()` are one-shot observables).

Fixes #235

## Test plan
- [x] `npm run build` succeeds
- [ ] `npm test -- --watch=false` — Chrome unavailable in this sandbox, could not run Karma tests; no logic changes beyond subscription wiring