### PR TITLE
feat(nutrition): log a meal template from the day view

### DIFF
--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.css
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.css
@@ -259,7 +259,8 @@
   color: var(--c-kcal);
 }
 
-.btn-meal-add {
+.btn-meal-add,
+.btn-meal-template {
   flex-shrink: 0;
   width: 36px;
   height: 36px;
@@ -270,6 +271,11 @@
 .btn-meal-add:hover {
   color: var(--c-kcal);
   background: color-mix(in srgb, var(--c-kcal) 12%, transparent);
+}
+
+.btn-meal-template:hover {
+  color: var(--c-p);
+  background: color-mix(in srgb, var(--c-p) 12%, transparent);
 }
 
 .meal__empty {

--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.html
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.html
@@ -90,6 +90,9 @@
           <header class="meal__head">
             <span class="meal__title">{{ group.label }}</span>
             <span class="meal__kcal">{{ group.kcal | number:'1.0-0':'de' }} kcal</span>
+            <button mat-icon-button class="btn-meal-template" matTooltip="Mahlzeit-Vorlage loggen" aria-label="Mahlzeit-Vorlage loggen" (click)="openTemplatePickerDialog(group.type)">
+              <mat-icon>restaurant_menu</mat-icon>
+            </button>
             <button mat-icon-button class="btn-meal-add" matTooltip="Hinzufügen" aria-label="Hinzufügen" (click)="openAddDialog(group.type)">
               <mat-icon>add</mat-icon>
             </button>

--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.ts
@@ -21,6 +21,7 @@ import {
 } from '../../dialogs/add-day-entry-dialog/add-day-entry-dialog.component';
 import {EntryEditDialogComponent} from '../../dialogs/entry-edit-dialog/entry-edit-dialog.component';
 import {EntryDeleteDialogComponent} from '../../dialogs/entry-delete-dialog/entry-delete-dialog.component';
+import {MealTemplatePickerDialogComponent} from '../../dialogs/meal-template-picker-dialog/meal-template-picker-dialog.component';
 
 interface MealGroup {
   type: MealType;
@@ -203,6 +204,22 @@ export class NutritionDayComponent implements OnInit {
         this.snackBar.open(message, 'OK', {duration: 3000});
       },
       error: () => this.snackBar.open('Eintrag konnte nicht gespeichert werden', 'Schließen', {duration: 5000})
+    });
+  }
+
+  openTemplatePickerDialog(mealType?: MealType): void {
+    const data = {mealType: mealType ?? this.defaultMealType()};
+    const ref = this.dialog.open(MealTemplatePickerDialogComponent, {data});
+    ref.afterClosed().pipe(
+      switchMap(result => result ? this.nutritionService.logMealTemplate(this.isoDate, result.templateId, result.mealType) : EMPTY),
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe({
+      next: created => {
+        this.load();
+        const message = created.length === 1 ? '1 Eintrag aus Vorlage hinzugefügt' : `${created.length} Einträge aus Vorlage hinzugefügt`;
+        this.snackBar.open(message, 'OK', {duration: 3000});
+      },
+      error: () => this.snackBar.open('Vorlage konnte nicht geloggt werden', 'Schließen', {duration: 5000})
     });
   }
 

--- a/src/app/nutrition/dialogs/meal-template-picker-dialog/meal-template-picker-dialog.component.css
+++ b/src/app/nutrition/dialogs/meal-template-picker-dialog/meal-template-picker-dialog.component.css
@@ -1,0 +1,206 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
+
+:host {
+  --surface:     #0c1018;
+  --raised:      #111826;
+  --border:      rgba(255, 255, 255, 0.07);
+  --border-mid:  rgba(255, 255, 255, 0.13);
+  --text:        #c8d4e8;
+  --text-muted:  #7a93b0;
+  --text-dim:    #3d5470;
+  --c-g:         #a3e635;
+  --c-n:         #2dd4bf;
+  --c-e:         #fb7185;
+}
+
+::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-mid) !important;
+  border-radius: 12px !important;
+  color: var(--text) !important;
+  min-width: 340px !important;
+}
+
+::ng-deep .mat-mdc-dialog-title {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
+  color: var(--text) !important;
+  letter-spacing: 0.03em;
+}
+
+::ng-deep .mat-mdc-dialog-content {
+  color: var(--text-muted) !important;
+  font-family: 'Outfit', sans-serif !important;
+  font-size: 0.9rem !important;
+  overflow: visible !important;
+}
+
+::ng-deep .mat-mdc-dialog-actions {
+  gap: 10px;
+  padding-bottom: 16px !important;
+  justify-content: center !important;
+}
+
+.picker-form {
+  display: flex;
+  flex-direction: column;
+  padding-top: 0.5rem;
+}
+
+.field-full { width: 100%; }
+
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined .mdc-notched-outline__trailing {
+  border-color: var(--border-mid) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mdc-text-field--outlined:not(.mdc-text-field--disabled) .mdc-text-field__input {
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-mdc-floating-label,
+::ng-deep .mat-mdc-form-field .mat-mdc-select-value-text,
+::ng-deep .mat-mdc-form-field .mat-mdc-select-min-line {
+  color: var(--text) !important;
+}
+
+::ng-deep .mat-mdc-form-field .mat-mdc-floating-label { color: var(--text-dim) !important; }
+
+::ng-deep .mat-mdc-form-field .mat-icon,
+::ng-deep .mat-mdc-form-field .mat-mdc-select-arrow {
+  color: var(--text-dim) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__leading,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__notch,
+::ng-deep .mat-mdc-form-field.mat-focused .mdc-notched-outline__trailing {
+  border-color: var(--c-g) !important;
+}
+
+::ng-deep .mat-mdc-form-field.mat-focused .mat-mdc-floating-label { color: var(--c-g) !important; }
+
+/* ── States ──────────────────────────────────────── */
+.state {
+  display: flex;
+  justify-content: center;
+  padding: 1.5rem 0;
+}
+
+::ng-deep .state mat-spinner circle {
+  stroke: var(--c-n) !important;
+}
+
+.load-error {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--c-e);
+}
+
+.empty {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-dim);
+}
+
+/* ── Template list ───────────────────────────────── */
+.template-list {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.template-option {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+  padding: 0.5rem 0.7rem;
+  background: var(--raised);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-family: 'Outfit', sans-serif;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.template-option:hover {
+  border-color: var(--border-mid);
+}
+
+.template-option--selected {
+  border-color: var(--c-g) !important;
+  background: color-mix(in srgb, var(--c-g) 8%, var(--raised));
+}
+
+.template-option__name {
+  font-weight: 600;
+}
+
+.template-option__meta {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  color: var(--text-dim);
+}
+
+/* ── Buttons ─────────────────────────────────────── */
+.btn-confirm,
+.btn-cancel {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.85rem;
+  font-weight: 600;
+  border-radius: 8px !important;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.btn-confirm mat-icon,
+.btn-cancel mat-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+}
+
+.btn-confirm {
+  background: rgba(45, 212, 191, 0.10) !important;
+  border: 1px solid rgba(45, 212, 191, 0.3) !important;
+  color: var(--c-n) !important;
+}
+
+.btn-confirm:hover:not([disabled]) {
+  background: rgba(45, 212, 191, 0.18) !important;
+  box-shadow: 0 0 12px rgba(45, 212, 191, 0.25) !important;
+}
+
+.btn-confirm[disabled] { opacity: 0.4 !important; }
+
+.btn-confirm mat-icon { color: var(--c-n) !important; }
+
+.btn-cancel {
+  background: rgba(251, 113, 133, 0.10) !important;
+  border: 1px solid rgba(251, 113, 133, 0.3) !important;
+  color: var(--c-e) !important;
+}
+
+.btn-cancel:hover {
+  background: rgba(251, 113, 133, 0.18) !important;
+  box-shadow: 0 0 12px rgba(251, 113, 133, 0.25) !important;
+}
+
+.btn-cancel mat-icon { color: var(--c-e) !important; }
+
+@media (max-width: 420px) {
+  .btn-confirm,
+  .btn-cancel {
+    flex: 1;
+    justify-content: center;
+  }
+}

--- a/src/app/nutrition/dialogs/meal-template-picker-dialog/meal-template-picker-dialog.component.html
+++ b/src/app/nutrition/dialogs/meal-template-picker-dialog/meal-template-picker-dialog.component.html
@@ -1,0 +1,48 @@
+<h2 mat-dialog-title>Vorlage loggen</h2>
+
+<mat-dialog-content>
+  <form class="picker-form">
+    <mat-form-field appearance="outline" class="field-full">
+      <mat-label>Mahlzeit</mat-label>
+      <mat-select [formControl]="mealType">
+        @for (m of mealTypes; track m.value) {
+          <mat-option [value]="m.value">{{ m.label }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  </form>
+
+  @if (loading) {
+    <div class="state">
+      <mat-spinner diameter="28" />
+    </div>
+  } @else if (loadFailed) {
+    <p class="load-error">Vorlagen konnten nicht geladen werden.</p>
+  } @else if (templates.length === 0) {
+    <p class="empty">Noch keine Vorlagen vorhanden.</p>
+  } @else {
+    <div class="template-list">
+      @for (template of templates; track template.id) {
+        <button type="button" class="template-option" [class.template-option--selected]="selected === template"
+                (click)="select(template)">
+          <span class="template-option__name">{{ template.name }}</span>
+          <span class="template-option__meta">
+            {{ template.items.length }} {{ template.items.length === 1 ? 'Eintrag' : 'Einträge' }} ·
+            {{ totalKcal(template) | number:'1.0-0':'de' }} kcal
+          </span>
+        </button>
+      }
+    </div>
+  }
+</mat-dialog-content>
+
+<mat-dialog-actions align="center">
+  <button mat-flat-button type="button" class="btn-confirm" [disabled]="!canConfirm" (click)="confirm()">
+    <mat-icon>check_circle</mat-icon>
+    Loggen
+  </button>
+  <button mat-stroked-button type="button" mat-dialog-close class="btn-cancel">
+    <mat-icon>close</mat-icon>
+    Abbrechen
+  </button>
+</mat-dialog-actions>

--- a/src/app/nutrition/dialogs/meal-template-picker-dialog/meal-template-picker-dialog.component.ts
+++ b/src/app/nutrition/dialogs/meal-template-picker-dialog/meal-template-picker-dialog.component.ts
@@ -1,0 +1,102 @@
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, inject, OnInit} from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
+import {DecimalPipe} from '@angular/common';
+import {FormControl, ReactiveFormsModule} from '@angular/forms';
+import {MAT_DIALOG_DATA, MatDialogActions, MatDialogClose, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MatFormField, MatLabel} from '@angular/material/form-field';
+import {MatSelect} from '@angular/material/select';
+import {MatOption} from '@angular/material/core';
+import {MatIcon} from '@angular/material/icon';
+import {MatProgressSpinner} from '@angular/material/progress-spinner';
+import {MatButton} from '@angular/material/button';
+import {NutritionService} from '../../services/nutrition.service';
+import {MealTemplate, MealType} from '../../models/nutrition.model';
+
+export interface MealTemplatePickerDialogData {
+  mealType: MealType;
+}
+
+export interface MealTemplatePickerDialogResult {
+  templateId: string;
+  mealType: MealType;
+}
+
+const MEAL_TYPES: { value: MealType; label: string }[] = [
+  {value: 'BREAKFAST', label: 'Frühstück'},
+  {value: 'LUNCH', label: 'Mittagessen'},
+  {value: 'DINNER', label: 'Abendessen'},
+  {value: 'SNACK', label: 'Snack'}
+];
+
+@Component({
+  selector: 'app-meal-template-picker-dialog',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ReactiveFormsModule,
+    DecimalPipe,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatFormField,
+    MatLabel,
+    MatSelect,
+    MatOption,
+    MatIcon,
+    MatProgressSpinner,
+    MatButton
+  ],
+  templateUrl: './meal-template-picker-dialog.component.html',
+  styleUrl: './meal-template-picker-dialog.component.css'
+})
+export class MealTemplatePickerDialogComponent implements OnInit {
+
+  private nutritionService = inject(NutritionService);
+  private dialogRef = inject(MatDialogRef<MealTemplatePickerDialogComponent>);
+  private cdr = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
+  private data = inject<MealTemplatePickerDialogData>(MAT_DIALOG_DATA);
+
+  readonly mealTypes = MEAL_TYPES;
+
+  mealType = new FormControl<MealType>(this.data.mealType, {nonNullable: true});
+
+  templates: MealTemplate[] = [];
+  selected: MealTemplate | null = null;
+  loading = true;
+  loadFailed = false;
+
+  ngOnInit(): void {
+    this.nutritionService.getMealTemplates().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: templates => {
+        this.templates = templates;
+        this.loading = false;
+        this.cdr.markForCheck();
+      },
+      error: () => {
+        this.loadFailed = true;
+        this.loading = false;
+        this.cdr.markForCheck();
+      }
+    });
+  }
+
+  totalKcal(template: MealTemplate): number {
+    return template.items.reduce((sum, item) => sum + item.kcal, 0);
+  }
+
+  select(template: MealTemplate): void {
+    this.selected = template;
+    this.cdr.markForCheck();
+  }
+
+  get canConfirm(): boolean {
+    return !!this.selected;
+  }
+
+  confirm(): void {
+    if (!this.selected) return;
+    const result: MealTemplatePickerDialogResult = {templateId: this.selected.id, mealType: this.mealType.value};
+    this.dialogRef.close(result);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `MealTemplatePickerDialogComponent`: pick a saved meal template (name, item count, total kcal) and a meal type, defaulting to the tapped meal group.
- Add a "Mahlzeit-Vorlage loggen" icon button next to "add entry" in each meal section of the day view, which opens the picker and logs the chosen template's items into the diary via the existing `logMealTemplate` service.

Closes #248

## Test plan
- [x] `npm run build` succeeds
- [ ] From `/nutrition/day`, log a meal template into BREAKFAST for a date, confirm entries appear with correct snapshotted macros and day totals update
- [ ] Deleting the template afterwards leaves previously-logged entries untouched