### PR TITLE
fix(nutrition): make foods/meals/weight tables scrollable on iPhone

### DIFF
--- a/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.css
+++ b/src/app/nutrition/components/nutrition-foods/nutrition-foods.component.css
@@ -19,7 +19,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow: hidden;
+  overflow-y: auto;
   font-family: 'Outfit', sans-serif;
   color: var(--text);
 }
@@ -33,16 +33,11 @@
   width: 100%;
   margin: 0 auto;
   box-sizing: border-box;
-  min-height: 0;
-  flex: 1;
-  overflow: hidden;
 }
 
 .panel-table {
   display: flex;
   flex-direction: column;
-  min-height: 0;
-  flex: 1;
 }
 
 /* ── Panels ──────────────────────────────────────── */
@@ -141,9 +136,7 @@
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 12px;
-  overflow: auto;
-  min-height: 0;
-  flex: 1;
+  overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior-x: contain;
 }

--- a/src/app/nutrition/components/nutrition-meals/nutrition-meals.component.css
+++ b/src/app/nutrition/components/nutrition-meals/nutrition-meals.component.css
@@ -17,7 +17,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow: hidden;
+  overflow-y: auto;
   font-family: 'Outfit', sans-serif;
   color: var(--text);
 }
@@ -31,16 +31,11 @@
   width: 100%;
   margin: 0 auto;
   box-sizing: border-box;
-  min-height: 0;
-  flex: 1;
-  overflow: hidden;
 }
 
 .panel-table {
   display: flex;
   flex-direction: column;
-  min-height: 0;
-  flex: 1;
 }
 
 /* ── Panels ──────────────────────────────────────── */
@@ -101,9 +96,7 @@
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 12px;
-  overflow: auto;
-  min-height: 0;
-  flex: 1;
+  overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior-x: contain;
 }

--- a/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.css
+++ b/src/app/nutrition/components/nutrition-weight/nutrition-weight.component.css
@@ -17,7 +17,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow: hidden;
+  overflow-y: auto;
   font-family: 'Outfit', sans-serif;
   color: var(--text);
 }
@@ -31,16 +31,11 @@
   width: 100%;
   margin: 0 auto;
   box-sizing: border-box;
-  min-height: 0;
-  flex: 1;
-  overflow: hidden;
 }
 
 .panel-table {
   display: flex;
   flex-direction: column;
-  min-height: 0;
-  flex: 1;
 }
 
 /* ── Panels ──────────────────────────────────────── */
@@ -105,9 +100,7 @@
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 12px;
-  overflow: auto;
-  min-height: 0;
-  flex: 1;
+  overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior-x: contain;
 }


### PR DESCRIPTION
## Summary
- Same bug class as #256 (Tagebuch scroll fix), found by the user reporting "Lebensmittel table shows nothing" on iPhone.
- `nutrition-foods`, `nutrition-meals`, and `nutrition-weight` all used the same pinned-header + `flex:1`/`overflow:hidden` budget for their table area. On a short real-device viewport that budget can collapse to ~0, making the table invisible with no scrollbar to reach it.
- Switched all three to the same whole-page-scroll pattern used by profile/canteen/dashboard/day. Tables now scroll horizontally only (for wide columns); the page scrolls vertically.

## Test plan
- [x] `npm run build` succeeds
- [x] Mocked 15 foods via Playwright route interception at 375×667: page scrolls (1290px content vs 614px viewport), last row reachable
- [x] Mocked 10 meal templates: scrollable, last row reachable
- [x] Mocked 12 weight entries: scrollable, last row reachable, screenshot confirms clean rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)