### PR TITLE
fix(vocabulary): broaden word search filter charset

### DIFF
--- a/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.spec.ts
+++ b/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.spec.ts
@@ -52,4 +52,31 @@ describe('ListComponent', () => {
     expect(component.flashcards.filteredData).toEqual([flashcardDeck12]);
     expect(component.flashcards.filteredData).not.toContain(flashcardDeck2);
   });
+
+  it('should filter by search term containing digits, spaces and accented characters', () => {
+    const flashcardMatching: Flashcard = {
+      id: 1,
+      deckId: 1,
+      ankiId: null,
+      front: 'café 123',
+      back: 'back1',
+      description: '',
+      updated: false
+    };
+    const flashcardNonMatching: Flashcard = {
+      id: 2,
+      deckId: 1,
+      ankiId: null,
+      front: 'other word',
+      back: 'back2',
+      description: '',
+      updated: false
+    };
+
+    component.flashcards.data = [flashcardMatching, flashcardNonMatching];
+    component.flashcards.filter = '####café 123####';
+
+    expect(component.flashcards.filteredData).toEqual([flashcardMatching]);
+    expect(component.flashcards.filteredData).not.toContain(flashcardNonMatching);
+  });
 });

--- a/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.ts
+++ b/src/app/vocabulary/components/vocabulary-list/vocabulary-list.component.ts
@@ -46,7 +46,7 @@ function applyFilter(flashcard: Flashcard, filter: string, value: string): boole
     return !flashcard.description || flashcard.description.trim() === '';
   }
 
-  const wordFilter = /####([a-z]+)####/i.exec(filter);
+  const wordFilter = /####(.+)####/i.exec(filter);
   if (wordFilter) {
     return value.toLowerCase().includes(wordFilter[1]);
   }


### PR DESCRIPTION
## Summary
- The `####...####` word search filter in `vocabulary-list.component.ts` only matched `[a-z]+`, so search terms containing digits, spaces, or accented characters never matched a flashcard's `front` text.
- Broaden the captured group to `.+` (non-greedy stop is unnecessary since `####` is unlikely to appear in a search term), so any character sequence up to the closing `####` delimiter is matched.

## Test plan
- [x] Added a spec test asserting that a search term containing digits, spaces, and accented characters (`café 123`) correctly matches a flashcard whose `front` contains that text, and does not match an unrelated flashcard.
- [x] `npm run build` succeeds.
- [ ] `npm test` could not run in this sandbox (no Chrome binary available).

Fixes #238