### PR TITLE
feat(nutrition): save canteen estimate as MAHLZEIT template (#253)

### DIFF
--- a/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.css
+++ b/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.css
@@ -133,6 +133,34 @@
 ::ng-deep .btn-estimate mat-spinner circle { stroke: var(--c-b) !important; }
 ::ng-deep .btn-log mat-spinner circle { stroke: var(--c-g) !important; }
 
+.save-template-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+}
+
+.btn-save-template {
+  height: 48px;
+  border-radius: 8px !important;
+  font-weight: 600 !important;
+  color: var(--c-n) !important;
+  border-color: color-mix(in srgb, var(--c-n) 35%, transparent) !important;
+}
+
+.btn-save-template:hover:not([disabled]) {
+  background: color-mix(in srgb, var(--c-n) 10%, transparent) !important;
+  box-shadow: 0 0 12px rgba(45, 212, 191, 0.2) !important;
+}
+
+.btn-save-template[disabled] { opacity: 0.55 !important; }
+
+.btn-save-template mat-spinner { margin-right: 4px; }
+
+::ng-deep .btn-save-template mat-spinner circle { stroke: var(--c-n) !important; }
+
 /* ── Estimate grid ───────────────────────────────── */
 .grid {
   display: grid;

--- a/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.html
+++ b/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.html
@@ -112,6 +112,24 @@
         }
         Eintragen
       </button>
+
+      <div class="save-template-row">
+        <mat-form-field appearance="outline" class="field-full">
+          <mat-label>Als Mahlzeit speichern</mat-label>
+          <input matInput [formControl]="templateName"
+                 placeholder="z. B. Kantine Schnitzel" />
+        </mat-form-field>
+
+        <button mat-stroked-button type="button" class="btn-save-template"
+                [disabled]="templateName.invalid || saving" (click)="saveAsTemplate()">
+          @if (saving) {
+            <mat-spinner diameter="18" />
+          } @else {
+            <mat-icon>bookmark_add</mat-icon>
+          }
+          Speichern
+        </button>
+      </div>
     </section>
   }
 

--- a/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.ts
+++ b/src/app/nutrition/components/nutrition-canteen/nutrition-canteen.component.ts
@@ -13,7 +13,7 @@ import {MatSnackBar} from '@angular/material/snack-bar';
 import {format} from 'date-fns';
 import {Subscription, timeout, TimeoutError} from 'rxjs';
 import {NutritionService} from '../../services/nutrition.service';
-import {AdHocEntryInput, MealEstimate, MealType} from '../../models/nutrition.model';
+import {AdHocEntryInput, MealEstimate, MealType, SaveEstimateAsTemplateInput} from '../../models/nutrition.model';
 
 const ESTIMATE_TIMEOUT_MS = 30000;
 
@@ -55,12 +55,14 @@ export class NutritionCanteenComponent implements OnInit {
   portionHint = new FormControl('', {nonNullable: true});
   mealType = new FormControl<MealType>('LUNCH', {nonNullable: true});
   date = new FormControl<Date>(new Date(), {nonNullable: true});
+  templateName = new FormControl('', {nonNullable: true, validators: Validators.required});
 
   /** Editable macro values; populated once an estimate arrives. */
   valuesForm!: FormGroup;
   assumptions = '';
   estimating = false;
   logging = false;
+  saving = false;
   hasEstimate = false;
 
   private fb = inject(FormBuilder);
@@ -120,6 +122,7 @@ export class NutritionCanteenComponent implements OnInit {
       fatG: estimate.fatG
     });
     this.assumptions = estimate.assumptions;
+    this.templateName.setValue(this.description.value.trim());
   }
 
   log(): void {
@@ -153,11 +156,41 @@ export class NutritionCanteenComponent implements OnInit {
     });
   }
 
+  saveAsTemplate(): void {
+    if (this.templateName.invalid || this.saving) return;
+    this.saving = true;
+    this.cdr.markForCheck();
+
+    const v = this.valuesForm.getRawValue();
+    const payload: SaveEstimateAsTemplateInput = {
+      name: this.templateName.value.trim(),
+      kcal: Number(v.kcal),
+      proteinG: Number(v.proteinG),
+      carbsG: Number(v.carbsG),
+      fatG: Number(v.fatG)
+    };
+
+    this.nutritionService.saveEstimateAsTemplate(payload).subscribe({
+      next: () => {
+        this.saving = false;
+        this.cdr.markForCheck();
+        this.snackBar.open('Als Mahlzeit gespeichert', 'OK', {duration: 3000});
+      },
+      error: () => {
+        this.saving = false;
+        this.cdr.markForCheck();
+        this.snackBar.open('Mahlzeit konnte nicht gespeichert werden', 'Schließen', {duration: 5000});
+      }
+    });
+  }
+
   private reset(): void {
     this.description.reset('');
     this.portionHint.reset('');
     this.assumptions = '';
     this.hasEstimate = false;
+    this.templateName.reset('');
+    this.saving = false;
     this.valuesForm.reset({kcal: 0, proteinG: 0, carbsG: 0, fatG: 0});
   }
 }

--- a/src/app/nutrition/models/nutrition.model.ts
+++ b/src/app/nutrition/models/nutrition.model.ts
@@ -194,3 +194,11 @@ export interface MealTemplateInput {
   name: string;
   items: MealTemplateItemInput[];
 }
+
+export interface SaveEstimateAsTemplateInput {
+  name: string;
+  kcal: number;
+  proteinG: number;
+  carbsG: number;
+  fatG: number;
+}

--- a/src/app/nutrition/services/nutrition.service.ts
+++ b/src/app/nutrition/services/nutrition.service.ts
@@ -16,6 +16,7 @@ import {
   MealType,
   Profile,
   ProfileInput,
+  SaveEstimateAsTemplateInput,
   Targets,
   WeightEntry,
   WeightEntryInput
@@ -162,5 +163,9 @@ export class NutritionService {
     return this.http.post<MealEntry[]>(
       `${this.host}/days/${date}/entries/from-template/${templateId}`, {}, {params: {mealType}}
     );
+  }
+
+  saveEstimateAsTemplate(input: SaveEstimateAsTemplateInput): Observable<MealTemplate> {
+    return this.http.post<MealTemplate>(`${this.host}/meal-templates/from-estimate`, input);
   }
 }


### PR DESCRIPTION
## Summary
- Adds `SaveEstimateAsTemplateInput` interface to `nutrition.model.ts`
- Adds `saveEstimateAsTemplate()` method to `NutritionService` calling `POST /nutrition/meal-templates/from-estimate`
- Adds `templateName` FormControl and `saving` flag to the canteen component; pre-fills the name from the meal description after a successful estimate
- Adds save-as-template UI block (name input + teal "Speichern" button with spinner) below the "Eintragen" button, visible only when an estimate is present
- Resets `templateName` and `saving` on form reset

## Test plan
- [ ] Get a canteen estimate — name input appears pre-filled with the description
- [ ] Edit the name and click "Speichern" — snackbar "Als Mahlzeit gespeichert" appears
- [ ] Navigate to MAHLZEITEN — new template is listed
- [ ] Leave name empty — "Speichern" button is disabled
- [ ] `npm run build` passes with no errors

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)