### PR TITLE
fix(nutrition): make Tagebuch (day) view scrollable on iPhone

### DIFF
--- a/src/app/nutrition/components/nutrition-day/nutrition-day.component.css
+++ b/src/app/nutrition/components/nutrition-day/nutrition-day.component.css
@@ -20,7 +20,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow: hidden;
+  overflow-y: auto;
   font-family: 'Outfit', sans-serif;
   color: var(--text);
 }
@@ -34,19 +34,12 @@
   width: 100%;
   margin: 0 auto;
   box-sizing: border-box;
-  min-height: 0;
-  flex: 1;
-  overflow: hidden;
 }
 
 .meals {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  min-height: 0;
-  flex: 1;
-  overflow-y: auto;
-  padding-bottom: 0.25rem;
 }
 
 /* ── Panels ──────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Fixes a regression from #255: the Tagebuch (day) view pinned its toolbar and tried to fit the meal-entry list into whatever vertical space was left, via a flex:1/overflow-y:auto budget. On a short iPhone viewport that budget collapsed to ~0, so the entry list was unreachable — only the top of "Übersicht" was visible, with no working scrollbar.
- Switches `.day`/`:host` to the same simple whole-page-scroll pattern already used by `nutrition-profile`, `nutrition-canteen`, and `nutrition-dashboard`, instead of a pinned-header + inner-scroll layout that depended on a height budget that doesn't hold on small screens.

## Test plan
- [x] `npm run build` succeeds
- [x] Mocked a populated day (targets + 8 entries across all 4 meal groups) via Playwright route interception and confirmed at 375×667 (iPhone SE) that the page scrolls (`scrollHeight` 1508px vs `clientHeight` 614px) and the last entry becomes fully visible after scrolling
- [x] Confirmed iPad Air (820×1180) still renders the same content without needing to scroll, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)