### PR TITLE
feat(nutrition): meal templates management page (CRUD UI)

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -37,6 +37,7 @@ import {NutritionFoodsComponent} from './nutrition/components/nutrition-foods/nu
 import {NutritionDayComponent} from './nutrition/components/nutrition-day/nutrition-day.component';
 import {NutritionCanteenComponent} from './nutrition/components/nutrition-canteen/nutrition-canteen.component';
 import {NutritionDashboardComponent} from './nutrition/components/nutrition-dashboard/nutrition-dashboard.component';
+import {NutritionMealsComponent} from './nutrition/components/nutrition-meals/nutrition-meals.component';
 
 export const routes: Routes = [
   {path: '', component: HomeComponent},
@@ -116,6 +117,7 @@ export const routes: Routes = [
       {path: 'canteen', component: NutritionCanteenComponent, data: {home: '/nutrition'}},
       {path: 'weight', component: NutritionWeightComponent, data: {home: '/nutrition'}},
       {path: 'foods', component: NutritionFoodsComponent, data: {home: '/nutrition'}},
+      {path: 'meals', component: NutritionMealsComponent, data: {home: '/nutrition'}},
       {path: 'profile', component: NutritionProfileComponent, data: {home: '/nutrition'}}
     ]
   }

--- a/src/app/nutrition/components/nutrition-layout/nutrition-layout.component.html
+++ b/src/app/nutrition/components/nutrition-layout/nutrition-layout.component.html
@@ -26,6 +26,9 @@
         <a mat-menu-item routerLink="/nutrition/foods">
           <span>Lebensmittel</span>
         </a>
+        <a mat-menu-item routerLink="/nutrition/meals">
+          <span>Mahlzeiten</span>
+        </a>
         <a mat-menu-item routerLink="/nutrition/profile">
           <span>Profil</span>
         </a>

