### PR TITLE
fix(vocabulary): type-safe sortingDataAccessor

### DIFF
--- a/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.ts
+++ b/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.ts
@@ -199,10 +199,19 @@ export class VocabularyListComponent implements OnInit, AfterViewInit, OnDestroy
     this.flashcards.sortingDataAccessor = (data, sortHeaderId) => {
       if (sortHeaderId === 'front') {
         return data[sortHeaderId]?.toLowerCase();
-      } else {
-        return (data as any)[sortHeaderId];
       }
+
+      if (this.isFlashcardKey(data, sortHeaderId)) {
+        const value = data[sortHeaderId];
+        return typeof value === 'string' || typeof value === 'number' ? value : '';
+      }
+
+      return '';
     }
+  }
+
+  private isFlashcardKey(data: Flashcard, key: string): key is keyof Flashcard {
+    return key in data;
   }
 
   navigateToWord(id: number) {


### PR DESCRIPTION
## Summary
- Replace `(data as any)[sortHeaderId]` with a type-safe `keyof Flashcard` check in `vocabulary-list.component.ts`
- Sort accessor now returns `''` for unknown/non-primitive fields instead of relying on an `any` cast

Fixes #237

## Test plan
- [x] `npm run build` succeeds
- [ ] `npm test -- --watch=false` (Chrome not available in sandbox; relies on build/typecheck success)