### PR TITLE
feat(nutrition): add Mahlzeiten nav card to nutrition home

### DIFF
--- a/src/app/nutrition/components/nutrition-home/nutrition-home.component.css
+++ b/src/app/nutrition/components/nutrition-home/nutrition-home.component.css
@@ -14,6 +14,7 @@
   --c-w:  #a3e635;  --cg-w: rgba(163, 230,  53, 0.18);
   --c-f:  #2dd4bf;  --cg-f: rgba(45,  212, 191, 0.18);
   --c-p:  #c084fc;  --cg-p: rgba(192, 132, 252, 0.18);
+  --c-m:  #fb923c;  --cg-m: rgba(251, 146,  60, 0.18);
 
   display: block;
   height: 100%;
@@ -87,6 +88,7 @@
 .navcard--w { --cc: var(--c-w); --cc-glow: var(--cg-w); }
 .navcard--f { --cc: var(--c-f); --cc-glow: var(--cg-f); }
 .navcard--p { --cc: var(--c-p); --cc-glow: var(--cg-p); }
+.navcard--m { --cc: var(--c-m); --cc-glow: var(--cg-m); }
 
 .navcard__mark {
   width: 36px;
@@ -147,3 +149,4 @@
 .navcard:nth-child(4) { animation-delay: 0.26s; }
 .navcard:nth-child(5) { animation-delay: 0.33s; }
 .navcard:nth-child(6) { animation-delay: 0.40s; }
+.navcard:nth-child(7) { animation-delay: 0.47s; }

--- a/src/app/nutrition/components/nutrition-home/nutrition-home.component.html
+++ b/src/app/nutrition/components/nutrition-home/nutrition-home.component.html
@@ -31,6 +31,13 @@
       <span class="navcard__arrow" aria-hidden="true">↗</span>
     </a>
 
+    <a class="navcard navcard--m" routerLink="/nutrition/meals">
+      <div class="navcard__mark">▣</div>
+      <h2 class="navcard__title">Mahlzeiten</h2>
+      <p class="navcard__sub">Vorlagen verwalten</p>
+      <span class="navcard__arrow" aria-hidden="true">↗</span>
+    </a>
+
     <a class="navcard navcard--f" routerLink="/nutrition/foods">
       <div class="navcard__mark">⬡</div>
       <h2 class="navcard__title">Lebensmittel</h2>


### PR DESCRIPTION
## Summary
- The meal templates page (`/nutrition/meals`) was added in a prior PR but had no link from the nutrition dashboard.
- Adds a "Mahlzeiten" nav card (linking to `/nutrition/meals`) to `/nutrition` home, alongside the other sections.

## Test plan
- [x] `npm run build` succeeds
- [ ] `/nutrition` shows a "Mahlzeiten" card that navigates to `/nutrition/meals`