--- a/src/app/nutrition/components/nutrition-meals/nutrition-meals.component.css
+++ b/src/app/nutrition/components/nutrition-meals/nutrition-meals.component.css
@@ -1,0 +1,183 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --bg:          #06080e;
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+
+  --c-g:  #a3e635;
+  --c-e:  #fb7185;
+
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  font-family: 'Outfit', sans-serif;
+  color: var(--text);
+}
+
+.meals {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem clamp(1rem, 6vw, 4rem);
+  max-width: 760px;
+  width: 100%;
+  margin: 0 auto;
+  box-sizing: border-box;
+  min-height: 0;
+  flex: 1;
+  overflow: hidden;
+}
+
+.panel-table {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+}
+
+/* ── Panels ──────────────────────────────────────── */
+.panel__head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.panel__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--c-g);
+  box-shadow: 0 0 6px var(--c-g);
+}
+
+.panel__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  color: var(--text-dim);
+  text-transform: uppercase;
+}
+
+/* ── Toolbar ─────────────────────────────────────── */
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.btn-add {
+  height: 56px;
+  border-radius: 8px !important;
+  font-weight: 600 !important;
+  transition: background 0.2s, box-shadow 0.2s;
+  background: color-mix(in srgb, var(--c-g) 14%, transparent) !important;
+  border: 1px solid color-mix(in srgb, var(--c-g) 35%, transparent) !important;
+  color: var(--c-g) !important;
+}
+
+.btn-add:hover {
+  background: color-mix(in srgb, var(--c-g) 22%, transparent) !important;
+  box-shadow: 0 0 12px rgba(163, 230, 53, 0.25) !important;
+}
+
+/* ── Table ───────────────────────────────────────── */
+.table-container {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: auto;
+  min-height: 0;
+  flex: 1;
+}
+
+table {
+  width: 100%;
+  background: transparent !important;
+}
+
+.col-header {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.75rem !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.12em !important;
+  text-transform: uppercase !important;
+  color: var(--text-dim) !important;
+  background: var(--raised) !important;
+  border-bottom: 1px solid var(--border-mid) !important;
+  height: 36px !important;
+  padding: 0 12px !important;
+}
+
+::ng-deep .mat-mdc-header-row {
+  background: var(--raised) !important;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+::ng-deep .mat-mdc-cell {
+  font-size: 0.85rem !important;
+  color: var(--text) !important;
+  background: transparent !important;
+  border-bottom: 1px solid var(--border) !important;
+  padding: 0 12px !important;
+}
+
+.col-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.col-actions {
+  width: 96px;
+  text-align: right;
+  padding-right: 8px !important;
+  white-space: nowrap;
+}
+
+.btn-edit, .btn-del {
+  min-width: 48px;
+  min-height: 48px;
+}
+
+.btn-edit {
+  color: var(--text-dim);
+  transition: color 0.2s;
+}
+
+.btn-edit:hover { color: var(--c-g); }
+
+.btn-del {
+  color: var(--text-dim);
+  transition: color 0.2s;
+}
+
+.btn-del:hover { color: var(--c-e); }
+
+/* ── Empty ───────────────────────────────────────── */
+.empty {
+  margin: 0;
+  padding: 1.5rem;
+  text-align: center;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  background: var(--surface);
+  border: 1px dashed var(--border-mid);
+  border-radius: 12px;
+}

--- a/src/app/nutrition/components/nutrition-meals/nutrition-meals.component.html
+++ b/src/app/nutrition/components/nutrition-meals/nutrition-meals.component.html
@@ -1,0 +1,61 @@
+<div class="meals">
+
+  <section class="panel">
+    <header class="panel__head">
+      <span class="panel__dot"></span>
+      <span class="panel__label">MAHLZEITEN</span>
+    </header>
+
+    <div class="toolbar">
+      <div class="actions">
+        <button mat-flat-button type="button" class="btn-add" (click)="openAddDialog()">
+          <mat-icon>add</mat-icon>
+          Mahlzeit hinzufügen
+        </button>
+      </div>
+    </div>
+  </section>
+
+  <section class="panel panel-table">
+    @if (templates.length) {
+      <div class="table-container">
+        <table mat-table [dataSource]="templates">
+
+          <ng-container matColumnDef="name">
+            <th *matHeaderCellDef mat-header-cell class="col-header">Name</th>
+            <td *matCellDef="let template" mat-cell>{{ template.name }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="items">
+            <th *matHeaderCellDef mat-header-cell class="col-header col-num">Anzahl</th>
+            <td *matCellDef="let template" mat-cell class="col-num">{{ template.items.length }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="kcal">
+            <th *matHeaderCellDef mat-header-cell class="col-header col-num">kcal</th>
+            <td *matCellDef="let template" mat-cell class="col-num">{{ totalKcal(template) | number:'1.0-0':'de' }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="actions">
+            <th *matHeaderCellDef mat-header-cell class="col-header"></th>
+            <td *matCellDef="let template" mat-cell class="col-actions">
+              <button mat-icon-button class="btn-edit" matTooltip="Bearbeiten" aria-label="Bearbeiten" (click)="openEditDialog(template)">
+                <mat-icon>edit</mat-icon>
+              </button>
+              <button mat-icon-button class="btn-del" matTooltip="Löschen" aria-label="Löschen" (click)="openDeleteDialog(template)">
+                <mat-icon>delete</mat-icon>
+              </button>
+            </td>
+          </ng-container>
+
+          <tr *matHeaderRowDef="columnsToDisplay" mat-header-row></tr>
+          <tr *matRowDef="let template; columns: columnsToDisplay;" mat-row></tr>
+
+        </table>
+      </div>
+    } @else {
+      <p class="empty">Noch keine Mahlzeiten. Lege eine an, um sie schnell ins Tagebuch übernehmen zu können.</p>
+    }
+  </section>
+
+</div>

--- a/src/app/nutrition/components/nutrition-meals/nutrition-meals.component.ts
+++ b/src/app/nutrition/components/nutrition-meals/nutrition-meals.component.ts
@@ -1,0 +1,124 @@
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, inject, OnInit} from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
+import {DecimalPipe} from '@angular/common';
+import {
+  MatCell,
+  MatCellDef,
+  MatColumnDef,
+  MatHeaderCell,
+  MatHeaderCellDef,
+  MatHeaderRow,
+  MatHeaderRowDef,
+  MatRow,
+  MatRowDef,
+  MatTable
+} from '@angular/material/table';
+import {MatButton, MatIconButton} from '@angular/material/button';
+import {MatIcon} from '@angular/material/icon';
+import {MatTooltip} from '@angular/material/tooltip';
+import {MatDialog} from '@angular/material/dialog';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {EMPTY, switchMap} from 'rxjs';
+import {NutritionService} from '../../services/nutrition.service';
+import {MealTemplate} from '../../models/nutrition.model';
+import {MealTemplateEditDialogComponent} from '../../dialogs/meal-template-edit-dialog/meal-template-edit-dialog.component';
+import {MealTemplateDeleteDialogComponent} from '../../dialogs/meal-template-delete-dialog/meal-template-delete-dialog.component';
+
+@Component({
+  selector: 'app-nutrition-meals',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DecimalPipe,
+    MatTable,
+    MatColumnDef,
+    MatHeaderCell,
+    MatHeaderCellDef,
+    MatCellDef,
+    MatCell,
+    MatHeaderRow,
+    MatHeaderRowDef,
+    MatRow,
+    MatRowDef,
+    MatButton,
+    MatIconButton,
+    MatIcon,
+    MatTooltip
+  ],
+  templateUrl: './nutrition-meals.component.html',
+  styleUrl: './nutrition-meals.component.css'
+})
+export class NutritionMealsComponent implements OnInit {
+
+  templates: MealTemplate[] = [];
+  columnsToDisplay = ['name', 'items', 'kcal', 'actions'];
+
+  private nutritionService = inject(NutritionService);
+  private dialog = inject(MatDialog);
+  private snackBar = inject(MatSnackBar);
+  private cdr = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
+
+  ngOnInit(): void {
+    this.reload();
+  }
+
+  totalKcal(template: MealTemplate): number {
+    return template.items.reduce((s, i) => s + i.kcal, 0);
+  }
+
+  private reload(): void {
+    this.nutritionService.getMealTemplates().subscribe(templates => {
+      this.templates = templates;
+      this.cdr.markForCheck();
+    });
+  }
+
+  openAddDialog(): void {
+    this.openEditDialog(null);
+  }
+
+  openEditDialog(template: MealTemplate | null): void {
+    const ref = this.dialog.open(MealTemplateEditDialogComponent, {data: {template}});
+    ref.afterClosed().pipe(
+      switchMap(result => {
+        if (!result) return EMPTY;
+        return template
+          ? this.nutritionService.updateMealTemplate(template.id, result)
+          : this.nutritionService.createMealTemplate(result);
+      }),
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe({
+      next: updated => {
+        if (template) {
+          this.templates = this.templates.map(t => t.id === updated.id ? updated : t);
+          this.snackBar.open('Mahlzeit aktualisiert', 'OK', {duration: 3000});
+        } else {
+          this.templates = [...this.templates, updated];
+          this.snackBar.open('Mahlzeit gespeichert', 'OK', {duration: 3000});
+        }
+        this.cdr.markForCheck();
+      },
+      error: () => {
+        const msg = template ? 'Mahlzeit konnte nicht aktualisiert werden' : 'Mahlzeit konnte nicht gespeichert werden';
+        this.snackBar.open(msg, 'Schließen', {duration: 5000});
+      }
+    });
+  }
+
+  openDeleteDialog(template: MealTemplate): void {
+    const ref = this.dialog.open(MealTemplateDeleteDialogComponent, {data: {name: template.name}});
+    ref.afterClosed().pipe(
+      switchMap(result => result === 'confirmed' ? this.nutritionService.deleteMealTemplate(template.id) : EMPTY),
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe({
+      next: () => {
+        this.templates = this.templates.filter(t => t.id !== template.id);
+        this.cdr.markForCheck();
+        this.snackBar.open('Mahlzeit gelöscht', 'OK', {duration: 3000});
+      },
+      error: () => {
+        this.snackBar.open('Mahlzeit konnte nicht gelöscht werden', 'Schließen', {duration: 5000});
+      }
+    });
+  }
+}

--- a/src/app/nutrition/dialogs/meal-template-delete-dialog/meal-template-delete-dialog.component.css
+++ b/src/app/nutrition/dialogs/meal-template-delete-dialog/meal-template-delete-dialog.component.css
@@ -1,0 +1,69 @@
+:host {
+  --surface:     #0c1018;
+  --border-mid:  rgba(255, 255, 255, 0.13);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --c-n:         #2dd4bf;
+  --c-e:         #fb7185;
+}
+
+::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-dialog-title {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
+  color: var(--text) !important;
+  letter-spacing: 0.03em;
+}
+
+::ng-deep .mat-mdc-dialog-content {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.9rem !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions {
+  gap: 10px;
+  padding-bottom: 16px !important;
+  justify-content: center !important;
+}
+
+.btn-confirm {
+  background: rgba(45, 212, 191, 0.10) !important;
+  border: 1px solid rgba(45, 212, 191, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-n) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-confirm:hover {
+  background: rgba(45, 212, 191, 0.18) !important;
+  box-shadow: 0 0 12px rgba(45, 212, 191, 0.25) !important;
+}
+
+.btn-confirm mat-icon {
+  color: var(--c-n) !important;
+}
+
+.btn-cancel {
+  background: rgba(251, 113, 133, 0.10) !important;
+  border: 1px solid rgba(251, 113, 133, 0.3) !important;
+  border-radius: 8px !important;
+  color: var(--c-e) !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-cancel:hover {
+  background: rgba(251, 113, 133, 0.18) !important;
+  box-shadow: 0 0 12px rgba(251, 113, 133, 0.25) !important;
+}
+
+.btn-cancel mat-icon {
+  color: var(--c-e) !important;
+}

--- a/src/app/nutrition/dialogs/meal-template-delete-dialog/meal-template-delete-dialog.component.html
+++ b/src/app/nutrition/dialogs/meal-template-delete-dialog/meal-template-delete-dialog.component.html
@@ -1,0 +1,14 @@
+<h2 mat-dialog-title>Mahlzeit löschen</h2>
+
+<mat-dialog-content>
+  <span>«{{ templateName }}» wirklich löschen?</span>
+</mat-dialog-content>
+
+<mat-dialog-actions align="center">
+  <button mat-mini-fab class="btn-confirm" aria-label="Löschen bestätigen" (click)="confirm()">
+    <mat-icon>check_circle</mat-icon>
+  </button>
+  <button mat-mini-fab mat-dialog-close class="btn-cancel" aria-label="Abbrechen">
+    <mat-icon>close</mat-icon>
+  </button>
+</mat-dialog-actions>

--- a/src/app/nutrition/dialogs/meal-template-delete-dialog/meal-template-delete-dialog.component.ts
+++ b/src/app/nutrition/dialogs/meal-template-delete-dialog/meal-template-delete-dialog.component.ts
@@ -1,0 +1,28 @@
+import {ChangeDetectionStrategy, Component, inject} from '@angular/core';
+import {MAT_DIALOG_DATA, MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MatIcon} from '@angular/material/icon';
+import {MatMiniFabButton} from '@angular/material/button';
+
+@Component({
+  selector: 'app-meal-template-delete-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatIcon,
+    MatMiniFabButton
+  ],
+  templateUrl: './meal-template-delete-dialog.component.html',
+  styleUrl: './meal-template-delete-dialog.component.css'
+})
+export class MealTemplateDeleteDialogComponent {
+
+  private dialogRef = inject(MatDialogRef<MealTemplateDeleteDialogComponent>);
+  templateName = inject<{name: string}>(MAT_DIALOG_DATA).name;
+
+  confirm() {
+    this.dialogRef.close('confirmed');
+  }
+}

--- a/src/app/nutrition/dialogs/meal-template-edit-dialog/meal-template-edit-dialog.component.css
+++ b/src/app/nutrition/dialogs/meal-template-edit-dialog/meal-template-edit-dialog.component.css
@@ -1,0 +1,278 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+  --c-g:         #a3e635;
+  --c-n:         #2dd4bf;
+  --c-b:         #4da6ff;
+  --c-e:         #fb7185;
+}
+
+::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+  min-width: 340px !important;
+}
+
+::ng-deep .mat-mdc-dialog-title {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
+  color: var(--text) !important;
+  letter-spacing: 0.03em;
+}
+
+::ng-deep .mat-mdc-dialog-content {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.9rem !important;
+  overflow: visible !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions {
+  gap: 10px;
+  padding-bottom: 16px !important;
+  justify-content: center !important;
+}
+
+.entry-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.5rem;
+}
+
+.field-full { width: 100%; }
+
+.search-error {
+  margin: 0 0 0.25rem;
+  font-size: 0.75rem;
+  color: var(--c-e);
+}
+
+::ng-deep .mat-mdc-form-field mat-spinner circle {
+  stroke: var(--c-n) !important;
+}
+
+/* ── Autocomplete options ────────────────────────── */
+.opt-name { font-weight: 600; }
+
+.opt-brand {
+  margin-left: 0.4rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.opt-kcal {
+  display: block;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  color: var(--text-dim);
+}
+
+/* ── Live macros ─────────────────────────────────── */
+.macros {
+  margin-top: 0.25rem;
+  padding: 0.75rem;
+  background: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+
+.macros__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.macros__grid {
+  margin-top: 0.5rem;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5rem;
+}
+
+.macro {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.4rem 0.25rem;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--mc) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--mc) 25%, transparent);
+}
+
+.macro--kcal { --mc: var(--c-g); }
+.macro--p    { --mc: var(--c-n); }
+.macro--c    { --mc: var(--c-b); }
+.macro--f    { --mc: var(--c-e); }
+
+.macro__v {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--mc);
+  font-variant-numeric: tabular-nums;
+}
+
+.macro__u {
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+}
+
+/* ── Dark theme form fields ──────────────────────── */
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__trailing {
+  border-color: var(--border-mid) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined:not(.mdc-text-field--disabled) .mdc-text-field__input {
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-mdc-floating-label {
+  color: var(--text-dim) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-icon {
+  color: var(--text-dim) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__trailing {
+  border-color: var(--c-g) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mat-mdc-floating-label { color: var(--c-g) !important; }
+
+/* ── Staged list ─────────────────────────────────── */
+.btn-add-staged {
+  align-self: flex-start;
+  margin-top: 0.5rem;
+  border-color: var(--border-mid) !important;
+  color: var(--c-n) !important;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.8rem;
+}
+
+.btn-add-staged mat-icon {
+  margin-right: 0.25rem;
+  color: var(--c-n) !important;
+}
+
+.staged-list {
+  margin-top: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.staged-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  background: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.staged-item__name {
+  flex: 1;
+  font-weight: 600;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.staged-item__qty,
+.staged-item__kcal {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.staged-item__remove {
+  width: 32px !important;
+  height: 32px !important;
+  padding: 0 !important;
+  color: var(--c-e) !important;
+}
+
+.staged-item__remove mat-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+  color: var(--c-e) !important;
+}
+
+/* ── Buttons ─────────────────────────────────────── */
+.btn-confirm,
+.btn-cancel {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.85rem;
+  font-weight: 600;
+  border-radius: 8px !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-confirm mat-icon,
+.btn-cancel mat-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+}
+
+.btn-confirm {
+  background: rgba(45, 212, 191, 0.10) !important;
+  border: 1px solid rgba(45, 212, 191, 0.3) !important;
+  color: var(--c-n) !important;
+}
+
+.btn-confirm:hover:not([disabled]) {
+  background: rgba(45, 212, 191, 0.18) !important;
+  box-shadow: 0 0 12px rgba(45, 212, 191, 0.25) !important;
+}
+
+.btn-confirm[disabled] { opacity: 0.4 !important; }
+
+.btn-confirm mat-icon { color: var(--c-n) !important; }
+
+.btn-cancel {
+  background: rgba(251, 113, 133, 0.10) !important;
+  border: 1px solid rgba(251, 113, 133, 0.3) !important;
+  color: var(--c-e) !important;
+}
+
+.btn-cancel:hover {
+  background: rgba(251, 113, 133, 0.18) !important;
+  box-shadow: 0 0 12px rgba(251, 113, 133, 0.25) !important;
+}
+
+.btn-cancel mat-icon { color: var(--c-e) !important; }
+
+@media (max-width: 420px) {
+  .btn-confirm,
+  .btn-cancel {
+    flex: 1;
+    justify-content: center;
+  }
+}

--- a/src/app/nutrition/dialogs/meal-template-edit-dialog/meal-template-edit-dialog.component.html
+++ b/src/app/nutrition/dialogs/meal-template-edit-dialog/meal-template-edit-dialog.component.html
@@ -1,0 +1,106 @@
+<h2 mat-dialog-title>{{ title }}</h2>
+
+<mat-dialog-content>
+  <form class="entry-form" [formGroup]="form">
+    <mat-form-field appearance="outline" class="field-full">
+      <mat-label>Name</mat-label>
+      <input matInput formControlName="name" />
+      @if (name.hasError('required')) {
+        <mat-error>Name ist erforderlich</mat-error>
+      }
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="field-full">
+      <mat-label>Lebensmittel</mat-label>
+      @if (searching) {
+        <mat-spinner matSuffix diameter="18" />
+      } @else {
+        <mat-icon matSuffix>search</mat-icon>
+      }
+      <input matInput autocomplete="off" formControlName="foodSearch"
+             [matAutocomplete]="auto" placeholder="Suchen…" />
+      <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayFood"
+                        (optionSelected)="onFoodSelected($event)">
+        @for (food of results; track food.id) {
+          <mat-option [value]="food">
+            <span class="opt-name">{{ food.name }}</span>
+            @if (food.brand) {
+              <span class="opt-brand">{{ food.brand }}</span>
+            }
+            <span class="opt-kcal">{{ food.kcalPer100 | number:'1.0-0':'de' }} kcal / 100 g</span>
+          </mat-option>
+        }
+      </mat-autocomplete>
+    </mat-form-field>
+
+    @if (searchFailed) {
+      <p class="search-error">Lebensmittel konnten nicht geladen werden.</p>
+    }
+
+    <mat-form-field appearance="outline" class="field-full">
+      <mat-label>Menge</mat-label>
+      <input matInput #quantityInput type="number" step="1" inputmode="numeric" formControlName="quantityG" />
+      <span matSuffix>g</span>
+      @if (quantityG.hasError('required')) {
+        <mat-error>Menge ist erforderlich</mat-error>
+      } @else if (quantityG.hasError('min')) {
+        <mat-error>Muss 0 oder größer sein</mat-error>
+      }
+    </mat-form-field>
+
+    @if (selected) {
+      <div class="macros">
+        <span class="macros__label">Für {{ quantityG.value || 0 }} g</span>
+        <div class="macros__grid">
+          <div class="macro macro--kcal">
+            <span class="macro__v">{{ scaled(selected.kcalPer100) | number:'1.0-0':'de' }}</span>
+            <span class="macro__u">kcal</span>
+          </div>
+          <div class="macro macro--p">
+            <span class="macro__v">{{ scaled(selected.proteinPer100) | number:'1.0-1':'de' }}</span>
+            <span class="macro__u">P</span>
+          </div>
+          <div class="macro macro--c">
+            <span class="macro__v">{{ scaled(selected.carbsPer100) | number:'1.0-1':'de' }}</span>
+            <span class="macro__u">KH</span>
+          </div>
+          <div class="macro macro--f">
+            <span class="macro__v">{{ scaled(selected.fatPer100) | number:'1.0-1':'de' }}</span>
+            <span class="macro__u">F</span>
+          </div>
+        </div>
+      </div>
+
+      <button mat-stroked-button type="button" class="btn-add-staged" [disabled]="!canAdd" (click)="addToStaged()">
+        <mat-icon>playlist_add</mat-icon>
+        Weiteres hinzufügen
+      </button>
+    }
+  </form>
+
+  @if (staged.length > 0) {
+    <div class="staged-list">
+      @for (item of staged; track item; let i = $index) {
+        <div class="staged-item">
+          <span class="staged-item__name">{{ item.foodName }}</span>
+          <span class="staged-item__qty">{{ item.quantityG | number:'1.0-0':'de' }} g</span>
+          <span class="staged-item__kcal">{{ scaledFor(item, item.kcalPer100) | number:'1.0-0':'de' }} kcal</span>
+          <button mat-icon-button type="button" class="staged-item__remove" aria-label="Eintrag entfernen" (click)="removeStaged(i)">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </div>
+      }
+    </div>
+  }
+</mat-dialog-content>
+
+<mat-dialog-actions align="center">
+  <button mat-flat-button type="button" class="btn-confirm" [disabled]="name.invalid" (click)="save()">
+    <mat-icon>check_circle</mat-icon>
+    Speichern
+  </button>
+  <button mat-stroked-button type="button" mat-dialog-close class="btn-cancel">
+    <mat-icon>close</mat-icon>
+    Abbrechen
+  </button>
+</mat-dialog-actions>

--- a/src/app/nutrition/dialogs/meal-template-edit-dialog/meal-template-edit-dialog.component.ts
+++ b/src/app/nutrition/dialogs/meal-template-edit-dialog/meal-template-edit-dialog.component.ts
@@ -1,0 +1,184 @@
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, ElementRef, inject, OnInit, ViewChild} from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
+import {DecimalPipe} from '@angular/common';
+import {FormControl, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
+import {MAT_DIALOG_DATA, MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MatError, MatFormField, MatLabel, MatSuffix} from '@angular/material/form-field';
+import {MatInput} from '@angular/material/input';
+import {NoWheelDirective} from '../../directives/no-wheel.directive';
+import {MatAutocomplete, MatAutocompleteSelectedEvent, MatAutocompleteTrigger} from '@angular/material/autocomplete';
+import {MatOption} from '@angular/material/core';
+import {MatIcon} from '@angular/material/icon';
+import {MatProgressSpinner} from '@angular/material/progress-spinner';
+import {MatButton, MatIconButton} from '@angular/material/button';
+import {catchError, debounceTime, distinctUntilChanged, finalize, of, startWith, switchMap, tap} from 'rxjs';
+import {NutritionService} from '../../services/nutrition.service';
+import {Food, MealTemplate, MealTemplateInput} from '../../models/nutrition.model';
+
+export interface MealTemplateEditDialogData {
+  template: MealTemplate | null;
+}
+
+/** A food + portion staged for the template, with per-100 g macros snapshot for display. */
+interface StagedItem {
+  foodId: string;
+  foodName: string;
+  quantityG: number;
+  kcalPer100: number;
+  proteinPer100: number;
+  carbsPer100: number;
+  fatPer100: number;
+}
+
+@Component({
+  selector: 'app-meal-template-edit-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ReactiveFormsModule,
+    DecimalPipe,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatFormField,
+    MatLabel,
+    MatError,
+    MatSuffix,
+    MatInput,
+    NoWheelDirective,
+    MatAutocomplete,
+    MatAutocompleteTrigger,
+    MatOption,
+    MatIcon,
+    MatProgressSpinner,
+    MatIconButton,
+    MatButton
+  ],
+  templateUrl: './meal-template-edit-dialog.component.html',
+  styleUrl: './meal-template-edit-dialog.component.css'
+})
+export class MealTemplateEditDialogComponent implements OnInit {
+
+  private nutritionService = inject(NutritionService);
+  private dialogRef = inject(MatDialogRef<MealTemplateEditDialogComponent>);
+  private cdr = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
+  private data = inject<MealTemplateEditDialogData>(MAT_DIALOG_DATA);
+
+  @ViewChild('quantityInput') quantityInput?: ElementRef<HTMLInputElement>;
+
+  title = this.data.template ? 'Mahlzeit bearbeiten' : 'Mahlzeit hinzufügen';
+
+  name = new FormControl(this.data.template?.name ?? '', {nonNullable: true, validators: Validators.required});
+  foodSearch = new FormControl<string | Food>('', {nonNullable: true});
+  quantityG = new FormControl<number | null>(null, [Validators.required, Validators.min(0)]);
+  form = new FormGroup({name: this.name, foodSearch: this.foodSearch, quantityG: this.quantityG});
+
+  results: Food[] = [];
+  selected: Food | null = null;
+  searchFailed = false;
+  searching = false;
+
+  staged: StagedItem[] = (this.data.template?.items ?? []).map(item => ({
+    foodId: item.foodId,
+    foodName: item.foodName,
+    quantityG: item.quantityG,
+    kcalPer100: item.kcal / item.quantityG * 100,
+    proteinPer100: item.proteinG / item.quantityG * 100,
+    carbsPer100: item.carbsG / item.quantityG * 100,
+    fatPer100: item.fatG / item.quantityG * 100
+  }));
+
+  ngOnInit(): void {
+    this.foodSearch.valueChanges.pipe(
+      startWith(this.foodSearch.value),
+      debounceTime(300),
+      distinctUntilChanged(),
+      tap(() => {
+        this.searchFailed = false;
+        this.searching = true;
+        this.cdr.markForCheck();
+      }),
+      switchMap(value => {
+        return this.nutritionService.searchFoods(typeof value === 'string' ? value.trim() : '').pipe(
+          catchError(() => {
+            this.searchFailed = true;
+            return of<Food[]>([]);
+          }),
+          finalize(() => {
+            this.searching = false;
+            this.cdr.markForCheck();
+          })
+        );
+      }),
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe(foods => {
+      this.results = foods;
+      this.cdr.markForCheck();
+    });
+  }
+
+  displayFood(food: Food | string | null): string {
+    return food && typeof food !== 'string' ? food.name : (food ?? '');
+  }
+
+  onFoodSelected(event: MatAutocompleteSelectedEvent): void {
+    this.selected = event.option.value as Food;
+    if (this.quantityG.value == null && this.selected.defaultServingG != null) {
+      this.quantityG.setValue(this.selected.defaultServingG);
+    }
+    this.cdr.markForCheck();
+    setTimeout(() => {
+      const input = this.quantityInput?.nativeElement;
+      input?.focus();
+      input?.select();
+    });
+  }
+
+  /** Macro value for the current portion, scaled from the per-100 g figure. */
+  scaled(per100: number): number {
+    const qty = Number(this.quantityG.value);
+    if (!this.selected || !qty) return 0;
+    return per100 * qty / 100;
+  }
+
+  /** Macro value for a staged item's portion, scaled from the per-100 g figure. */
+  scaledFor(item: StagedItem, per100: number): number {
+    return per100 * item.quantityG / 100;
+  }
+
+  get canAdd(): boolean {
+    return !!this.selected && this.quantityG.valid && Number(this.quantityG.value) > 0;
+  }
+
+  addToStaged(): void {
+    if (!this.canAdd || !this.selected) return;
+    this.staged.push({
+      foodId: this.selected.id,
+      foodName: this.selected.name,
+      quantityG: Number(this.quantityG.value),
+      kcalPer100: this.selected.kcalPer100,
+      proteinPer100: this.selected.proteinPer100,
+      carbsPer100: this.selected.carbsPer100,
+      fatPer100: this.selected.fatPer100
+    });
+    this.selected = null;
+    this.foodSearch.setValue('');
+    this.quantityG.setValue(null);
+    this.cdr.markForCheck();
+  }
+
+  removeStaged(index: number): void {
+    this.staged.splice(index, 1);
+    this.cdr.markForCheck();
+  }
+
+  save(): void {
+    if (this.name.invalid) return;
+    const result: MealTemplateInput = {
+      name: this.name.value.trim(),
+      items: this.staged.map(item => ({foodId: item.foodId, quantityG: item.quantityG}))
+    };
+    this.dialogRef.close(result);
+  }
+}


### PR DESCRIPTION
## Summary
- New `/nutrition/meals` page (`NutritionMealsComponent`) listing meal templates with name, item count and total kcal, plus add/edit/delete actions.
- New `MealTemplateEditDialogComponent`: name field + food-search/staged-list pattern (reused from `add-day-entry-dialog`, without the `mealType` field).
- New `MealTemplateDeleteDialogComponent`: confirmation dialog mirroring `food-delete-dialog`.
- Wired up route `/nutrition/meals` and added "Mahlzeiten" nav link.

Closes #247

## Test plan
- [x] `npm run build` succeeds
- [ ] Manual: create a template with 2-3 foods
- [ ] Manual: edit a template (rename, add/remove item)
- [ ] Manual: delete a template